### PR TITLE
fix: stop false aws errors and relax wrangler timeout

### DIFF
--- a/internal/cli/status.go
+++ b/internal/cli/status.go
@@ -43,7 +43,6 @@ func newStatusCommand(opts *rootOptions, runner execx.Runner) *cobra.Command {
 				return err
 			}
 
-			runnerT := execx.TimeoutRunner{Runner: runner, Timeout: opts.Timeout}
 			reg := tools.DefaultRegistry()
 			if strings.TrimSpace(toolsFilter) != "" {
 				filterSet, err := parseToolsFilter(toolsFilter)
@@ -77,7 +76,7 @@ func newStatusCommand(opts *rootOptions, runner execx.Runner) *cobra.Command {
 				wg.Add(1)
 				go func(i int, def tools.ToolDefinition) {
 					defer wg.Done()
-					report.Tools[i] = tools.Evaluate(baseCtx, def, runnerT)
+					report.Tools[i] = tools.Evaluate(baseCtx, def, runnerForTool(runner, opts.Timeout, def))
 					if spinner != nil {
 						spinner.Inc(def.ID)
 					}
@@ -106,6 +105,14 @@ func newStatusCommand(opts *rootOptions, runner execx.Runner) *cobra.Command {
 	cmd.Flags().StringVar(&groupBy, "group-by", statusGroupByCategory, "Group output: category|none")
 	cmd.Flags().StringVar(&sortBy, "sort", statusSortTool, "Sort order: tool|tool-desc|category|category-desc")
 	return cmd
+}
+
+func runnerForTool(baseRunner execx.Runner, defaultTimeout time.Duration, def tools.ToolDefinition) execx.Runner {
+	timeout := defaultTimeout
+	if def.Timeout > 0 {
+		timeout = def.Timeout
+	}
+	return execx.TimeoutRunner{Runner: baseRunner, Timeout: timeout}
 }
 
 func parseToolsFilter(s string) (map[string]bool, error) {

--- a/internal/cli/status_test.go
+++ b/internal/cli/status_test.go
@@ -2,8 +2,11 @@ package cli
 
 import (
 	"testing"
+	"time"
 
+	"github.com/oldwinter/all-cli/internal/execx"
 	"github.com/oldwinter/all-cli/internal/model"
+	"github.com/oldwinter/all-cli/internal/tools"
 )
 
 func TestParseStatusGroupBy(t *testing.T) {
@@ -86,5 +89,33 @@ func TestSortToolSummaries(t *testing.T) {
 		if got[i] != want[i] {
 			t.Fatalf("tool sort desc: got %v, want %v", got, want)
 		}
+	}
+}
+
+func TestRunnerForToolUsesToolTimeoutOverride(t *testing.T) {
+	base := execx.DefaultRunner{}
+	def := tools.ToolDefinition{ID: "wrangler", Timeout: 10 * time.Second}
+
+	got := runnerForTool(base, 5*time.Second, def)
+	timeoutRunner, ok := got.(execx.TimeoutRunner)
+	if !ok {
+		t.Fatalf("expected execx.TimeoutRunner, got %T", got)
+	}
+	if timeoutRunner.Timeout != 10*time.Second {
+		t.Fatalf("timeout = %v, want %v", timeoutRunner.Timeout, 10*time.Second)
+	}
+}
+
+func TestRunnerForToolUsesDefaultTimeoutWhenNoOverride(t *testing.T) {
+	base := execx.DefaultRunner{}
+	def := tools.ToolDefinition{ID: "aws"}
+
+	got := runnerForTool(base, 5*time.Second, def)
+	timeoutRunner, ok := got.(execx.TimeoutRunner)
+	if !ok {
+		t.Fatalf("expected execx.TimeoutRunner, got %T", got)
+	}
+	if timeoutRunner.Timeout != 5*time.Second {
+		t.Fatalf("timeout = %v, want %v", timeoutRunner.Timeout, 5*time.Second)
 	}
 }

--- a/internal/tools/aws/adapter.go
+++ b/internal/tools/aws/adapter.go
@@ -67,7 +67,7 @@ func (a Adapter) Current(ctx context.Context) (map[string]string, []string, []st
 
 	format := strings.TrimSpace(os.Getenv("AWS_DEFAULT_OUTPUT"))
 	if format == "" {
-		f, w, e, _ := a.configureGet(ctx, profile, "output")
+		f, w, e, _ := a.configureGetOptional(ctx, profile, "output")
 		warnings = append(warnings, w...)
 		errs = append(errs, e...)
 		format = strings.TrimSpace(f)
@@ -90,6 +90,22 @@ func currentProfile() string {
 func (a Adapter) configureGet(ctx context.Context, profile, key string) (string, []string, []string, error) {
 	res := a.runner.Run(ctx, "aws", "configure", "get", key, "--profile", profile)
 	if res.Err != nil {
+		errMsg := strings.TrimSpace(res.Stderr)
+		if errMsg == "" {
+			errMsg = res.Err.Error()
+		}
+		return "", nil, []string{errMsg}, fmt.Errorf("aws configure get %s failed (exit=%d)", key, res.ExitCode)
+	}
+	return strings.TrimSpace(res.Stdout), nil, nil, nil
+}
+
+func (a Adapter) configureGetOptional(ctx context.Context, profile, key string) (string, []string, []string, error) {
+	res := a.runner.Run(ctx, "aws", "configure", "get", key, "--profile", profile)
+	if res.Err != nil {
+		// AWS CLI returns exit 1 with empty stderr when an optional config value is unset.
+		if strings.TrimSpace(res.Stderr) == "" && res.ExitCode == 1 {
+			return "", nil, nil, nil
+		}
 		errMsg := strings.TrimSpace(res.Stderr)
 		if errMsg == "" {
 			errMsg = res.Err.Error()

--- a/internal/tools/aws/adapter_test.go
+++ b/internal/tools/aws/adapter_test.go
@@ -83,3 +83,40 @@ func TestAdapterCurrent_PrefersEnvironment(t *testing.T) {
 		t.Fatalf("unexpected current: %#v", cur)
 	}
 }
+
+func TestAdapterCurrent_IgnoresUnsetOptionalOutput(t *testing.T) {
+	t.Setenv("AWS_PROFILE", "default")
+	t.Setenv("AWS_REGION", "")
+	t.Setenv("AWS_DEFAULT_REGION", "")
+	t.Setenv("AWS_DEFAULT_OUTPUT", "")
+
+	a := New(fakeRunner{
+		results: map[string]execx.CmdResult{
+			"aws configure get region --profile default": {
+				ExitCode: 0,
+				Stdout:   "us-east-1\n",
+			},
+			"aws configure get output --profile default": {
+				ExitCode: 1,
+				Err:      errors.New("exit status 1"),
+			},
+		},
+	})
+
+	cur, warnings, errs, err := a.Current(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(warnings) != 0 {
+		t.Fatalf("unexpected warnings: %#v", warnings)
+	}
+	if len(errs) != 0 {
+		t.Fatalf("expected no errors for unset optional output, got %#v", errs)
+	}
+	if cur["profile"] != "default" || cur["region"] != "us-east-1" {
+		t.Fatalf("unexpected current: %#v", cur)
+	}
+	if _, ok := cur["output"]; ok {
+		t.Fatalf("expected output to be omitted when unset, got %#v", cur)
+	}
+}

--- a/internal/tools/registry.go
+++ b/internal/tools/registry.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/oldwinter/all-cli/internal/execx"
 	"github.com/oldwinter/all-cli/internal/model"
@@ -28,6 +29,7 @@ type ToolDefinition struct {
 	DisplayName string
 	Category    string
 	Binary      string
+	Timeout     time.Duration
 
 	Capabilities model.Capability
 
@@ -519,6 +521,7 @@ func wranglerTool() ToolDefinition {
 		DisplayName: "wrangler",
 		Category:    "cloud",
 		Binary:      "wrangler",
+		Timeout:     10 * time.Second,
 		Capabilities: model.Capability{
 			HasContexts: true,
 			CanSwitch:   false,


### PR DESCRIPTION
## Summary
- treat unset AWS output as an optional empty value instead of an error
- give wrangler status checks a tool-specific timeout override
- add regression coverage for both status behaviors

## Test Plan
- [x] go test ./...
- [x] all-cli status
- [x] all-cli status --tools wrangler --json


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发行说明

* **新功能**
  * 添加按工具级别的超时配置支持，允许为不同工具设置独立的超时时间

* **Bug 修复**
  * 改进 AWS 工具配置处理，现在正确处理未设置的可选配置项，防止不必要的错误

* **测试**
  * 增加超时行为验证测试
  * 增加 AWS 可选配置处理的测试用例

<!-- end of auto-generated comment: release notes by coderabbit.ai -->