### PR TITLE
fix: surface status diagnostics and tighten CI checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,5 +27,8 @@ jobs:
           go mod tidy
           git diff --exit-code
 
+      - name: Vet
+        run: go vet ./...
+
       - name: Test
         run: go test ./...

--- a/README.md
+++ b/README.md
@@ -64,6 +64,8 @@ Common high-frequency recipes:
 - `just release-check`
 - `just release-snapshot`
 
+If you hit a local Go toolchain mismatch like `compile: version "go1.x.y" does not match go tool version "go1.x.z"`, your shell is likely exporting a stale `GOROOT` or `GOTOOLDIR`. Clear those vars for the command (for example `env -u GOROOT -u GOTOOLDIR go test ./...`) or fix the shell config that exports them.
+
 ## Usage
 
 ### Global overview

--- a/docs/plans/2026-03-08-stability-phase0.md
+++ b/docs/plans/2026-03-08-stability-phase0.md
@@ -1,0 +1,166 @@
+# Stability Phase 0 Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Improve `all-cli` status reliability by surfacing diagnostic output, preserving AWS detection failures, and locking the behavior with tests.
+
+**Architecture:** Keep the existing adapter registry and Cobra command structure, but make diagnostics first-class in the human-readable `status` path. Fix the AWS adapter at the source so it returns warnings/errors instead of silently dropping failures, then update output helpers to render those diagnostics consistently without changing the JSON contract.
+
+**Tech Stack:** Go 1.25+, Cobra, standard library testing
+
+---
+
+### Task 1: Lock Status Diagnostics Behavior
+
+**Files:**
+- Modify: `internal/output/status_table_test.go`
+- Modify: `internal/cli/status_test.go`
+- Modify: `internal/output/status_table.go`
+- Modify: `internal/cli/status.go`
+
+**Step 1: Write the failing test**
+
+Add output tests that build a `model.StatusReport` containing warnings and errors, then assert the human-readable status output includes:
+- the normal table
+- a `Warnings:` section listing tool-scoped warnings
+- an `Errors:` section listing tool-scoped errors
+
+Add a CLI-level test for `status --json` and plain `status` to confirm:
+- JSON keeps warnings/errors in the payload only
+- plain output prints diagnostics after the table
+
+**Step 2: Run test to verify it fails**
+
+Run: `env -u GOROOT -u GOTOOLDIR go test ./internal/output ./internal/cli`
+
+Expected: FAIL because grouped/flat table output does not render any diagnostics sections yet.
+
+**Step 3: Write minimal implementation**
+
+Implement a small output helper that:
+- scans the report for non-empty warnings/errors
+- writes compact sections after the table in human output only
+- preserves stable table rendering
+
+Update `status` command tests/helpers only as needed to exercise the plain-text path without touching JSON behavior.
+
+**Step 4: Run test to verify it passes**
+
+Run: `env -u GOROOT -u GOTOOLDIR go test ./internal/output ./internal/cli`
+
+Expected: PASS
+
+**Step 5: Commit**
+
+```bash
+git add internal/output/status_table.go internal/output/status_table_test.go internal/cli/status.go internal/cli/status_test.go
+git commit -m "fix: show status diagnostics in human output"
+```
+
+### Task 2: Preserve AWS Detection Failures
+
+**Files:**
+- Modify: `internal/tools/aws/adapter_test.go`
+- Modify: `internal/tools/aws/adapter.go`
+
+**Step 1: Write the failing test**
+
+Add adapter tests covering:
+- `Current()` returns warning/error information when `aws configure get region` fails
+- `Current()` still returns the profile and any successfully resolved fields
+- environment variables still take precedence over command lookups
+
+**Step 2: Run test to verify it fails**
+
+Run: `env -u GOROOT -u GOTOOLDIR go test ./internal/tools/aws`
+
+Expected: FAIL because `Current()` currently drops warnings/errors from `configureGet`.
+
+**Step 3: Write minimal implementation**
+
+Update `Current()` so it accumulates warnings/errors from each lookup and returns them with the current-context map instead of discarding them.
+
+**Step 4: Run test to verify it passes**
+
+Run: `env -u GOROOT -u GOTOOLDIR go test ./internal/tools/aws`
+
+Expected: PASS
+
+**Step 5: Commit**
+
+```bash
+git add internal/tools/aws/adapter.go internal/tools/aws/adapter_test.go
+git commit -m "fix: keep aws context lookup diagnostics"
+```
+
+### Task 3: Lock Tool Evaluation Semantics
+
+**Files:**
+- Create: `internal/tools/evaluate_test.go`
+- Modify: `internal/tools/registry.go`
+- Modify: `internal/tools/evaluate.go`
+
+**Step 1: Write the failing test**
+
+Add tests that verify:
+- a file-configured tool cannot report `configured=yes` when the binary is not installed
+- warnings/errors are still preserved and deduplicated
+- installed tools keep the existing `configured=yes/no/n/a` behavior
+
+**Step 2: Run test to verify it fails**
+
+Run: `env -u GOROOT -u GOTOOLDIR go test ./internal/tools`
+
+Expected: FAIL because file-based config checks currently ignore install state.
+
+**Step 3: Write minimal implementation**
+
+Adjust file-configured tool evaluation so `installed=false` returns `configured_state=unknown`, matching the rest of the registry semantics, while keeping file detection for installed binaries.
+
+**Step 4: Run test to verify it passes**
+
+Run: `env -u GOROOT -u GOTOOLDIR go test ./internal/tools`
+
+Expected: PASS
+
+**Step 5: Commit**
+
+```bash
+git add internal/tools/evaluate_test.go internal/tools/registry.go internal/tools/evaluate.go
+git commit -m "fix: align configured state with install detection"
+```
+
+### Task 4: Verify the Stabilization Slice
+
+**Files:**
+- Modify: `.github/workflows/ci.yml`
+- Modify: `README.md`
+
+**Step 1: Write the failing test**
+
+No new Go test here. Instead, define the verification surface first:
+- CI should run `go vet ./...` in addition to tests
+- README local verification should mention `env -u GOROOT -u GOTOOLDIR` only if needed for local mismatch troubleshooting, not as the default workflow
+
+**Step 2: Run check to verify current gap**
+
+Run: `sed -n '1,120p' .github/workflows/ci.yml`
+
+Expected: `go vet ./...` is missing from CI.
+
+**Step 3: Write minimal implementation**
+
+Add a `Vet` step to CI and document the local Go-version mismatch troubleshooting note in the README without changing the standard commands.
+
+**Step 4: Run verification to verify it passes**
+
+Run: `env -u GOROOT -u GOTOOLDIR go test ./... && env -u GOROOT -u GOTOOLDIR go vet ./...`
+
+Expected: PASS
+
+**Step 5: Commit**
+
+```bash
+git add .github/workflows/ci.yml README.md
+git commit -m "chore: strengthen status verification workflow"
+```

