### PR TITLE
feat: add cloud platform cli context detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,9 +9,9 @@
 - `argocd` (Argo CD CLI contexts)
 - `kargo` (default project)
 
-It also detects “current context” for other common tools in `all-cli status` (read-only), including `aws`, `aliyun`, `wrangler`, `argocd`, `kargo`, `mise`, and `k9s`.
+It also detects “current context” for other common tools in `all-cli status` (read-only), including `aws`, `aliyun`, `wrangler`, `vercel`, `railway`, `netlify`, `argocd`, `kargo`, `mise`, and `k9s`.
 
-The inventory is intentionally broader than the context-switching set. It now also tracks common local CLIs grouped by category, including navigation (`fd`, `rg`, `fzf`, `zoxide`), shell/data helpers (`eza`, `bat`, `yq`), task/runtime tools (`uv`, `just`, `mise`), Kubernetes helpers (`kubectx`, `kubens`, `kubecolor`, `krew`), AI terminals (`claude`, `codex`, `openclaw`, `opencode`, `gemini`, `ccusage`, `litellm-proxy`), and a few workflow tools such as `linear` and `simplex-cli`.
+The inventory is intentionally broader than the context-switching set. It now also tracks common local CLIs grouped by category, including navigation (`fd`, `rg`, `fzf`, `zoxide`), shell/data helpers (`eza`, `bat`, `yq`), task/runtime tools (`uv`, `just`, `mise`), cloud/deployment CLIs (`aws`, `aliyun`, `wrangler`, `vercel`, `railway`, `netlify`), Kubernetes helpers (`kubectx`, `kubens`, `kubecolor`, `krew`), AI terminals (`claude`, `codex`, `openclaw`, `opencode`, `gemini`, `ccusage`, `litellm-proxy`), and a few workflow tools such as `linear` and `simplex-cli`.
 
 It defaults to human-friendly output and supports `--json` for stable machine-readable output (e.g. a future SwiftUI macOS app).
 

--- a/docs/plans/2026-03-17-cloud-platform-cli-contexts.md
+++ b/docs/plans/2026-03-17-cloud-platform-cli-contexts.md
@@ -1,0 +1,191 @@
+# Cloud Platform CLI Contexts Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Add `vercel`, `railway`, and `netlify` to `all-cli status` with install detection, login/config detection, and read-only current-account/context snapshots.
+
+**Architecture:** Follow the existing `aws`/`wrangler`/`gh` pattern: add one adapter package per CLI, keep parsing logic local to each adapter, and wire each tool into the shared registry with `Configured` and `Current` callbacks. Treat global authentication state as the primary context, and only include linked-project data when it is stable and does not redefine “logged in”.
+
+**Tech Stack:** Go, Cobra, stdlib JSON parsing, existing `internal/tools`, `internal/model`, and `internal/output` packages.
+
+---
+
+### Task 1: Add registry-first failing tests
+
+**Files:**
+- Modify: `internal/tools/registry_test.go`
+- Modify: `internal/tools/metadata_test.go`
+
+**Step 1: Write the failing test**
+
+Add tests that assert:
+
+- `FindByID("vercel")`, `FindByID("railway")`, and `FindByID("netlify")` exist
+- all three use category `cloud`
+- metadata exists for all three tools
+- `vercel` metadata documents account/scope fields
+
+**Step 2: Run test to verify it fails**
+
+Run: `env -u GOROOT -u GOTOOLDIR go test ./internal/tools -run 'TestDefaultRegistryIncludesToolsFromToolsMD|TestMetadataForTool' -v`
+Expected: FAIL because the new tool IDs and metadata do not exist yet.
+
+**Step 3: Write minimal implementation**
+
+Wire the three tools into:
+
+- `internal/tools/registry.go`
+- `internal/tools/metadata.go`
+
+Keep behavior limited to `status` integration only.
+
+**Step 4: Run test to verify it passes**
+
+Run: `env -u GOROOT -u GOTOOLDIR go test ./internal/tools -run 'TestDefaultRegistryIncludesToolsFromToolsMD|TestMetadataForTool' -v`
+Expected: PASS
+
+### Task 2: Add Vercel adapter with failing tests first
+
+**Files:**
+- Create: `internal/tools/vercel/adapter.go`
+- Create: `internal/tools/vercel/adapter_test.go`
+- Modify: `internal/tools/registry.go`
+
+**Step 1: Write the failing test**
+
+Add tests that assert:
+
+- `whoami --format json` yields `user` and `email`
+- `teams ls --format json` yields the current scope when present
+- config is `yes` only when `whoami` succeeds
+
+**Step 2: Run test to verify it fails**
+
+Run: `env -u GOROOT -u GOTOOLDIR go test ./internal/tools/vercel -v`
+Expected: FAIL because the adapter package does not exist.
+
+**Step 3: Write minimal implementation**
+
+Implement:
+
+- `Configured(ctx)` via `vercel whoami --format json`
+- `Current(ctx)` via `vercel whoami --format json` and `vercel teams ls --format json --next 0`
+
+Use warnings for ambiguous or missing scope data, not hard failures.
+
+**Step 4: Run test to verify it passes**
+
+Run: `env -u GOROOT -u GOTOOLDIR go test ./internal/tools/vercel -v`
+Expected: PASS
+
+### Task 3: Add Railway adapter with failing tests first
+
+**Files:**
+- Create: `internal/tools/railway/adapter.go`
+- Create: `internal/tools/railway/adapter_test.go`
+- Modify: `internal/tools/registry.go`
+
+**Step 1: Write the failing test**
+
+Add tests that assert:
+
+- `railway whoami --json` yields `name`, `email`, and workspace count
+- unauthorized output is treated as not configured, not as a parser crash
+
+**Step 2: Run test to verify it fails**
+
+Run: `env -u GOROOT -u GOTOOLDIR go test ./internal/tools/railway -v`
+Expected: FAIL because the adapter package does not exist.
+
+**Step 3: Write minimal implementation**
+
+Implement:
+
+- `Configured(ctx)` from `railway whoami --json`
+- `Current(ctx)` from the same JSON payload
+
+Do not depend on cwd-linked project state for global status.
+
+**Step 4: Run test to verify it passes**
+
+Run: `env -u GOROOT -u GOTOOLDIR go test ./internal/tools/railway -v`
+Expected: PASS
+
+### Task 4: Add Netlify adapter with failing tests first
+
+**Files:**
+- Create: `internal/tools/netlify/adapter.go`
+- Create: `internal/tools/netlify/adapter_test.go`
+- Modify: `internal/tools/registry.go`
+
+**Step 1: Write the failing test**
+
+Add tests that assert:
+
+- current user data can be read from the Netlify global config layout
+- current account selection follows `userId`
+- missing/invalid config yields `configured=no`
+
+**Step 2: Run test to verify it fails**
+
+Run: `env -u GOROOT -u GOTOOLDIR go test ./internal/tools/netlify -v`
+Expected: FAIL because the adapter package does not exist.
+
+**Step 3: Write minimal implementation**
+
+Implement:
+
+- config-file based detection for current account
+- `Configured(ctx)` based on presence of a selected user with token/email
+- `Current(ctx)` based on selected user name/email
+
+Prefer filesystem parsing over `netlify status` so “not linked to a site” does not look like “not logged in”.
+
+**Step 4: Run test to verify it passes**
+
+Run: `env -u GOROOT -u GOTOOLDIR go test ./internal/tools/netlify -v`
+Expected: PASS
+
+### Task 5: Document and verify the full integration
+
+**Files:**
+- Modify: `README.md`
+- Modify: `internal/tools/registry_test.go`
+- Modify: `internal/tools/metadata_test.go`
+
+**Step 1: Run focused tests**
+
+Run:
+
+```bash
+env -u GOROOT -u GOTOOLDIR go test ./internal/tools/... -v
+```
+
+Expected: PASS
+
+**Step 2: Run full suite**
+
+Run:
+
+```bash
+env -u GOROOT -u GOTOOLDIR go test ./...
+```
+
+Expected: PASS
+
+**Step 3: Smoke test status output**
+
+Run:
+
+```bash
+env -u GOROOT -u GOTOOLDIR go run ./cmd/all-cli status --tools vercel,railway,netlify --json
+```
+
+Expected: JSON includes the three tools with appropriate `configured_state` and `current` fields.
+
+**Step 4: Commit**
+
+```bash
+git add -A
+git commit -m "feat: add cloud platform cli context detection"
+```

