### PR TITLE
fix: resolve justfile build-release merge markers

### DIFF
--- a/justfile
+++ b/justfile
@@ -69,11 +69,7 @@ build:
 
 ## Build binary with release-style ldflags
 build-release:
-<<<<<<< Updated upstream
-    {{go_cmd}} build -trimpath -ldflags '{{ldflags}}' -o {{bin_path}} {{main_pkg}}
-=======
-    go build -trimpath -ldflags "-s -w -X github.com/oldwinter/all-cli/internal/cli.version={{version}} -X github.com/oldwinter/all-cli/internal/cli.commit={{commit}} -X github.com/oldwinter/all-cli/internal/cli.date={{build_date}}" -o {{bin_path}} {{main_pkg}}
->>>>>>> Stashed changes
+    {{go_cmd}} build -trimpath -ldflags "-s -w -X github.com/oldwinter/all-cli/internal/cli.version={{version}} -X github.com/oldwinter/all-cli/internal/cli.commit={{commit}} -X github.com/oldwinter/all-cli/internal/cli.date={{build_date}}" -o {{bin_path}} {{main_pkg}}
 
 ## Install binary to GOPATH/bin
 install:


### PR DESCRIPTION
## Summary
- remove leftover merge conflict markers from justfile
- keep the release build recipe on go_cmd while preserving working ldflags
- restore just help and just build-release

## Test Plan
- [x] just help
- [x] just build-release
- [x] go test ./...


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **Chores**
  * 优化了构建流程中的版本信息嵌入机制，改进了发布版本的构建配置。

---

**注：** 此次更新主要涉及内部构建工具链调整，对用户可见功能无直接影响。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->