### PR TITLE
feat: add AI-friendly status JSON metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,50 @@ all-cli status --sort category-desc
 all-cli status --timeout 10s
 ```
 
+### AI-friendly JSON additions
+
+`all-cli status --json` now includes additive English metadata for machine callers:
+
+- Top-level `legend`: explains shared fields such as `installed`, `configured_state`, `capabilities`, `warnings`, `errors`, and the meaning of metadata fields.
+- Per-tool `metadata`: explains `purpose`, `configured_when`, known keys inside `current`, suggested `agent_actions`, and short interpretation notes.
+
+Example shape:
+
+```json
+{
+  "schema_version": "v0.1",
+  "legend": {
+    "configured_state": {
+      "yes": "all-cli found enough local state to treat the tool as configured"
+    },
+    "metadata_fields": {
+      "purpose": "Short English description of what the tool is for"
+    }
+  },
+  "tools": [
+    {
+      "id": "kubectl",
+      "current": {
+        "context": "example-cluster"
+      },
+      "metadata": {
+        "purpose": "Kubernetes CLI used to inspect and operate clusters through kubeconfig contexts.",
+        "configured_when": "At least one kubeconfig context is available and readable.",
+        "current_field_descriptions": {
+          "context": "The active kubeconfig context name."
+        },
+        "agent_actions": [
+          "inspect_status",
+          "show_current",
+          "list_contexts",
+          "switch_context"
+        ]
+      }
+    }
+  ]
+}
+```
+
 ### kubectl
 
 ```bash

--- a/docs/plans/2026-03-13-ai-friendly-status-metadata-design.md
+++ b/docs/plans/2026-03-13-ai-friendly-status-metadata-design.md
@@ -1,0 +1,64 @@
+# AI-Friendly Status Metadata Design
+
+## Goal
+
+Add English, machine-friendly guidance to `all-cli status --json` without breaking existing fields or changing the human-readable table output.
+
+## Decision
+
+Extend the existing JSON shape additively:
+
+- Add a top-level `legend` object to `StatusReport`
+- Add a per-tool `metadata` object to `ToolSummary`
+
+No existing fields will be renamed or removed.
+
+## Why This Shape
+
+This keeps backward compatibility for existing callers that already parse `status --json`, while giving AI agents enough semantics to interpret the output without reverse-engineering tool-specific meanings.
+
+Compared with a separate `tool_catalog` object, embedding `metadata` inside each tool entry avoids extra lookup steps. Compared with a single free-form summary string, structured fields are more stable for programmatic use.
+
+## JSON Additions
+
+### `legend`
+
+Top-level English descriptions for shared fields:
+
+- `installed`
+- `configured_state`
+- `capabilities`
+- `current`
+- `warnings`
+- `errors`
+- `metadata_fields`
+
+This explains how to interpret common status semantics across all tools.
+
+### `metadata`
+
+Per-tool English guidance:
+
+- `purpose`
+- `configured_when`
+- `current_field_descriptions`
+- `agent_actions`
+- `notes`
+
+This gives an AI enough context to understand what a tool does, what `configured_state=yes` means for that tool, how to read keys inside `current`, and which high-level actions are reasonable.
+
+## Data Placement
+
+Tool metadata should live in a dedicated catalog file, not be spread through command code or output code. The registry already owns discovery/config/current behavior; AI-facing explanations should be a separate concern keyed by tool ID.
+
+## Compatibility
+
+- Existing JSON fields remain unchanged.
+- Human-readable output remains unchanged.
+- Unknown new fields are safe for older clients that ignore extra JSON properties.
+
+## Notes
+
+- All supplemental text should be English.
+- Text should be short and stable, optimized for machine interpretation rather than prose.
+- Tools without context switching support still get metadata, but their `agent_actions` stay minimal.

