### PR TITLE
fix: restore registry imports for release build

### DIFF
--- a/internal/tools/registry.go
+++ b/internal/tools/registry.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"os"
 	"path/filepath"
+	"strings"
+	"sync"
 	"time"
 
 	"github.com/oldwinter/all-cli/internal/execx"


### PR DESCRIPTION
## Summary
- add the missing registry imports required by the new cloud CLI tool definitions
- fix the clean-environment build failure that broke the post-merge release workflow

## Test Plan
- env -u GOROOT -u GOTOOLDIR go test ./...
- just check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

本次发布无用户可见的功能变更。仅包含内部代码维护和优化。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->