### PR TITLE
chore: upgrade go and action runtimes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,15 +9,18 @@ on:
 permissions:
   contents: read
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
 jobs:
   test:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6.0.2
 
       - name: Setup Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6.3.0
         with:
           go-version-file: go.mod
           cache: true
@@ -46,6 +49,6 @@ jobs:
         run: go test -race ./...
 
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v9
+        uses: golangci/golangci-lint-action@v9.2.0
         with:
-          version: v2.10
+          version: v2.11.3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,6 +8,9 @@ on:
 permissions:
   contents: write
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
 concurrency:
   group: release-${{ github.ref }}
 
@@ -16,12 +19,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6.0.2
         with:
           fetch-depth: 0
 
       - name: Setup Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6.3.0
         with:
           go-version-file: go.mod
           cache: true
@@ -49,9 +52,9 @@ jobs:
           git push origin "$tag"
 
       - name: GoReleaser
-        uses: goreleaser/goreleaser-action@v6
+        uses: goreleaser/goreleaser-action@v7.0.0
         with:
-          version: v2.14.0
+          version: v2.14.3
           args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,7 +20,7 @@
 - Without `just`: `go test ./...`, `go vet ./...`, `go build ./cmd/all-cli`.
 
 ## Coding Style & Naming Conventions
-- Target Go `1.25` (see `go.mod`).
+- Target Go `1.26.1` (see `go.mod`).
 - Always format with `gofmt` (`just fmt` or `just fmt-check` in pre-PR checks).
 - Follow Go naming defaults: package names lowercase, exported identifiers in `CamelCase`, test names `TestXxx`.
 - Keep command constructors in `internal/cli` as `new<Name>Command`.
@@ -48,6 +48,6 @@ This is a pure Go CLI with zero runtime service dependencies. The update script 
 
 - **Service**: `all-cli` — a standalone CLI binary; no servers, databases, or Docker required.
 - **Build & run**: see `justfile` recipes or the "Build, Test, and Development Commands" section above. `just ci` is the fastest way to verify correctness; `just smoke` builds and runs a quick sanity check.
-- **Go toolchain**: The project requires Go 1.25 (declared in `go.mod`). The Go toolchain auto-downloads the correct version on first use, so no manual version management is needed.
+- **Go toolchain**: The project requires Go 1.26.1 (declared in `go.mod`). The Go toolchain auto-downloads the correct version on first use, so no manual version management is needed.
 - **justfile quirk**: All Go commands in the justfile use `env -u GOROOT -u GOTOOLDIR go` to avoid stale shell variable mismatches. Run `just go-env` to debug toolchain issues.
 - **No external services**: The CLI shells out to other tools (kubectl, docker, gh, etc.) to inspect their status at runtime, but none of these are required for building or testing `all-cli` itself.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,7 @@ Thanks for your interest in contributing! This document covers the development w
 
 ## Prerequisites
 