--- a/docs/plans/2026-03-13-ai-friendly-status-metadata.md
+++ b/docs/plans/2026-03-13-ai-friendly-status-metadata.md
@@ -1,0 +1,207 @@
+# AI-Friendly Status Metadata Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Add English AI-oriented metadata to `status --json` while preserving existing fields and human-readable output.
+
+**Architecture:** Extend the shared status models with additive JSON-only fields, populate report-level legend data from a central constructor, and attach per-tool metadata from a dedicated catalog keyed by tool ID. Keep command behavior and table rendering unchanged.
+
+**Tech Stack:** Go, Cobra, stdlib JSON encoding, existing `internal/model`, `internal/tools`, and `internal/output` packages.
+
+---
+
+### Task 1: Model the New JSON Fields
+
+**Files:**
+- Modify: `internal/model/model.go`
+- Test: `internal/model/model_test.go`
+
+**Step 1: Write the failing test**
+
+Add a test that constructs a new status report via a constructor and asserts:
+
+- `legend` is populated
+- `legend.configured_state.yes` exists
+- `legend.metadata_fields.purpose` exists
+
+Add a second test that marshals a `ToolSummary` with `metadata` and asserts JSON contains `"metadata"` and `"purpose"`.
+
+**Step 2: Run test to verify it fails**
+
+Run: `go test ./internal/model -v`
+Expected: FAIL because the new legend/metadata types and constructor do not exist yet.
+
+**Step 3: Write minimal implementation**
+
+Add:
+
+- `ToolMetadata`
+- `StatusLegend`
+- `NewStatusReport(toolCount int) StatusReport`
+
+Keep existing fields untouched.
+
+**Step 4: Run test to verify it passes**
+
+Run: `go test ./internal/model -v`
+Expected: PASS
+
+**Step 5: Commit**
+
+```bash
+git add internal/model/model.go internal/model/model_test.go
+git commit -m "feat: add ai-friendly status metadata model"
+```
+
+### Task 2: Attach Tool Metadata During Evaluation
+
+**Files:**
+- Create: `internal/tools/metadata.go`
+- Modify: `internal/tools/evaluate.go`
+- Test: `internal/tools/metadata_test.go`
+
+**Step 1: Write the failing test**
+
+Add tests that assert:
+
+- `MetadataForTool("kubectl")` includes `purpose`, `configured_when`, `current_field_descriptions["context"]`, and `agent_actions`
+- `Evaluate(...)` copies metadata into the returned `ToolSummary`
+
+**Step 2: Run test to verify it fails**
+
+Run: `go test ./internal/tools -v`
+Expected: FAIL because the catalog and metadata assignment do not exist.
+
+**Step 3: Write minimal implementation**
+
+Create a single catalog file with:
+
+- report legend builder
+- tool metadata lookup keyed by tool ID
+
+Update evaluation to set `summary.Metadata`.
+
+**Step 4: Run test to verify it passes**
+
+Run: `go test ./internal/tools -v`
+Expected: PASS
+
+**Step 5: Commit**
+
+```bash
+git add internal/tools/metadata.go internal/tools/evaluate.go internal/tools/metadata_test.go
+git commit -m "feat: attach ai metadata to tool summaries"
+```
+
+### Task 3: Use the Report Constructor in Status Commands
+
+**Files:**
+- Modify: `internal/cli/status.go`
+- Modify: `internal/cli/docker.go`
+- Modify: `internal/cli/kubectl.go`
+- Modify: `internal/cli/argocd.go`
+- Modify: `internal/cli/kargo.go`
+- Test: `internal/cli/status_test.go`
+
+**Step 1: Write the failing test**
+
+Add a test that verifies the shared report constructor is used for status report creation, so `legend` is present in JSON-report paths.
+
+**Step 2: Run test to verify it fails**
+
+Run: `go test ./internal/cli -v`
+Expected: FAIL because commands still construct raw `StatusReport` values manually.
+
+**Step 3: Write minimal implementation**
+
+Replace direct `model.StatusReport{...}` literals with `model.NewStatusReport(...)`.
+
+**Step 4: Run test to verify it passes**
+
+Run: `go test ./internal/cli -v`
+Expected: PASS
+
+**Step 5: Commit**
+
+```bash
+git add internal/cli/status.go internal/cli/docker.go internal/cli/kubectl.go internal/cli/argocd.go internal/cli/kargo.go internal/cli/status_test.go
+git commit -m "refactor: use shared status report constructor"
+```
+
+### Task 4: Verify JSON Encoding and Document the Contract
+
+**Files:**
+- Create: `internal/output/json_test.go`
+- Modify: `README.md`
+
+**Step 1: Write the failing test**
+
+Add a JSON output test that encodes a `StatusReport` and asserts the JSON includes:
+
+- `"legend"`
+- `"metadata"`
+- `"agent_actions"`
+- `"current_field_descriptions"`
+
+**Step 2: Run test to verify it fails**
+
+Run: `go test ./internal/output -v`
+Expected: FAIL because the new fields are not present yet in a representative encoded report.
+
+**Step 3: Write minimal implementation**
+
+If needed, adjust JSON tags/omitempty behavior so the new fields appear when populated. Update README with a short English section documenting the new JSON additions for AI callers.
+
+**Step 4: Run test to verify it passes**
+
+Run: `go test ./internal/output -v`
+Expected: PASS
+
+**Step 5: Commit**
+
+```bash
+git add internal/output/json_test.go README.md
+git commit -m "docs: describe ai-friendly status json fields"
+```
+
+### Task 5: Full Verification
+
+**Files:**
+- Modify: `none`
+
+**Step 1: Run focused tests**
+
+Run:
+
+```bash
+go test ./internal/model ./internal/tools ./internal/output ./internal/cli -v
+```
+
+Expected: PASS
+
+**Step 2: Run full test suite**
+
+Run:
+
+```bash
+go test ./...
+```
+
+Expected: PASS
+
+**Step 3: Smoke-test JSON output**
+
+Run:
+
+```bash
+go run ./cmd/all-cli status --json
+```
+
+Expected: Output contains `legend` at the top level and `metadata` under each tool.
+
+**Step 4: Commit**
+
+```bash
+git add -A
+git commit -m "feat: add ai-friendly metadata to status json"
+```