--- a/internal/output/json_test.go
+++ b/internal/output/json_test.go
@@ -15,8 +15,8 @@ func TestPrintJSONIncludesLegendAndMetadata(t *testing.T) {
 	report.Tools[0] = model.ToolSummary{
 		ID: "kubectl",
 		Metadata: model.ToolMetadata{
-			Purpose:        "Kubernetes CLI.",
-			AgentActions:   []string{"inspect_status", "show_current"},
+			Purpose:                  "Kubernetes CLI.",
+			AgentActions:             []string{"inspect_status", "show_current"},
 			CurrentFieldDescriptions: map[string]string{"context": "The active kubeconfig context name."},
 		},
 	}

--- a/internal/tools/metadata.go
+++ b/internal/tools/metadata.go
@@ -80,6 +80,41 @@ func MetadataForTool(id string) model.ToolMetadata {
 			[]string{"inspect_status", "show_current"},
 			"Multiple accounts are not an error, but they mean there is no single globally implied target account.",
 		)
+	case "vercel":
+		return currentMetadata(
+			"Vercel CLI for deployments, projects, teams, and hosted application operations.",
+			"The current Vercel CLI session can resolve the authenticated user.",
+			map[string]string{
+				"user":  "The authenticated Vercel username.",
+				"email": "The email address of the authenticated Vercel user.",
+				"scope": "The current Vercel team scope slug when the CLI reports one.",
+			},
+			[]string{"inspect_status", "show_current"},
+		)
+	case "railway":
+		return currentMetadata(
+			"Railway CLI for deployment, project, environment, and service operations.",
+			"The Railway CLI can resolve the currently authenticated user.",
+			map[string]string{
+				"name":             "The display name of the authenticated Railway user, if available.",
+				"email":            "The email address of the authenticated Railway user.",
+				"workspaces_count": "How many Railway workspaces are visible to the authenticated user.",
+				"workspace":        "The single visible workspace name when exactly one workspace is available.",
+			},
+			[]string{"inspect_status", "show_current"},
+			"Multiple workspaces are not an error, but they mean there is no single globally implied Railway workspace.",
+		)
+	case "netlify":
+		return currentMetadata(
+			"Netlify CLI for site, deploy, environment, and account operations.",
+			"The Netlify CLI can resolve the currently authenticated user through the Netlify API.",
+			map[string]string{
+				"user_id": "The Netlify user ID of the authenticated account.",
+				"name":    "The display name of the authenticated Netlify user, if available.",
+				"email":   "The email address of the authenticated Netlify user.",
+			},
+			[]string{"inspect_status", "show_current"},
+		)
 	case "eksctl":
 		return naMetadata("CLI for managing Amazon EKS clusters and related resources.")
 	case "kubectl":

--- a/internal/tools/metadata_test.go
+++ b/internal/tools/metadata_test.go
@@ -26,6 +26,47 @@ func TestMetadataForToolKubectl(t *testing.T) {
 	}
 }
 