--- a/internal/output/status_table.go
+++ b/internal/output/status_table.go
@@ -40,6 +40,7 @@ func PrintStatusTableWithOptions(w io.Writer, report model.StatusReport, opts St
 	default:
 		printStatusTableFlat(w, report)
 	}
+	printStatusDiagnostics(w, report)
 }
 
 func printStatusTableFlat(w io.Writer, report model.StatusReport) {
@@ -135,4 +136,48 @@ func boolToYesNo(b bool) string {
 		return "yes"
 	}
 	return "no"
+}
+
+func printStatusDiagnostics(w io.Writer, report model.StatusReport) {
+	warnings := collectToolMessages(report.Tools, func(tool model.ToolSummary) []string {
+		return tool.Warnings
+	})
+	errors := collectToolMessages(report.Tools, func(tool model.ToolSummary) []string {
+		return tool.Errors
+	})
+
+	if len(warnings) == 0 && len(errors) == 0 {
+		return
+	}
+
+	fmt.Fprintln(w)
+	if len(warnings) > 0 {
+		fmt.Fprintln(w, "Warnings:")
+		for _, line := range warnings {
+			fmt.Fprintf(w, "- %s\n", line)
+		}
+	}
+	if len(errors) > 0 {
+		if len(warnings) > 0 {
+			fmt.Fprintln(w)
+		}
+		fmt.Fprintln(w, "Errors:")
+		for _, line := range errors {
+			fmt.Fprintf(w, "- %s\n", line)
+		}
+	}
+}
+
+func collectToolMessages(tools []model.ToolSummary, pick func(model.ToolSummary) []string) []string {
+	var out []string
+	for _, tool := range tools {
+		for _, msg := range pick(tool) {
+			msg = strings.TrimSpace(msg)
+			if msg == "" {
+				continue
+			}
+			out = append(out, fmt.Sprintf("%s: %s", tool.ID, msg))
+		}
+	}
+	return out
 }