--- a/internal/cli/argocd.go
+++ b/internal/cli/argocd.go
@@ -40,7 +40,8 @@ func newArgoCDStatusCommand(opts *rootOptions, runner execx.Runner) *cobra.Comma
 			if opts.JSON {
 				return output.PrintJSON(cmd.OutOrStdout(), summary)
 			}
-			report := model.StatusReport{SchemaVersion: model.SchemaVersionV01, Tools: []model.ToolSummary{summary}}
+			report := model.NewStatusReport(1)
+			report.Tools[0] = summary
 			output.PrintStatusTable(cmd.OutOrStdout(), report)
 			return nil
 		},

--- a/internal/cli/docker.go
+++ b/internal/cli/docker.go
@@ -40,7 +40,8 @@ func newDockerStatusCommand(opts *rootOptions, runner execx.Runner) *cobra.Comma
 			if opts.JSON {
 				return output.PrintJSON(cmd.OutOrStdout(), summary)
 			}
-			report := model.StatusReport{SchemaVersion: model.SchemaVersionV01, Tools: []model.ToolSummary{summary}}
+			report := model.NewStatusReport(1)
+			report.Tools[0] = summary
 			output.PrintStatusTable(cmd.OutOrStdout(), report)
 			return nil
 		},

--- a/internal/cli/kargo.go
+++ b/internal/cli/kargo.go
@@ -39,7 +39,8 @@ func newKargoStatusCommand(opts *rootOptions, runner execx.Runner) *cobra.Comman
 			if opts.JSON {
 				return output.PrintJSON(cmd.OutOrStdout(), summary)
 			}
-			report := model.StatusReport{SchemaVersion: model.SchemaVersionV01, Tools: []model.ToolSummary{summary}}
+			report := model.NewStatusReport(1)
+			report.Tools[0] = summary
 			output.PrintStatusTable(cmd.OutOrStdout(), report)
 			return nil
 		},

--- a/internal/cli/kubectl.go
+++ b/internal/cli/kubectl.go
@@ -41,7 +41,8 @@ func newKubectlStatusCommand(opts *rootOptions, runner execx.Runner) *cobra.Comm
 			if opts.JSON {
 				return output.PrintJSON(cmd.OutOrStdout(), summary)
 			}