+func TestMetadataForCloudPlatformTools(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		id         string
+		field      string
+		wantAction string
+	}{
+		{id: "vercel", field: "email", wantAction: "show_current"},
+		{id: "railway", field: "email", wantAction: "show_current"},
+		{id: "netlify", field: "email", wantAction: "show_current"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.id, func(t *testing.T) {
+			meta := MetadataForTool(tt.id)
+
+			if meta.Purpose == "" {
+				t.Fatalf("expected purpose for %s", tt.id)
+			}
+			if meta.ConfiguredWhen == "" {
+				t.Fatalf("expected configured_when for %s", tt.id)
+			}
+			if meta.CurrentFieldDescriptions[tt.field] == "" {
+				t.Fatalf("expected current field description for %s.%s", tt.id, tt.field)
+			}
+
+			found := false
+			for _, action := range meta.AgentActions {
+				if action == tt.wantAction {
+					found = true
+					break
+				}
+			}
+			if !found {
+				t.Fatalf("expected %s action for %s, got %#v", tt.wantAction, tt.id, meta.AgentActions)
+			}
+		})
+	}
+}
+
 func TestEvaluateAddsMetadataToToolSummary(t *testing.T) {
 	t.Parallel()
 

--- a/internal/tools/netlify/adapter.go
+++ b/internal/tools/netlify/adapter.go
@@ -1,0 +1,93 @@
+package netlify
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/oldwinter/all-cli/internal/execx"
+)
+
+type Adapter struct {
+	runner execx.Runner
+}
+
+func New(runner execx.Runner) Adapter {
+	return Adapter{runner: runner}
+}
+
+type CurrentUser struct {
+	ID       string `json:"id"`
+	FullName string `json:"full_name,omitempty"`
+	Email    string `json:"email"`
+}
+
+func (a Adapter) Configured(ctx context.Context) (bool, []string, []string, error) {
+	user, warnings, errs, err := a.CurrentUser(ctx)
+	if err != nil {
+		return false, warnings, errs, err
+	}
+	return strings.TrimSpace(user.ID) != "" || strings.TrimSpace(user.Email) != "", warnings, errs, nil
+}
+
+func (a Adapter) Current(ctx context.Context) (map[string]string, []string, []string, error) {
+	user, warnings, errs, err := a.CurrentUser(ctx)
+	if err != nil {
+		return nil, warnings, errs, err
+	}
+	if strings.TrimSpace(user.ID) == "" && strings.TrimSpace(user.Email) == "" {
+		return nil, warnings, errs, nil
+	}
+
+	cur := map[string]string{}
+	if strings.TrimSpace(user.ID) != "" {
+		cur["user_id"] = user.ID
+	}
+	if strings.TrimSpace(user.FullName) != "" {
+		cur["name"] = user.FullName
+	}
+	if strings.TrimSpace(user.Email) != "" {
+		cur["email"] = user.Email
+	}
+	return cur, warnings, errs, nil
+}
+
+func (a Adapter) CurrentUser(ctx context.Context) (CurrentUser, []string, []string, error) {
+	res := a.runner.Run(ctx, "netlify", "api", "getCurrentUser")
+	if res.Err != nil {
+		if errors.Is(res.Err, context.DeadlineExceeded) || errors.Is(res.Err, context.Canceled) {
+			return CurrentUser{}, nil, nil, res.Err
+		}
+		if isAuthFailure(stdoutOrStderr(res)) {
+			return CurrentUser{}, nil, nil, nil
+		}
+		errMsg := strings.TrimSpace(stdoutOrStderr(res))
+		if errMsg == "" {
+			errMsg = res.Err.Error()
+		}
+		return CurrentUser{}, nil, []string{errMsg}, fmt.Errorf("netlify api getCurrentUser failed (exit=%d)", res.ExitCode)
+	}
+
+	var user CurrentUser
+	if err := json.Unmarshal([]byte(strings.TrimSpace(res.Stdout)), &user); err != nil {
+		return CurrentUser{}, nil, nil, fmt.Errorf("failed to parse netlify current user JSON: %w", err)
+	}
+	return user, nil, nil, nil
+}
+
+func stdoutOrStderr(res execx.CmdResult) string {
+	if strings.TrimSpace(res.Stdout) != "" {
+		return res.Stdout
+	}
+	return res.Stderr
+}
+
+func isAuthFailure(text string) bool {
+	text = strings.ToLower(strings.TrimSpace(text))
+	return strings.Contains(text, "session has expired") ||
+		strings.Contains(text, "unauthorized") ||
+		strings.Contains(text, "not logged in") ||
+		strings.Contains(text, "netlify login")
+}