--- a/internal/output/status_table_test.go
+++ b/internal/output/status_table_test.go
@@ -79,10 +79,80 @@ func TestPrintStatusTableWithOptions_GroupByNone(t *testing.T) {
 	})
 
 	got := buf.String()
-	if !strings.Contains(got, "TOOL  CATEGORY  INSTALLED  CONFIGURED  CURRENT") {
+	if !strings.Contains(got, "TOOL") || !strings.Contains(got, "CONFIGURED") {
 		t.Fatalf("expected flat table header, got:\n%s", got)
 	}
 	if strings.Contains(got, "Category: ") {
 		t.Fatalf("expected no group headings in flat output, got:\n%s", got)
+	}
+}
+
+func TestPrintStatusTableWithOptions_IncludesDiagnosticsSections(t *testing.T) {
+	report := model.StatusReport{
+		Tools: []model.ToolSummary{
+			{
+				ID:              "aws",
+				Category:        "cloud",
+				Installed:       true,
+				ConfiguredState: model.ConfiguredUnknown,
+				Warnings:        []string{"region lookup failed"},
+				Errors:          []string{"aws configure get region failed (exit=1)"},
+			},
+			{
+				ID:              "kubectl",
+				Category:        "k8s",
+				Installed:       true,
+				ConfiguredState: model.ConfiguredYes,
+				Warnings:        []string{"namespace not set"},
+			},
+		},
+	}
+
+	var buf bytes.Buffer
+	PrintStatusTableWithOptions(&buf, report, StatusTableOptions{
+		GroupBy: StatusTableGroupByNone,
+		SortBy:  StatusTableSortTool,
+	})
+
+	got := buf.String()
+	if !strings.Contains(got, "TOOL") || !strings.Contains(got, "CONFIGURED") {
+		t.Fatalf("expected flat table header, got:\n%s", got)
+	}
+	if !strings.Contains(got, "Warnings:\n") {
+		t.Fatalf("expected warnings section, got:\n%s", got)
+	}
+	if !strings.Contains(got, "- aws: region lookup failed") {
+		t.Fatalf("expected aws warning entry, got:\n%s", got)
+	}
+	if !strings.Contains(got, "- kubectl: namespace not set") {
+		t.Fatalf("expected kubectl warning entry, got:\n%s", got)
+	}
+	if !strings.Contains(got, "Errors:\n") {
+		t.Fatalf("expected errors section, got:\n%s", got)
+	}
+	if !strings.Contains(got, "- aws: aws configure get region failed (exit=1)") {
+		t.Fatalf("expected aws error entry, got:\n%s", got)
+	}
+}
+
+func TestPrintStatusTableWithOptions_OmitsEmptyDiagnosticsSections(t *testing.T) {
+	report := model.StatusReport{
+		Tools: []model.ToolSummary{
+			{ID: "aws", Category: "cloud", Installed: true, ConfiguredState: model.ConfiguredYes},
+		},
+	}
+
+	var buf bytes.Buffer
+	PrintStatusTableWithOptions(&buf, report, StatusTableOptions{
+		GroupBy: StatusTableGroupByCategory,
+		SortBy:  StatusTableSortCategory,
+	})
+
+	got := buf.String()
+	if strings.Contains(got, "Warnings:\n") {
+		t.Fatalf("expected no warnings section, got:\n%s", got)
+	}
+	if strings.Contains(got, "Errors:\n") {
+		t.Fatalf("expected no errors section, got:\n%s", got)
 	}
 }