-			report := model.StatusReport{SchemaVersion: model.SchemaVersionV01, Tools: []model.ToolSummary{summary}}
+			report := model.NewStatusReport(1)
+			report.Tools[0] = summary
 			output.PrintStatusTable(cmd.OutOrStdout(), report)
 			return nil
 		},

--- a/internal/cli/status.go
+++ b/internal/cli/status.go
@@ -62,11 +62,8 @@ func newStatusCommand(opts *rootOptions, runner execx.Runner) *cobra.Command {
 				reg = filtered
 			}
 
-			report := model.StatusReport{
-				SchemaVersion: model.SchemaVersionV01,
-				GeneratedAt:   time.Now(),
-				Tools:         make([]model.ToolSummary, len(reg)),
-			}
+			report := model.NewStatusReport(len(reg))
+			report.GeneratedAt = time.Now()
 
 			var spinner *progressSpinner
 			if !opts.JSON && isTerminal(os.Stderr) {

--- a/internal/model/model.go
+++ b/internal/model/model.go
@@ -18,6 +18,24 @@ type Capability struct {
 	CanSwitch   bool `json:"can_switch"`
 }
 
+type ToolMetadata struct {
+	Purpose                  string            `json:"purpose,omitempty"`
+	ConfiguredWhen           string            `json:"configured_when,omitempty"`
+	CurrentFieldDescriptions map[string]string `json:"current_field_descriptions,omitempty"`
+	AgentActions             []string          `json:"agent_actions,omitempty"`
+	Notes                    []string          `json:"notes,omitempty"`
+}
+
+type StatusLegend struct {
+	Installed       string            `json:"installed,omitempty"`
+	ConfiguredState map[string]string `json:"configured_state,omitempty"`
+	Capabilities    map[string]string `json:"capabilities,omitempty"`
+	Current         string            `json:"current,omitempty"`
+	Warnings        string            `json:"warnings,omitempty"`
+	Errors          string            `json:"errors,omitempty"`
+	MetadataFields  map[string]string `json:"metadata_fields,omitempty"`
+}
+
 type ToolSummary struct {
 	ID              string            `json:"id"`
 	DisplayName     string            `json:"display_name"`
@@ -28,6 +46,7 @@ type ToolSummary struct {
 	Configured      bool              `json:"configured"`
 	Capabilities    Capability        `json:"capabilities"`
 	Current         map[string]string `json:"current,omitempty"`
+	Metadata        ToolMetadata      `json:"metadata,omitempty"`
 	Warnings        []string          `json:"warnings,omitempty"`
 	Errors          []string          `json:"errors,omitempty"`
 }
@@ -35,6 +54,7 @@ type ToolSummary struct {
 type StatusReport struct {
 	SchemaVersion string        `json:"schema_version"`
 	GeneratedAt   time.Time     `json:"generated_at"`
+	Legend        StatusLegend  `json:"legend,omitempty"`
 	Tools         []ToolSummary `json:"tools"`
 }
 
@@ -43,4 +63,34 @@ type UseResult struct {
 	ToolID  string            `json:"tool_id"`
 	Current map[string]string `json:"current,omitempty"`
 	Error   string            `json:"error,omitempty"`
+}
+
+func NewStatusReport(toolCount int) StatusReport {
+	return StatusReport{
+		SchemaVersion: SchemaVersionV01,
+		Legend: StatusLegend{
+			Installed: "Whether the CLI binary was found in PATH.",
+			ConfiguredState: map[string]string{
+				"yes":     "all-cli found enough local state to treat the tool as configured.",
+				"no":      "all-cli checked configuration for this tool and found it missing or empty.",
+				"n/a":     "all-cli does not evaluate configuration for this tool.",
+				"unknown": "all-cli could not determine configuration state reliably.",
+			},
+			Capabilities: map[string]string{
+				"has_contexts": "The tool exposes a current context-like concept that all-cli can read.",
+				"can_switch":   "The tool supports switching context-like state through all-cli commands.",
+			},
+			Current:  "Tool-specific key/value snapshot of the active context or runtime selection.",
+			Warnings: "Non-fatal observations that may affect interpretation, but did not block status collection.",
+			Errors:   "Status collection failures or command errors observed while inspecting this tool.",
+			MetadataFields: map[string]string{
+				"purpose":                    "Short English description of what the tool is for.",
+				"configured_when":            "Tool-specific meaning of configured_state=yes.",
+				"current_field_descriptions": "English explanation for each known key inside current.",
+				"agent_actions":              "Stable high-level actions an agent can reasonably take with this tool.",
+				"notes":                      "Short caveats that help interpret ambiguous or non-error states.",
+			},
+		},
+		Tools: make([]ToolSummary, toolCount),
+	}
 }

--- a/internal/model/model_test.go
+++ b/internal/model/model_test.go
@@ -1,0 +1,50 @@
+package model
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+func TestNewStatusReportIncludesLegend(t *testing.T) {
+	t.Parallel()
+
+	report := NewStatusReport(2)
+
+	if report.SchemaVersion != SchemaVersionV01 {
+		t.Fatalf("schema version = %q, want %q", report.SchemaVersion, SchemaVersionV01)
+	}
+	if len(report.Tools) != 2 {
+		t.Fatalf("tool count = %d, want 2", len(report.Tools))
+	}
+	if report.Legend.ConfiguredState["yes"] == "" {
+		t.Fatalf("expected configured_state.yes legend entry")
+	}
+	if report.Legend.MetadataFields["purpose"] == "" {
+		t.Fatalf("expected metadata_fields.purpose legend entry")
+	}
+}
+
+func TestToolSummaryMetadataMarshalsToJSON(t *testing.T) {
+	t.Parallel()
+
+	summary := ToolSummary{
+		ID: "kubectl",
+		Metadata: ToolMetadata{
+			Purpose: "Kubernetes CLI.",
+		},
+	}
+
+	data, err := json.Marshal(summary)
+	if err != nil {
+		t.Fatalf("marshal summary: %v", err)
+	}
+
+	text := string(data)
+	if !strings.Contains(text, `"metadata"`) {
+		t.Fatalf("expected metadata in json, got %s", text)
+	}
+	if !strings.Contains(text, `"purpose":"Kubernetes CLI."`) {
+		t.Fatalf("expected purpose in json, got %s", text)
+	}
+}

--- a/internal/output/json_test.go
+++ b/internal/output/json_test.go
@@ -1,0 +1,35 @@
+package output
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/oldwinter/all-cli/internal/model"
+)
+
+func TestPrintJSONIncludesLegendAndMetadata(t *testing.T) {
+	t.Parallel()
+
+	report := model.NewStatusReport(1)
+	report.Tools[0] = model.ToolSummary{
+		ID: "kubectl",
+		Metadata: model.ToolMetadata{
+			Purpose:        "Kubernetes CLI.",
+			AgentActions:   []string{"inspect_status", "show_current"},
+			CurrentFieldDescriptions: map[string]string{"context": "The active kubeconfig context name."},
+		},
+	}
+
+	var buf bytes.Buffer
+	if err := PrintJSON(&buf, report); err != nil {
+		t.Fatalf("print json: %v", err)
+	}
+
+	text := buf.String()
+	for _, needle := range []string{`"legend"`, `"metadata"`, `"agent_actions"`, `"current_field_descriptions"`} {
+		if !strings.Contains(text, needle) {
+			t.Fatalf("expected %s in json, got:\n%s", needle, text)
+		}
+	}
+}

--- a/internal/tools/evaluate.go
+++ b/internal/tools/evaluate.go
@@ -32,6 +32,7 @@ func Evaluate(ctx context.Context, def ToolDefinition, runner execx.Runner) mode
 		},
 		ConfiguredState: model.ConfiguredUnknown,
 		Configured:      false,
+		Metadata:        MetadataForTool(def.ID),
 	}
 	if installed {
 		summary.InstallPath = installPath

--- a/internal/tools/metadata.go
+++ b/internal/tools/metadata.go
@@ -1,0 +1,221 @@
+package tools
+
+import "github.com/oldwinter/all-cli/internal/model"
+
+func MetadataForTool(id string) model.ToolMetadata {
+	switch id {
+	case "fd":
+		return naMetadata("Fast file finder for local filesystem search.")
+	case "rg":
+		return naMetadata("Fast text search tool for recursive code and file content search.")
+	case "fzf":
+		return naMetadata("Interactive fuzzy finder used to select items from terminal input.")
+	case "zoxide":
+		return naMetadata("Smart directory jumper that tracks and ranks frequently used paths.")
+	case "eza":
+		return naMetadata("Modern replacement for ls with richer file listing output.")
+	case "bat":
+		return naMetadata("File viewer with syntax highlighting and line numbers.")
+	case "yq":
+		return naMetadata("Command-line processor for YAML and structured data transformations.")
+	case "brew":
+		return naMetadata("Homebrew package manager for installing and updating local tooling.")
+	case "uv":
+		return naMetadata("Python-oriented package and tool runner used for fast environment and CLI workflows.")
+	case "just":
+		return naMetadata("Task runner for project automation recipes declared in a justfile.")
+	case "obsidian":
+		return naMetadata(
+			"Obsidian desktop application for local markdown knowledge bases.",
+			"The detected binary launches a desktop app, not a pure command-line workflow.",
+		)
+	case "yazi":
+		return naMetadata("Terminal file manager for navigating and manipulating local files.")
+	case "k9s":
+		return currentMetadata(
+			"Terminal dashboard for inspecting Kubernetes resources through the current kubeconfig context.",
+			"Configuration is not evaluated directly; current reports the k9s config file and resolved Kubernetes context when available.",
+			map[string]string{
+				"config":    "Path to the k9s configuration file in use.",
+				"context":   "The Kubernetes context k9s resolves for the current session.",
+				"namespace": "The namespace k9s would open by default, if explicitly configured.",
+			},
+			[]string{"inspect_status", "show_current"},
+			"Missing namespace is often a normal state because kubeconfig may not pin a default namespace.",
+		)
+	case "lazydocker":
+		return naMetadata("Terminal dashboard for viewing and operating Docker resources.")
+	case "aws":
+		return currentMetadata(
+			"Amazon Web Services CLI for account, infrastructure, and service operations.",
+			"At least one AWS profile is discoverable through local AWS CLI configuration.",
+			map[string]string{
+				"profile": "The active AWS profile resolved from environment variables or local config.",
+				"region":  "The active AWS region resolved from environment variables or local config.",
+				"output":  "The default AWS CLI output format, if configured.",
+			},
+			[]string{"inspect_status", "show_current"},
+		)
+	case "aliyun":
+		return currentMetadata(
+			"Alibaba Cloud CLI for account and infrastructure operations.",
+			"At least one Aliyun profile is available in local CLI configuration.",
+			map[string]string{
+				"profile":  "The current or preferred Aliyun profile name.",
+				"region":   "The default region associated with the selected profile.",
+				"language": "The CLI language preference for the selected profile.",
+				"valid":    "Validation status reported by the Aliyun CLI for the selected profile.",
+			},
+			[]string{"inspect_status", "show_current"},
+		)
+	case "wrangler":
+		return currentMetadata(
+			"Cloudflare Wrangler CLI for Workers, Pages, and related Cloudflare resources.",
+			"The current user is authenticated with Wrangler.",
+			map[string]string{
+				"logged_in":      "Whether Wrangler reports an authenticated user session.",
+				"accounts_count": "How many Cloudflare accounts are visible to the authenticated user.",
+				"account_id":     "The single visible account ID when exactly one account is available.",
+			},
+			[]string{"inspect_status", "show_current"},
+			"Multiple accounts are not an error, but they mean there is no single globally implied target account.",
+		)
+	case "eksctl":
+		return naMetadata("CLI for managing Amazon EKS clusters and related resources.")
+	case "kubectl":
+		return currentMetadata(
+			"Kubernetes CLI used to inspect and operate clusters through kubeconfig contexts.",
+			"At least one kubeconfig context is available and readable.",
+			map[string]string{
+				"context":   "The active kubeconfig context name.",
+				"namespace": "The default namespace bound to the active context, if one is set.",
+			},
+			[]string{"inspect_status", "show_current", "list_contexts", "switch_context", "switch_namespace"},
+			"Missing namespace is not always an error because many kubeconfig contexts rely on the cluster default namespace.",
+		)
+	case "kubectx":
+		return naMetadata("Helper CLI for switching Kubernetes contexts quickly.")
+	case "kubens":
+		return naMetadata("Helper CLI for switching Kubernetes namespaces quickly.")
+	case "kubecolor":
+		return naMetadata("kubectl-compatible wrapper that adds colorized output.")
+	case "krew":
+		return naMetadata("Plugin manager for kubectl extensions.")
+	case "kubefwd":
+		return naMetadata("Utility for forwarding multiple Kubernetes services to localhost for local debugging.")
+	case "kubeshark":
+		return naMetadata("Kubernetes network inspection tool for observing in-cluster traffic.")
+	case "docker":
+		return currentMetadata(
+			"Docker CLI for containers, images, networks, and Docker contexts.",
+			"At least one Docker context is available and the Docker CLI config is readable.",
+			map[string]string{
+				"context": "The active Docker context name.",
+			},
+			[]string{"inspect_status", "show_current", "list_contexts", "switch_context"},
+		)
+	case "gh":
+		return currentMetadata(
+			"GitHub CLI for repository, issue, pull request, and workflow operations.",
+			"At least one authenticated GitHub host/account is available to the CLI.",
+			map[string]string{
+				"hostname": "The GitHub hostname associated with the effective account selection.",
+				"user":     "The login of the effective authenticated GitHub user.",
+			},
+			[]string{"inspect_status", "show_current", "list_accounts", "switch_account"},
+		)
+	case "glab":
+		return currentMetadata(
+			"GitLab CLI for repository, merge request, issue, and workflow operations.",
+			"At least one usable GitLab instance is authenticated in local glab configuration.",
+			map[string]string{
+				"effective_host": "The GitLab host glab currently resolves for API operations in this environment.",
+				"global_host":    "The global default GitLab host configured in glab.",
+				"user":           "The effective authenticated GitLab user for the current host.",
+			},
+			[]string{"inspect_status", "show_current", "list_instances", "switch_host"},
+			"`effective_host` and `global_host` may differ when repository or environment settings override the global default.",
+		)
+	case "linear":
+		return naMetadata("Linear CLI for issue, project, and workflow management.")
+	case "claude":
+		return naMetadata("Claude Code CLI for AI-assisted coding and terminal workflows.")
+	case "codex":
+		return naMetadata("Codex CLI for AI-assisted coding and terminal workflows.")
+	case "openclaw":
+		return naMetadata("AI coding CLI for terminal-based development workflows.")
+	case "opencode":
+		return naMetadata("AI coding CLI for interactive code and terminal workflows.")
+	case "gemini":
+		return naMetadata("Gemini CLI for AI-assisted terminal and content workflows.")
+	case "ccusage":
+		return naMetadata("CLI for inspecting Claude Code usage and related local usage data.")
+	case "litellm-proxy":
+		return naMetadata("LiteLLM proxy CLI for local or staging model routing and smoke tests.")
+	case "simplex-cli":
+		return naMetadata("Internal operations CLI for Simplex product and account workflows.")
+	case "rclone":
+		return currentMetadata(
+			"File sync and transfer CLI for local and remote storage backends.",
+			"A readable rclone config file exists on disk.",
+			nil,
+			[]string{"inspect_status"},
+		)
+	case "kargo":
+		return currentMetadata(
+			"Kargo CLI for GitOps delivery and default project selection.",
+			"A non-empty Kargo API address is configured locally.",
+			map[string]string{
+				"api_address": "The Kargo API endpoint configured for the current CLI context.",
+				"project":     "The default Kargo project selected for CLI commands, if one is set.",
+			},
+			[]string{"inspect_status", "show_current", "switch_project"},
+		)
+	case "argocd":
+		return currentMetadata(
+			"Argo CD CLI for GitOps application management and server context switching.",
+			"At least one Argo CD context is configured locally.",
+			map[string]string{
+				"context": "The active Argo CD context name.",
+				"server":  "The Argo CD server address associated with the active context.",
+			},
+			[]string{"inspect_status", "show_current", "list_contexts", "switch_context"},
+		)
+	case "opensearch":
+		return naMetadata("OpenSearch CLI for OpenSearch cluster and index operations.")
+	case "mise":
+		return currentMetadata(
+			"Runtime manager that resolves active tool versions for the current shell and project.",
+			"Configuration is not evaluated directly; current reports resolved runtime versions when available.",
+			map[string]string{
+				"*": "Each key is a runtime or tool name and each value is the resolved active version.",
+			},
+			[]string{"inspect_status", "show_current"},
+		)
+	default:
+		return model.ToolMetadata{
+			Purpose:        "Command-line tool tracked by all-cli.",
+			ConfiguredWhen: "Configuration semantics are tool-specific and may not be available in this build.",
+			AgentActions:   []string{"inspect_status"},
+		}
+	}
+}
+
+func naMetadata(purpose string, notes ...string) model.ToolMetadata {
+	return model.ToolMetadata{
+		Purpose:        purpose,
+		ConfiguredWhen: "all-cli does not evaluate configuration for this tool; configured_state is reported as n/a when the binary is installed.",
+		AgentActions:   []string{"inspect_status"},
+		Notes:          notes,
+	}
+}
+
+func currentMetadata(purpose, configuredWhen string, fields map[string]string, actions []string, notes ...string) model.ToolMetadata {
+	return model.ToolMetadata{
+		Purpose:                  purpose,
+		ConfiguredWhen:           configuredWhen,
+		CurrentFieldDescriptions: fields,
+		AgentActions:             actions,
+		Notes:                    notes,
+	}
+}

--- a/internal/tools/metadata_test.go
+++ b/internal/tools/metadata_test.go
@@ -1,0 +1,45 @@
+package tools
+
+import (
+	"context"
+	"testing"
+
+	"github.com/oldwinter/all-cli/internal/execx"
+)
+
+func TestMetadataForToolKubectl(t *testing.T) {
+	t.Parallel()
+
+	meta := MetadataForTool("kubectl")
+
+	if meta.Purpose == "" {
+		t.Fatalf("expected purpose for kubectl")
+	}
+	if meta.ConfiguredWhen == "" {
+		t.Fatalf("expected configured_when for kubectl")
+	}
+	if meta.CurrentFieldDescriptions["context"] == "" {
+		t.Fatalf("expected current field description for context")
+	}
+	if len(meta.AgentActions) == 0 {
+		t.Fatalf("expected agent actions for kubectl")
+	}
+}
+
+func TestEvaluateAddsMetadataToToolSummary(t *testing.T) {
+	t.Parallel()
+
+	summary := Evaluate(context.Background(), ToolDefinition{
+		ID:          "kubectl",
+		DisplayName: "kubectl",
+		Category:    "k8s",
+		Binary:      "sh",
+	}, execx.DefaultRunner{})
+
+	if summary.Metadata.Purpose == "" {
+		t.Fatalf("expected metadata purpose on evaluated summary")
+	}
+	if len(summary.Metadata.AgentActions) == 0 {
+		t.Fatalf("expected metadata agent actions on evaluated summary")
+	}
+}


### PR DESCRIPTION
## Summary
- add additive English legend and per-tool metadata to all-cli status --json
- document AI-facing JSON semantics and current-field descriptions for tracked tools
- cover the new report and metadata contract with model, tools, and output tests

## Test Plan
- [x] go test ./...
- [x] all-cli status --json


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# 发布说明

* **新功能**
  * JSON 状态输出现已包含 AI 友好的元数据，包括工具用途、配置信息、字段描述和推荐操作，使自动化系统能更好地理解和处理工具状态。

* **文档**
  * 添加了新的设计和实现计划文档，详细说明了增强型 JSON 输出的架构。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->