--- a/internal/tools/netlify/adapter_test.go
+++ b/internal/tools/netlify/adapter_test.go
@@ -1,0 +1,85 @@
+package netlify
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/oldwinter/all-cli/internal/execx"
+)
+
+type fakeRunner struct {
+	results map[string]execx.CmdResult
+}
+
+func (f fakeRunner) Run(_ context.Context, name string, args ...string) execx.CmdResult {
+	key := name
+	if len(args) > 0 {
+		key += " " + strings.Join(args, " ")
+	}
+	if res, ok := f.results[key]; ok {
+		return res
+	}
+	return execx.CmdResult{ExitCode: 1, Err: errors.New("unexpected command"), Stderr: "unexpected command"}
+}
+
+func TestCurrentParsesCurrentUserJSON(t *testing.T) {
+	t.Parallel()
+
+	a := New(fakeRunner{
+		results: map[string]execx.CmdResult{
+			"netlify api getCurrentUser": {
+				Stdout: `{"id":"user_123","full_name":"Old Winter","email":"cdd2zju@gmail.com"}`,
+			},
+		},
+	})
+
+	cur, warnings, errs, err := a.Current(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(warnings) != 0 {
+		t.Fatalf("unexpected warnings: %#v", warnings)
+	}
+	if len(errs) != 0 {
+		t.Fatalf("unexpected errs: %#v", errs)
+	}
+	if cur["user_id"] != "user_123" {
+		t.Fatalf("expected user_id, got %#v", cur)
+	}
+	if cur["name"] != "Old Winter" {
+		t.Fatalf("expected name, got %#v", cur)
+	}
+	if cur["email"] != "cdd2zju@gmail.com" {
+		t.Fatalf("expected email, got %#v", cur)
+	}
+}
+
+func TestConfiguredTreatsExpiredSessionAsNotConfigured(t *testing.T) {
+	t.Parallel()
+
+	a := New(fakeRunner{
+		results: map[string]execx.CmdResult{
+			"netlify api getCurrentUser": {
+				ExitCode: 1,
+				Err:      errors.New("exit status 1"),
+				Stderr:   "Error: Your session has expired. Please try to re-authenticate by running `netlify logout` and `netlify login`.",
+			},
+		},
+	})
+
+	ok, warnings, errs, err := a.Configured(context.Background())
+	if err != nil {
+		t.Fatalf("expected expired session to be treated as not configured, got error %v", err)
+	}
+	if ok {
+		t.Fatalf("expected ok=false when session expired")
+	}
+	if len(warnings) != 0 {
+		t.Fatalf("unexpected warnings: %#v", warnings)
+	}
+	if len(errs) != 0 {
+		t.Fatalf("unexpected errs: %#v", errs)
+	}
+}

--- a/internal/tools/railway/adapter.go
+++ b/internal/tools/railway/adapter.go
@@ -1,0 +1,100 @@
+package railway
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/oldwinter/all-cli/internal/execx"
+)
+
+type Adapter struct {
+	runner execx.Runner
+}
+
+func New(runner execx.Runner) Adapter {
+	return Adapter{runner: runner}
+}
+
+type Whoami struct {
+	Name       string      `json:"name,omitempty"`
+	Email      string      `json:"email"`
+	Workspaces []Workspace `json:"workspaces"`
+}
+
+type Workspace struct {
+	ID   string `json:"id"`
+	Name string `json:"name"`
+}
+
+func (a Adapter) Configured(ctx context.Context) (bool, []string, []string, error) {
+	who, warnings, errs, err := a.Whoami(ctx)
+	if err != nil {
+		return false, warnings, errs, err
+	}
+	return strings.TrimSpace(who.Email) != "", warnings, errs, nil
+}
+
+func (a Adapter) Current(ctx context.Context) (map[string]string, []string, []string, error) {
+	who, warnings, errs, err := a.Whoami(ctx)
+	if err != nil {
+		return nil, warnings, errs, err
+	}
+	if strings.TrimSpace(who.Email) == "" {
+		return nil, warnings, errs, nil
+	}
+
+	cur := map[string]string{
+		"email":            who.Email,
+		"workspaces_count": fmt.Sprintf("%d", len(who.Workspaces)),
+	}
+	if strings.TrimSpace(who.Name) != "" {
+		cur["name"] = who.Name
+	}
+	if len(who.Workspaces) == 1 && strings.TrimSpace(who.Workspaces[0].Name) != "" {
+		cur["workspace"] = who.Workspaces[0].Name
+	}
+	if len(who.Workspaces) > 1 {
+		warnings = append(warnings, "multiple railway workspaces detected; no single global default")
+	}
+	return cur, warnings, errs, nil
+}
+
+func (a Adapter) Whoami(ctx context.Context) (Whoami, []string, []string, error) {
+	res := a.runner.Run(ctx, "railway", "whoami", "--json")
+	if res.Err != nil {
+		if errors.Is(res.Err, context.DeadlineExceeded) || errors.Is(res.Err, context.Canceled) {
+			return Whoami{}, nil, nil, res.Err
+		}
+		if isAuthFailure(stdoutOrStderr(res)) {
+			return Whoami{}, nil, nil, nil
+		}
+		errMsg := strings.TrimSpace(stdoutOrStderr(res))
+		if errMsg == "" {
+			errMsg = res.Err.Error()
+		}
+		return Whoami{}, nil, []string{errMsg}, fmt.Errorf("railway whoami failed (exit=%d)", res.ExitCode)
+	}
+
+	var who Whoami
+	if err := json.Unmarshal([]byte(strings.TrimSpace(res.Stdout)), &who); err != nil {
+		return Whoami{}, nil, nil, fmt.Errorf("failed to parse railway whoami JSON: %w", err)
+	}
+	return who, nil, nil, nil
+}
+
+func stdoutOrStderr(res execx.CmdResult) string {
+	if strings.TrimSpace(res.Stdout) != "" {
+		return res.Stdout
+	}
+	return res.Stderr
+}
+
+func isAuthFailure(text string) bool {
+	text = strings.ToLower(strings.TrimSpace(text))
+	return strings.Contains(text, "unauthorized") ||
+		strings.Contains(text, "please login") ||
+		strings.Contains(text, "not logged in")
+}