--- a/internal/tools/aws/adapter.go
+++ b/internal/tools/aws/adapter.go
@@ -51,10 +51,14 @@ func (a Adapter) Current(ctx context.Context) (map[string]string, []string, []st
 	out := map[string]string{
 		"profile": profile,
 	}
+	warnings := []string{}
+	errs := []string{}
 
 	region := strings.TrimSpace(firstNonEmpty(os.Getenv("AWS_REGION"), os.Getenv("AWS_DEFAULT_REGION")))
 	if region == "" {
-		r, _, _, _ := a.configureGet(ctx, profile, "region")
+		r, w, e, _ := a.configureGet(ctx, profile, "region")
+		warnings = append(warnings, w...)
+		errs = append(errs, e...)
 		region = strings.TrimSpace(r)
 	}
 	if region != "" {
@@ -63,14 +67,16 @@ func (a Adapter) Current(ctx context.Context) (map[string]string, []string, []st
 
 	format := strings.TrimSpace(os.Getenv("AWS_DEFAULT_OUTPUT"))
 	if format == "" {
-		f, _, _, _ := a.configureGet(ctx, profile, "output")
+		f, w, e, _ := a.configureGet(ctx, profile, "output")
+		warnings = append(warnings, w...)
+		errs = append(errs, e...)
 		format = strings.TrimSpace(f)
 	}
 	if format != "" {
 		out["output"] = format
 	}
 
-	return out, nil, nil, nil
+	return out, warnings, errs, nil
 }
 
 func currentProfile() string {

--- a/internal/tools/aws/adapter_test.go
+++ b/internal/tools/aws/adapter_test.go
@@ -1,0 +1,85 @@
+package aws
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/oldwinter/all-cli/internal/execx"
+)
+
+type fakeRunner struct {
+	results map[string]execx.CmdResult
+}
+
+func (f fakeRunner) Run(_ context.Context, name string, args ...string) execx.CmdResult {
+	key := name + " " + strings.Join(args, " ")
+	if r, ok := f.results[key]; ok {
+		return r
+	}
+	return execx.CmdResult{ExitCode: 1, Err: errors.New("unexpected command"), Stderr: "unexpected command"}
+}
+
+func TestAdapterCurrent_PreservesLookupDiagnostics(t *testing.T) {
+	t.Setenv("AWS_PROFILE", "prod")
+	t.Setenv("AWS_REGION", "")
+	t.Setenv("AWS_DEFAULT_REGION", "")
+	t.Setenv("AWS_DEFAULT_OUTPUT", "")
+
+	a := New(fakeRunner{
+		results: map[string]execx.CmdResult{
+			"aws configure get region --profile prod": {
+				ExitCode: 1,
+				Err:      errors.New("exit status 1"),
+				Stderr:   "missing region",
+			},
+			"aws configure get output --profile prod": {
+				ExitCode: 0,
+				Stdout:   "json\n",
+			},
+		},
+	})
+
+	cur, warnings, errs, err := a.Current(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(warnings) != 0 {
+		t.Fatalf("unexpected warnings: %#v", warnings)
+	}
+	if cur["profile"] != "prod" {
+		t.Fatalf("expected profile to be preserved, got %#v", cur)
+	}
+	if cur["output"] != "json" {
+		t.Fatalf("expected successful output lookup to be preserved, got %#v", cur)
+	}
+	if _, ok := cur["region"]; ok {
+		t.Fatalf("expected missing region after failed lookup, got %#v", cur)
+	}
+	if len(errs) == 0 {
+		t.Fatalf("expected lookup errors to be returned")
+	}
+	if errs[0] != "missing region" {
+		t.Fatalf("unexpected errs: %#v", errs)
+	}
+}
+
+func TestAdapterCurrent_PrefersEnvironment(t *testing.T) {
+	t.Setenv("AWS_PROFILE", "dev")
+	t.Setenv("AWS_REGION", "us-west-2")
+	t.Setenv("AWS_DEFAULT_OUTPUT", "yaml")
+
+	a := New(fakeRunner{})
+
+	cur, warnings, errs, err := a.Current(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(warnings) != 0 || len(errs) != 0 {
+		t.Fatalf("unexpected warnings/errs: %#v %#v", warnings, errs)
+	}
+	if cur["profile"] != "dev" || cur["region"] != "us-west-2" || cur["output"] != "yaml" {
+		t.Fatalf("unexpected current: %#v", cur)
+	}
+}

--- a/internal/tools/evaluate_test.go
+++ b/internal/tools/evaluate_test.go
@@ -1,0 +1,69 @@
+package tools
+
+import (
+	"context"
+	"testing"
+
+	"github.com/oldwinter/all-cli/internal/execx"
+	"github.com/oldwinter/all-cli/internal/model"
+)
+
+func TestEvaluate_FileConfiguredToolRequiresInstalledBinary(t *testing.T) {
+	def := toolFileConfigured(
+		"fake",
+		"Fake Tool",
+		"test",
+		"definitely-not-installed-all-cli-test-binary",
+		func() (bool, []string, []string) {
+			return true, nil, nil
+		},
+	)
+
+	summary := Evaluate(context.Background(), def, execx.DefaultRunner{})
+
+	if summary.Installed {
+		t.Fatalf("expected binary to be missing, got installed summary %#v", summary)
+	}
+	if summary.ConfiguredState != model.ConfiguredUnknown {
+		t.Fatalf("expected configured state to stay unknown when binary is missing, got %#v", summary.ConfiguredState)
+	}
+	if summary.Configured {
+		t.Fatalf("expected configured=false when binary is missing, got %#v", summary)
+	}
+}
+
+func TestEvaluate_FileConfiguredToolKeepsConfiguredWhenInstalled(t *testing.T) {
+	def := toolFileConfigured(
+		"fake",
+		"Fake Tool",
+		"test",
+		"go",
+		func() (bool, []string, []string) {
+			return true, []string{"dup", "dup"}, []string{"err", "err"}
+		},
+	)
+	def.Current = func(_ context.Context, _ execx.Runner, installed bool) (map[string]string, []string, []string) {
+		if !installed {
+			t.Fatalf("expected installed binary for current callback")
+		}
+		return map[string]string{"profile": "dev"}, []string{"dup"}, []string{"err"}
+	}
+
+	summary := Evaluate(context.Background(), def, execx.DefaultRunner{})
+
+	if !summary.Installed {
+		t.Fatalf("expected go binary to be installed, got %#v", summary)
+	}
+	if summary.ConfiguredState != model.ConfiguredYes || !summary.Configured {
+		t.Fatalf("expected configured yes for installed binary, got %#v", summary)
+	}
+	if len(summary.Warnings) != 1 || summary.Warnings[0] != "dup" {
+		t.Fatalf("expected deduped warnings, got %#v", summary.Warnings)
+	}
+	if len(summary.Errors) != 1 || summary.Errors[0] != "err" {
+		t.Fatalf("expected deduped errors, got %#v", summary.Errors)
+	}
+	if summary.Current["profile"] != "dev" {
+		t.Fatalf("expected current context to be preserved, got %#v", summary.Current)
+	}
+}

--- a/internal/tools/registry.go
+++ b/internal/tools/registry.go
@@ -120,7 +120,10 @@ func toolFileConfigured(id, displayName, category, binary string, fn func() (boo
 			HasContexts: false,
 			CanSwitch:   false,
 		},
-		ConfigCheck: func(_ context.Context, _ execx.Runner, _ bool) (model.ConfiguredState, []string, []string) {
+		ConfigCheck: func(_ context.Context, _ execx.Runner, installed bool) (model.ConfiguredState, []string, []string) {
+			if !installed {
+				return model.ConfiguredUnknown, nil, nil
+			}
 			ok, warnings, errs := fn()
 			if ok {
 				return model.ConfiguredYes, warnings, errs

--- a/justfile
+++ b/justfile
@@ -18,7 +18,7 @@ help:
     just --list
 
 ## Local CI checks (same as GitHub CI workflow)
-ci: verify-tidy test
+ci: verify-tidy vet test
 
 ## Ensure go.mod/go.sum are tidy and unchanged
 verify-tidy:


### PR DESCRIPTION
## Summary
- surface per-tool warnings and errors in human-readable status output
- preserve AWS context lookup diagnostics instead of silently dropping them
- align local and GitHub CI verification to run go vet in addition to tests

## Test Plan
- env -u GOROOT -u GOTOOLDIR go test ./...
- env -u GOROOT -u GOTOOLDIR go vet ./...
- env -u GOROOT -u GOTOOLDIR go test -race ./...


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **新功能**
  * 状态输出中现已展示诊断信息，包括工具相关的警告和错误。

* **文档**
  * 添加本地Go工具链版本不匹配的故障排除指导。

* **测试**
  * 新增诊断信息呈现和工具评估语义的测试覆盖。

* **维护**
  * CI流程现包含代码检查步骤。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->