-- **Go 1.25+** (auto-downloads if your Go toolchain supports it; see `go.mod`)
+- **Go 1.26.1+** (auto-downloads if your Go toolchain supports it; see `go.mod`)
 - **just** (optional but recommended — install via `brew install just` or [just.systems](https://just.systems/))
 
 ## Quick Start

--- a/docs/context-research.md
+++ b/docs/context-research.md
@@ -155,7 +155,7 @@ Notes:
 - Effective tool versions for the current directory/shell environment.
 
 ### Read current (v0.1)
-- `mise current` parsed into a map like `go=1.26.0`, `node=22.20.0`, etc.
+- `mise current` parsed into a map like `go=1.26.1`, `node=25.8.1`, etc.
 
 ## k9s
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/oldwinter/all-cli
 
-go 1.25.0
+go 1.26.1
 
 require github.com/spf13/cobra v1.10.2
 

--- a/internal/cli/mise_test.go
+++ b/internal/cli/mise_test.go
@@ -20,7 +20,7 @@ func TestMiseStatusJSON(t *testing.T) {
 		ConfiguredState: model.ConfiguredNA,
 		Configured:      true,
 		Capabilities:    model.Capability{HasContexts: true},
-		Current:         map[string]string{"go": "1.26.0"},
+		Current:         map[string]string{"go": "1.26.1"},
 	}
 	stubToolEvaluation(t, "mise", summary)
 
@@ -37,7 +37,7 @@ func TestMiseStatusJSON(t *testing.T) {
 	if err := json.Unmarshal([]byte(stdout), &got); err != nil {
 		t.Fatalf("failed to decode JSON: %v", err)
 	}
-	if got.ID != "mise" || got.Current["go"] != "1.26.0" {
+	if got.ID != "mise" || got.Current["go"] != "1.26.1" {
 		t.Fatalf("unexpected summary: %#v", got)
 	}
 }
@@ -74,7 +74,7 @@ func TestMiseCurrentJSON(t *testing.T) {
 	runner := cliFakeRunner{
 		results: map[string]execx.CmdResult{
 			"mise current": {
-				Stdout: "node 22.20.0\ngo 1.26.0\n",
+				Stdout: "node 25.8.1\ngo 1.26.1\n",
 			},
 		},
 	}
@@ -93,7 +93,7 @@ func TestMiseCurrentJSON(t *testing.T) {
 	if err := json.Unmarshal([]byte(stdout), &got); err != nil {
 		t.Fatalf("failed to decode JSON: %v", err)
 	}
-	if got.Current["go"] != "1.26.0" || got.Current["node"] != "22.20.0" {
+	if got.Current["go"] != "1.26.1" || got.Current["node"] != "25.8.1" {
 		t.Fatalf("unexpected current: %#v", got.Current)
 	}
 }
@@ -103,7 +103,7 @@ func TestMiseCurrentPlainSorted(t *testing.T) {
 	runner := cliFakeRunner{
 		results: map[string]execx.CmdResult{
 			"mise current": {
-				Stdout: "python 3.14.0\ngo 1.26.0\nnode 22.20.0\n",
+				Stdout: "python 3.14.0\ngo 1.26.1\nnode 25.8.1\n",
 			},
 		},
 	}
@@ -117,7 +117,7 @@ func TestMiseCurrentPlainSorted(t *testing.T) {
 	}
 
 	lines := strings.Split(strings.TrimSpace(stdout), "\n")
-	want := []string{"go: 1.26.0", "node: 22.20.0", "python: 3.14.0"}
+	want := []string{"go: 1.26.1", "node: 25.8.1", "python: 3.14.0"}
 	if len(lines) != len(want) {
 		t.Fatalf("unexpected output lines: %#v", lines)
 	}
@@ -133,7 +133,7 @@ func TestMiseCurrentPlainWithWarning(t *testing.T) {
 	runner := cliFakeRunner{
 		results: map[string]execx.CmdResult{
 			"mise current": {
-				Stdout: "go 1.26.0\nbroken-line\n",
+				Stdout: "go 1.26.1\nbroken-line\n",
 			},
 		},
 	}
@@ -142,7 +142,7 @@ func TestMiseCurrentPlainWithWarning(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if !strings.Contains(stdout, "go: 1.26.0") {
+	if !strings.Contains(stdout, "go: 1.26.1") {
 		t.Fatalf("unexpected stdout:\n%s", stdout)
 	}
 	if !strings.Contains(stderr, "warning: unexpected mise current output line: broken-line") {

--- a/internal/tools/mise/adapter_test.go
+++ b/internal/tools/mise/adapter_test.go
@@ -26,8 +26,8 @@ func (f fakeRunner) Run(_ context.Context, name string, args ...string) execx.Cm
 
 func TestParseMiseCurrent(t *testing.T) {
 	stdout := `bun 1.3.0
-go 1.26.0
-node 22.20.0
+go 1.26.1
+node 25.8.1
 python 3.14.0
 `
 	cur, warnings, errs, err := parseMiseCurrent(stdout)
@@ -40,15 +40,15 @@ python 3.14.0
 	if len(errs) != 0 {
 		t.Fatalf("unexpected errs: %#v", errs)
 	}
-	if cur["go"] != "1.26.0" || cur["python"] != "3.14.0" {
+	if cur["go"] != "1.26.1" || cur["python"] != "3.14.0" {
 		t.Fatalf("unexpected current map: %#v", cur)
 	}
 }
 
 func TestParseMiseCurrent_WarnsOnMalformedLine(t *testing.T) {
-	stdout := `go 1.26.0
+	stdout := `go 1.26.1
 broken-line
-node 22.20.0
+node 25.8.1
 `
 	cur, warnings, errs, err := parseMiseCurrent(stdout)
 	if err != nil {
@@ -57,7 +57,7 @@ node 22.20.0
 	if len(errs) != 0 {
 		t.Fatalf("unexpected errs: %#v", errs)
 	}
-	if cur["go"] != "1.26.0" || cur["node"] != "22.20.0" {
+	if cur["go"] != "1.26.1" || cur["node"] != "25.8.1" {
 		t.Fatalf("unexpected current map: %#v", cur)
 	}
 	if len(warnings) != 1 || warnings[0] != "unexpected mise current output line: broken-line" {


### PR DESCRIPTION
## Summary
- upgrade the repo toolchain baseline from Go 1.25.0 to Go 1.26.1
- move GitHub Actions to the latest current releases and opt workflows into the Node 24 runtime
- refresh mise-related sample versions to current Go and Node releases in docs and tests

## Test Plan
- [x] env -u GOROOT -u GOTOOLDIR go mod tidy
- [x] env -u GOROOT -u GOTOOLDIR go vet ./...
- [x] env -u GOROOT -u GOTOOLDIR go test ./...
- [x] env -u GOROOT -u GOTOOLDIR go test -race ./...
- [x] env -u GOROOT -u GOTOOLDIR go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.11.3 run
- [x] env -u GOROOT -u GOTOOLDIR go test -count=1 -coverprofile=/tmp/all-cli-internal-cli.cover ./internal/cli