--- a/internal/tools/railway/adapter_test.go
+++ b/internal/tools/railway/adapter_test.go
@@ -1,0 +1,85 @@
+package railway
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/oldwinter/all-cli/internal/execx"
+)
+
+type fakeRunner struct {
+	results map[string]execx.CmdResult
+}
+
+func (f fakeRunner) Run(_ context.Context, name string, args ...string) execx.CmdResult {
+	key := name
+	if len(args) > 0 {
+		key += " " + strings.Join(args, " ")
+	}
+	if res, ok := f.results[key]; ok {
+		return res
+	}
+	return execx.CmdResult{ExitCode: 1, Err: errors.New("unexpected command"), Stderr: "unexpected command"}
+}
+
+func TestCurrentParsesWhoamiJSON(t *testing.T) {
+	t.Parallel()
+
+	a := New(fakeRunner{
+		results: map[string]execx.CmdResult{
+			"railway whoami --json": {
+				Stdout: `{"name":"Old Winter","email":"cdd2zju@gmail.com","workspaces":[{"id":"ws_1","name":"Team A"},{"id":"ws_2","name":"Team B"}]}`,
+			},
+		},
+	})
+
+	cur, warnings, errs, err := a.Current(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(errs) != 0 {
+		t.Fatalf("unexpected errs: %#v", errs)
+	}
+	if cur["name"] != "Old Winter" {
+		t.Fatalf("expected name, got %#v", cur)
+	}
+	if cur["email"] != "cdd2zju@gmail.com" {
+		t.Fatalf("expected email, got %#v", cur)
+	}
+	if cur["workspaces_count"] != "2" {
+		t.Fatalf("expected workspace count, got %#v", cur)
+	}
+	if len(warnings) == 0 {
+		t.Fatalf("expected warning for multiple workspaces")
+	}
+}
+
+func TestConfiguredTreatsUnauthorizedAsNotConfigured(t *testing.T) {
+	t.Parallel()
+
+	a := New(fakeRunner{
+		results: map[string]execx.CmdResult{
+			"railway whoami --json": {
+				ExitCode: 1,
+				Err:      errors.New("exit status 1"),
+				Stderr:   "Unauthorized. Please login with `railway login`",
+			},
+		},
+	})
+
+	ok, warnings, errs, err := a.Configured(context.Background())
+	if err != nil {
+		t.Fatalf("expected unauthorized to be treated as not configured, got error %v", err)
+	}
+	if ok {
+		t.Fatalf("expected ok=false when unauthorized")
+	}
+	if len(warnings) != 0 {
+		t.Fatalf("unexpected warnings: %#v", warnings)
+	}
+	if len(errs) != 0 {
+		t.Fatalf("unexpected errs: %#v", errs)
+	}
+}

--- a/internal/tools/registry.go
+++ b/internal/tools/registry.go
@@ -21,6 +21,9 @@ import (
 	"github.com/oldwinter/all-cli/internal/tools/kargo"
 	"github.com/oldwinter/all-cli/internal/tools/kubectl"
 	"github.com/oldwinter/all-cli/internal/tools/mise"
+	"github.com/oldwinter/all-cli/internal/tools/netlify"
+	"github.com/oldwinter/all-cli/internal/tools/railway"
+	"github.com/oldwinter/all-cli/internal/tools/vercel"
 	"github.com/oldwinter/all-cli/internal/tools/wrangler"
 )
 
@@ -62,6 +65,9 @@ func DefaultRegistry() []ToolDefinition {
 		awsTool(),
 		aliyunTool(),
 		wranglerTool(),
+		vercelTool(),
+		railwayTool(),
+		netlifyTool(),
 
 		toolNA("eksctl", "eksctl", "k8s", "eksctl"),
 		kubectlTool(),
@@ -551,6 +557,168 @@ func wranglerTool() ToolDefinition {
 			}
 			cur, moreWarnings := wranglerCurrentFromWhoami(w)
 			warnings = append(warnings, moreWarnings...)
+			return cur, warnings, errs
+		},
+	}
+}
+
+func vercelTool() ToolDefinition {
+	var (
+		once   sync.Once
+		cached vercel.Whoami
+		cWarn  []string
+		cErrs  []string
+		cErr   error
+	)
+	get := func(ctx context.Context, runner execx.Runner) (vercel.Whoami, []string, []string, error) {
+		once.Do(func() {
+			a := vercel.New(runner)
+			cached, cWarn, cErrs, cErr = a.Whoami(ctx)
+		})
+		return cached, cWarn, cErrs, cErr
+	}
+
+	return ToolDefinition{
+		ID:          "vercel",
+		DisplayName: "Vercel CLI",
+		Category:    "cloud",
+		Binary:      "vercel",
+		Timeout:     10 * time.Second,
+		Capabilities: model.Capability{
+			HasContexts: true,
+			CanSwitch:   false,
+		},
+		ConfigCheck: func(ctx context.Context, runner execx.Runner, installed bool) (model.ConfiguredState, []string, []string) {
+			if !installed {
+				return model.ConfiguredUnknown, nil, nil
+			}
+			who, warnings, errs, err := get(ctx, runner)
+			if err != nil {
+				errs = append(errs, err.Error())
+				return model.ConfiguredUnknown, warnings, errs
+			}
+			if strings.TrimSpace(who.Username) != "" || strings.TrimSpace(who.Email) != "" {
+				return model.ConfiguredYes, warnings, errs
+			}
+			return model.ConfiguredNo, warnings, errs
+		},
+		Current: func(ctx context.Context, runner execx.Runner, installed bool) (map[string]string, []string, []string) {
+			if !installed {
+				return nil, nil, nil
+			}
+			a := vercel.New(runner)
+			cur, warnings, errs, err := a.Current(ctx)
+			if err != nil {
+				errs = append(errs, err.Error())
+			}
+			return cur, warnings, errs
+		},
+	}
+}
+
+func railwayTool() ToolDefinition {
+	var (
+		once   sync.Once
+		cached railway.Whoami
+		cWarn  []string
+		cErrs  []string
+		cErr   error
+	)
+	get := func(ctx context.Context, runner execx.Runner) (railway.Whoami, []string, []string, error) {
+		once.Do(func() {
+			a := railway.New(runner)
+			cached, cWarn, cErrs, cErr = a.Whoami(ctx)
+		})
+		return cached, cWarn, cErrs, cErr
+	}
+
+	return ToolDefinition{
+		ID:          "railway",
+		DisplayName: "Railway CLI",
+		Category:    "cloud",
+		Binary:      "railway",
+		Timeout:     10 * time.Second,
+		Capabilities: model.Capability{
+			HasContexts: true,
+			CanSwitch:   false,
+		},
+		ConfigCheck: func(ctx context.Context, runner execx.Runner, installed bool) (model.ConfiguredState, []string, []string) {
+			if !installed {
+				return model.ConfiguredUnknown, nil, nil
+			}
+			who, warnings, errs, err := get(ctx, runner)
+			if err != nil {
+				errs = append(errs, err.Error())
+				return model.ConfiguredUnknown, warnings, errs
+			}
+			if strings.TrimSpace(who.Email) != "" {
+				return model.ConfiguredYes, warnings, errs
+			}
+			return model.ConfiguredNo, warnings, errs
+		},
+		Current: func(ctx context.Context, runner execx.Runner, installed bool) (map[string]string, []string, []string) {
+			if !installed {
+				return nil, nil, nil
+			}
+			a := railway.New(runner)
+			cur, warnings, errs, err := a.Current(ctx)
+			if err != nil {
+				errs = append(errs, err.Error())
+			}
+			return cur, warnings, errs
+		},
+	}
+}
+
+func netlifyTool() ToolDefinition {
+	var (
+		once   sync.Once
+		cached netlify.CurrentUser
+		cWarn  []string
+		cErrs  []string
+		cErr   error
+	)
+	get := func(ctx context.Context, runner execx.Runner) (netlify.CurrentUser, []string, []string, error) {
+		once.Do(func() {
+			a := netlify.New(runner)
+			cached, cWarn, cErrs, cErr = a.CurrentUser(ctx)
+		})
+		return cached, cWarn, cErrs, cErr
+	}
+
+	return ToolDefinition{
+		ID:          "netlify",
+		DisplayName: "Netlify CLI",
+		Category:    "cloud",
+		Binary:      "netlify",
+		Timeout:     10 * time.Second,
+		Capabilities: model.Capability{
+			HasContexts: true,
+			CanSwitch:   false,
+		},
+		ConfigCheck: func(ctx context.Context, runner execx.Runner, installed bool) (model.ConfiguredState, []string, []string) {
+			if !installed {
+				return model.ConfiguredUnknown, nil, nil
+			}
+			user, warnings, errs, err := get(ctx, runner)
+			if err != nil {
+				errs = append(errs, err.Error())
+				return model.ConfiguredUnknown, warnings, errs
+			}
+			if strings.TrimSpace(user.ID) != "" || strings.TrimSpace(user.Email) != "" {
+				return model.ConfiguredYes, warnings, errs
+			}
+			return model.ConfiguredNo, warnings, errs
+		},
+		Current: func(ctx context.Context, runner execx.Runner, installed bool) (map[string]string, []string, []string) {
+			if !installed {
+				return nil, nil, nil
+			}
+			a := netlify.New(runner)
+			cur, warnings, errs, err := a.Current(ctx)
+			if err != nil {
+				errs = append(errs, err.Error())
+			}
 			return cur, warnings, errs
 		},
 	}

--- a/internal/tools/registry_test.go
+++ b/internal/tools/registry_test.go
@@ -34,6 +34,9 @@ func TestDefaultRegistryIncludesToolsFromToolsMD(t *testing.T) {
 		"yq":            {category: "shell", binary: "yq"},
 		"kubefwd":       {category: "k8s", binary: "kubefwd"},
 		"kubeshark":     {category: "k8s", binary: "kubeshark"},
+		"vercel":        {category: "cloud", binary: "vercel"},
+		"railway":       {category: "cloud", binary: "railway"},
+		"netlify":       {category: "cloud", binary: "netlify"},
 	}
 
 	for id, want := range expected {

--- a/internal/tools/vercel/adapter.go
+++ b/internal/tools/vercel/adapter.go
@@ -1,0 +1,167 @@
+package vercel
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/oldwinter/all-cli/internal/execx"
+)
+
+type Adapter struct {
+	runner execx.Runner
+}
+
+func New(runner execx.Runner) Adapter {
+	return Adapter{runner: runner}
+}
+
+type Whoami struct {
+	Username string `json:"username"`
+	Email    string `json:"email"`
+	Name     string `json:"name,omitempty"`
+}
+
+type Teams struct {
+	Teams []Team `json:"teams"`
+}
+
+type Team struct {
+	ID      string `json:"id"`
+	Slug    string `json:"slug"`
+	Name    string `json:"name"`
+	Current bool   `json:"current"`
+}
+
+func (a Adapter) Configured(ctx context.Context) (bool, []string, []string, error) {
+	who, warnings, errs, err := a.Whoami(ctx)
+	if err != nil {
+		return false, warnings, errs, err
+	}
+	return strings.TrimSpace(who.Username) != "" || strings.TrimSpace(who.Email) != "", warnings, errs, nil
+}
+
+func (a Adapter) Current(ctx context.Context) (map[string]string, []string, []string, error) {
+	who, warnings, errs, err := a.Whoami(ctx)
+	if err != nil {
+		return nil, warnings, errs, err
+	}
+	if strings.TrimSpace(who.Username) == "" && strings.TrimSpace(who.Email) == "" {
+		return nil, warnings, errs, nil
+	}
+
+	cur := map[string]string{}
+	if strings.TrimSpace(who.Username) != "" {
+		cur["user"] = who.Username
+	}
+	if strings.TrimSpace(who.Email) != "" {
+		cur["email"] = who.Email
+	}
+
+	scope, moreWarnings, moreErrs, err := a.CurrentScope(ctx)
+	warnings = append(warnings, moreWarnings...)
+	errs = append(errs, moreErrs...)
+	if err != nil {
+		return cur, warnings, errs, err
+	}
+	if strings.TrimSpace(scope) != "" {
+		cur["scope"] = scope
+	}
+
+	return cur, warnings, errs, nil
+}
+
+func (a Adapter) Whoami(ctx context.Context) (Whoami, []string, []string, error) {
+	res := a.runner.Run(ctx, "vercel", "whoami", "--format", "json")
+	if res.Err != nil {
+		if errors.Is(res.Err, context.DeadlineExceeded) || errors.Is(res.Err, context.Canceled) {
+			return Whoami{}, nil, nil, res.Err
+		}
+		if isAuthFailure(stdoutOrStderr(res)) {
+			return Whoami{}, nil, nil, nil
+		}
+		errMsg := strings.TrimSpace(stdoutOrStderr(res))
+		if errMsg == "" {
+			errMsg = res.Err.Error()
+		}
+		return Whoami{}, nil, []string{errMsg}, fmt.Errorf("vercel whoami failed (exit=%d)", res.ExitCode)
+	}
+
+	payload, err := extractJSONObject(res.Stdout)
+	if err != nil {
+		return Whoami{}, nil, nil, err
+	}
+
+	var who Whoami
+	if err := json.Unmarshal([]byte(payload), &who); err != nil {
+		return Whoami{}, nil, nil, fmt.Errorf("failed to parse vercel whoami JSON: %w", err)
+	}
+	return who, nil, nil, nil
+}
+
+func (a Adapter) CurrentScope(ctx context.Context) (string, []string, []string, error) {
+	res := a.runner.Run(ctx, "vercel", "teams", "ls", "--format", "json", "--next", "0")
+	if res.Err != nil {
+		if errors.Is(res.Err, context.DeadlineExceeded) || errors.Is(res.Err, context.Canceled) {
+			return "", nil, nil, res.Err
+		}
+		if isAuthFailure(stdoutOrStderr(res)) {
+			return "", nil, nil, nil
+		}
+		errMsg := strings.TrimSpace(stdoutOrStderr(res))
+		if errMsg == "" {
+			errMsg = res.Err.Error()
+		}
+		return "", nil, []string{errMsg}, fmt.Errorf("vercel teams ls failed (exit=%d)", res.ExitCode)
+	}
+
+	payload, err := extractJSONObject(res.Stdout)
+	if err != nil {
+		return "", nil, nil, err
+	}
+
+	var teams Teams
+	if err := json.Unmarshal([]byte(payload), &teams); err != nil {
+		return "", nil, nil, fmt.Errorf("failed to parse vercel teams JSON: %w", err)
+	}
+
+	var current []string
+	for _, team := range teams.Teams {
+		if team.Current && strings.TrimSpace(team.Slug) != "" {
+			current = append(current, team.Slug)
+		}
+	}
+	switch len(current) {
+	case 0:
+		return "", nil, nil, nil
+	case 1:
+		return current[0], nil, nil, nil
+	default:
+		return current[0], []string{"multiple vercel team scopes marked current; using the first scope"}, nil, nil
+	}
+}
+
+func extractJSONObject(stdout string) (string, error) {
+	start := strings.Index(stdout, "{")
+	end := strings.LastIndex(stdout, "}")
+	if start == -1 || end == -1 || end < start {
+		return "", fmt.Errorf("no JSON object found in vercel output")
+	}
+	return stdout[start : end+1], nil
+}
+
+func stdoutOrStderr(res execx.CmdResult) string {
+	if strings.TrimSpace(res.Stdout) != "" {
+		return res.Stdout
+	}
+	return res.Stderr
+}
+
+func isAuthFailure(text string) bool {
+	text = strings.ToLower(strings.TrimSpace(text))
+	return strings.Contains(text, "please run `vercel login`") ||
+		strings.Contains(text, "no existing credentials found") ||
+		strings.Contains(text, "not logged in")
+}

--- a/internal/tools/vercel/adapter_test.go
+++ b/internal/tools/vercel/adapter_test.go
@@ -1,0 +1,89 @@
+package vercel
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/oldwinter/all-cli/internal/execx"
+)
+
+type fakeRunner struct {
+	results map[string]execx.CmdResult
+}
+
+func (f fakeRunner) Run(_ context.Context, name string, args ...string) execx.CmdResult {
+	key := name
+	if len(args) > 0 {
+		key += " " + strings.Join(args, " ")
+	}
+	if res, ok := f.results[key]; ok {
+		return res
+	}
+	return execx.CmdResult{ExitCode: 1, Err: errors.New("unexpected command"), Stderr: "unexpected command"}
+}
+
+func TestCurrentReadsWhoamiAndCurrentScope(t *testing.T) {
+	t.Parallel()
+
+	a := New(fakeRunner{
+		results: map[string]execx.CmdResult{
+			"vercel whoami --format json": {
+				Stdout: `{"username":"oldwinter","email":"cdd2zju@gmail.com","name":null}`,
+			},
+			"vercel teams ls --format json --next 0": {
+				Stdout: "Fetching teams\nFetching user information\n" +
+					`{"teams":[{"id":"team_123","slug":"oldwinters-projects","name":"oldwinter's projects","current":true},{"id":"team_456","slug":"other-team","name":"Other Team","current":false}]}`,
+			},
+		},
+	})
+
+	cur, warnings, errs, err := a.Current(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(warnings) != 0 {
+		t.Fatalf("unexpected warnings: %#v", warnings)
+	}
+	if len(errs) != 0 {
+		t.Fatalf("unexpected errs: %#v", errs)
+	}
+	if cur["user"] != "oldwinter" {
+		t.Fatalf("expected user=oldwinter, got %#v", cur)
+	}
+	if cur["email"] != "cdd2zju@gmail.com" {
+		t.Fatalf("expected email, got %#v", cur)
+	}
+	if cur["scope"] != "oldwinters-projects" {
+		t.Fatalf("expected scope from current team, got %#v", cur)
+	}
+}
+
+func TestConfiguredTreatsMissingLoginAsNotConfigured(t *testing.T) {
+	t.Parallel()
+
+	a := New(fakeRunner{
+		results: map[string]execx.CmdResult{
+			"vercel whoami --format json": {
+				ExitCode: 1,
+				Err:      errors.New("exit status 1"),
+				Stderr:   "Error: No existing credentials found. Please run `vercel login`",
+			},
+		},
+	})
+
+	ok, warnings, errs, err := a.Configured(context.Background())
+	if err != nil {
+		t.Fatalf("expected missing login to be treated as not configured, got error %v", err)
+	}
+	if ok {
+		t.Fatalf("expected ok=false when login is missing")
+	}
+	if len(warnings) != 0 {
+		t.Fatalf("unexpected warnings: %#v", warnings)
+	}
+	if len(errs) != 0 {
+		t.Fatalf("unexpected errs: %#v", errs)
+	}
+}


### PR DESCRIPTION
## Summary
- add read-only status integration for vercel, railway, and netlify
- detect authenticated account context for each CLI and expose it via status current fields
- add adapter tests, registry/metadata coverage, and update docs

## Test Plan
- env -u GOROOT -u GOTOOLDIR go test ./...
- just check
- env -u GOROOT -u GOTOOLDIR go run ./cmd/all-cli status --tools vercel,railway,netlify --json
- ./all-cli status --tools vercel,railway,netlify --group-by none

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **New Features**
  * Added support for Vercel, Railway, and Netlify in current-context detection.
  * These cloud platforms now display current account and authentication status alongside existing cloud platform CLI integrations.

* **Documentation**
  * Updated documentation to reflect new cloud platform integrations and their status capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->