### PR TITLE
feat(opencli): 增加 opencli 状态检测

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 
 It also detects “current context” for other common tools in `all-cli status` (read-only), including `aws`, `aliyun`, `wrangler`, `vercel`, `railway`, `netlify`, `argocd`, `kargo`, `mise`, and `k9s`.
 
-The inventory is intentionally broader than the context-switching set. It now also tracks common local CLIs grouped by category, including navigation (`fd`, `rg`, `fzf`, `zoxide`), shell/data helpers (`eza`, `bat`, `yq`), task/runtime tools (`uv`, `just`, `mise`), cloud/deployment CLIs (`aws`, `aliyun`, `wrangler`, `vercel`, `railway`, `netlify`), Kubernetes helpers (`kubectx`, `kubens`, `kubecolor`, `krew`), AI terminals (`claude`, `codex`, `openclaw`, `opencode`, `gemini`, `ccusage`, `litellm-proxy`), and a few workflow tools such as `linear` and `simplex-cli`.
+The inventory is intentionally broader than the context-switching set. It now also tracks common local CLIs grouped by category, including navigation (`fd`, `rg`, `fzf`, `zoxide`), shell/data helpers (`eza`, `bat`, `yq`), task/runtime tools (`uv`, `just`, `mise`), cloud/deployment CLIs (`aws`, `aliyun`, `wrangler`, `vercel`, `railway`, `netlify`), web automation (`opencli`), Kubernetes helpers (`kubectx`, `kubens`, `kubecolor`, `krew`), AI terminals (`claude`, `codex`, `openclaw`, `opencode`, `gemini`, `ccusage`, `litellm-proxy`), and a few workflow tools such as `linear` and `simplex-cli`.
 
 It defaults to human-friendly output and supports `--json` for stable machine-readable output (e.g. a future SwiftUI macOS app).
 

--- a/docs/plans/2026-03-17-opencli-integration.md
+++ b/docs/plans/2026-03-17-opencli-integration.md
@@ -1,0 +1,152 @@
+# OpenCLI Integration Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Install `opencli` and `opencli-skill` locally, then add `opencli` to `all-cli status` with accurate install/configuration detection.
+
+**Architecture:** Treat `opencli` as the real CLI artifact and `opencli-skill` as an optional companion skill. Use `opencli doctor` as the primary diagnostics source because it already consolidates browser bridge, token discovery, and MCP client propagation state. Reflect only stable, tool-owned state in `all-cli`.
+
+**Tech Stack:** Go, Node.js/npm, existing `internal/tools` adapter pattern, local Codex skill installer helper.
+
+---
+
+### Task 1: Install the tool and companion skill
+
+**Files:**
+- Modify: `none`
+
+**Step 1: Install the CLI**
+
+Run:
+
+```bash
+npm install -g @jackwener/opencli
+```
+
+**Step 2: Install the skill**
+
+Run:
+
+```bash
+python3 /Users/cdd/.codex/skills/.system/skill-installer/scripts/install-skill-from-github.py --repo joeseesun/opencli-skill --path . --name opencli-skill
+```
+
+**Step 3: Verify install state**
+
+Run:
+
+```bash
+opencli --version
+opencli doctor
+```
+
+Expected: CLI works; doctor reports any missing browser/token prerequisites.
+
+### Task 2: Add failing tests for registry and metadata
+
+**Files:**
+- Modify: `internal/tools/registry_test.go`
+- Modify: `internal/tools/metadata_test.go`
+
+**Step 1: Write the failing test**
+
+Add tests asserting:
+
+- `FindByID("opencli")` exists
+- category/binary are correct
+- metadata includes `bridge`, `token`, and `targets` field descriptions
+
+**Step 2: Run test to verify it fails**
+
+Run:
+
+```bash
+env -u GOROOT -u GOTOOLDIR go test ./internal/tools -run 'TestDefaultRegistryIncludesToolsFromToolsMD|TestMetadataForOpenCLI' -v
+```
+
+Expected: FAIL because `opencli` is not registered yet.
+
+### Task 3: Add failing tests for the adapter
+
+**Files:**
+- Create: `internal/tools/opencli/adapter.go`
+- Create: `internal/tools/opencli/adapter_test.go`
+
+**Step 1: Write the failing test**
+
+Add tests asserting:
+
+- `opencli doctor` output is parsed into bridge/token/targets state
+- configured=yes requires bridge installed and extension token detected
+- current snapshot stays concise
+
+**Step 2: Run test to verify it fails**
+
+Run:
+
+```bash
+env -u GOROOT -u GOTOOLDIR go test ./internal/tools/opencli -v
+```
+
+Expected: FAIL because the adapter package does not exist.
+
+### Task 4: Implement registry wiring and metadata
+
+**Files:**
+- Modify: `internal/tools/registry.go`
+- Modify: `internal/tools/metadata.go`
+- Modify: `README.md`
+
+**Step 1: Add tool registration**
+
+Register `opencli` in the default registry with:
+
+- binary: `opencli`
+- category: `web`
+- `HasContexts: false`
+- `CanSwitch: false`
+
+**Step 2: Add metadata**
+
+Document:
+
+- what `opencli` does
+- what `configured_state=yes` means
+- meanings of `bridge`, `token`, and `targets`
+
+**Step 3: Update README**
+
+Mention `opencli` in the tracked inventory.
+
+### Task 5: Verify end-to-end
+
+**Files:**
+- Modify: `none`
+
+**Step 1: Run focused tests**
+
+Run:
+
+```bash
+env -u GOROOT -u GOTOOLDIR go test ./internal/tools/... -v
+```
+
+**Step 2: Run full verification**
+
+Run:
+
+```bash
+env -u GOROOT -u GOTOOLDIR go test ./...
+just check
+```
+
+**Step 3: Smoke test**
+
+Run:
+
+```bash
+all-cli status --tools opencli --group-by none
+all-cli status --tools opencli --json
+```
+
+Expected: `opencli` appears with correct install/configured status and concise current snapshot.

--- a/internal/tools/metadata.go
+++ b/internal/tools/metadata.go
@@ -187,6 +187,19 @@ func MetadataForTool(id string) model.ToolMetadata {
 		return naMetadata("CLI for inspecting Claude Code usage and related local usage data.")
 	case "litellm-proxy":
 		return naMetadata("LiteLLM proxy CLI for local or staging model routing and smoke tests.")
+	case "opencli":
+		return currentMetadata(
+			"CLI that turns supported websites into command-line interfaces by reusing Chrome browser sessions.",
+			"The OpenCLI browser bridge is installed and `opencli` can detect the Playwright MCP extension token.",
+			map[string]string{
+				"bridge":  "Whether the Playwright MCP Bridge browser extension is installed.",
+				"token":   "Whether `opencli doctor` detected the browser extension token.",
+				"env":     "Whether PLAYWRIGHT_MCP_EXTENSION_TOKEN is exported in the current environment.",
+				"targets": "Comma-separated client configs that already contain the Playwright extension token.",
+			},
+			[]string{"inspect_status", "show_current"},
+			"`configured_state=yes` does not guarantee that target websites are logged in; it only verifies the local browser bridge prerequisites that OpenCLI reports.",
+		)
 	case "simplex-cli":
 		return naMetadata("Internal operations CLI for Simplex product and account workflows.")
 	case "rclone":

--- a/internal/tools/metadata_test.go
+++ b/internal/tools/metadata_test.go
@@ -67,6 +67,30 @@ func TestMetadataForCloudPlatformTools(t *testing.T) {
 	}
 }
 
+func TestMetadataForOpenCLI(t *testing.T) {
+	t.Parallel()
+
+	meta := MetadataForTool("opencli")
+	if meta.Purpose == "" {
+		t.Fatalf("expected purpose for opencli")
+	}
+	if meta.ConfiguredWhen == "" {
+		t.Fatalf("expected configured_when for opencli")
+	}
+	if meta.CurrentFieldDescriptions["bridge"] == "" {
+		t.Fatalf("expected bridge field description for opencli")
+	}
+	if meta.CurrentFieldDescriptions["token"] == "" {
+		t.Fatalf("expected token field description for opencli")
+	}
+	if meta.CurrentFieldDescriptions["targets"] == "" {
+		t.Fatalf("expected targets field description for opencli")
+	}
+	if len(meta.AgentActions) == 0 {
+		t.Fatalf("expected agent actions for opencli")
+	}
+}
+
 func TestEvaluateAddsMetadataToToolSummary(t *testing.T) {
 	t.Parallel()
 

--- a/internal/tools/opencli/adapter.go
+++ b/internal/tools/opencli/adapter.go
@@ -1,0 +1,122 @@
+package opencli
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/oldwinter/all-cli/internal/execx"
+)
+
+type Adapter struct {
+	runner execx.Runner
+}
+
+func New(runner execx.Runner) Adapter {
+	return Adapter{runner: runner}
+}
+
+type Diagnosis struct {
+	BridgeInstalled       bool
+	ExtensionTokenPresent bool
+	EnvironmentTokenSet   bool
+	Targets               []string
+	Warnings              []string
+}
+
+func (a Adapter) Configured(ctx context.Context) (bool, []string, []string, error) {
+	diag, warnings, errs, err := a.Doctor(ctx)
+	if err != nil {
+		return false, warnings, errs, err
+	}
+	warnings = append(warnings, diag.Warnings...)
+	return diag.BridgeInstalled && diag.ExtensionTokenPresent, warnings, errs, nil
+}
+
+func (a Adapter) Current(ctx context.Context) (map[string]string, []string, []string, error) {
+	diag, warnings, errs, err := a.Doctor(ctx)
+	if err != nil {
+		return nil, warnings, errs, err
+	}
+	warnings = append(warnings, diag.Warnings...)
+
+	cur := map[string]string{
+		"bridge": "missing",
+		"token":  "missing",
+	}
+	if diag.BridgeInstalled {
+		cur["bridge"] = "installed"
+	}
+	if diag.ExtensionTokenPresent {
+		cur["token"] = "detected"
+	}
+	if diag.EnvironmentTokenSet {
+		cur["env"] = "set"
+	}
+	if len(diag.Targets) > 0 {
+		cur["targets"] = strings.Join(diag.Targets, ",")
+	}
+
+	return cur, warnings, errs, nil
+}
+
+func (a Adapter) Doctor(ctx context.Context) (Diagnosis, []string, []string, error) {
+	res := a.runner.Run(ctx, "opencli", "doctor")
+	if res.Err != nil {
+		errMsg := strings.TrimSpace(stdoutOrStderr(res))
+		if errMsg == "" {
+			errMsg = res.Err.Error()
+		}
+		return Diagnosis{}, nil, []string{errMsg}, fmt.Errorf("opencli doctor failed (exit=%d)", res.ExitCode)
+	}
+
+	return parseDoctorOutput(res.Stdout), nil, nil, nil
+}
+
+func parseDoctorOutput(stdout string) Diagnosis {
+	diag := Diagnosis{}
+	targets := map[string]bool{}
+
+	for _, raw := range strings.Split(stdout, "\n") {
+		line := strings.TrimSpace(raw)
+		switch {
+		case strings.HasPrefix(line, "[OK] Extension installed in browser"),
+			strings.HasPrefix(line, "[OK] Extension installed ("):
+			diag.BridgeInstalled = true
+		case strings.HasPrefix(line, "[OK] Extension token (Chrome LevelDB):"):
+			diag.ExtensionTokenPresent = true
+		case strings.HasPrefix(line, "[OK] Environment token:"):
+			diag.EnvironmentTokenSet = true
+		case strings.HasPrefix(line, "[OK] ~/.zshrc [Shell]:"):
+			targets["shell"] = true
+		case strings.HasPrefix(line, "[OK] ~/.codex/config.toml [Codex]:"):
+			targets["codex"] = true
+		case strings.HasPrefix(line, "[OK] ~/.claude.json [Claude Code]:"):
+			targets["claude"] = true
+		case strings.HasPrefix(line, "[OK] ~/.cursor/mcp.json [Cursor]:"):
+			targets["cursor"] = true
+		case strings.HasPrefix(line, "[OK] ~/.gemini/settings.json [Gemini CLI]:"):
+			targets["gemini"] = true
+		case strings.HasPrefix(line, "[OK] ~/.gemini/antigravity/mcp_config.json [Antigravity]:"):
+			targets["antigravity"] = true
+		case strings.HasPrefix(line, "[OK] ~/.config/opencode/opencode.json [OpenCode]:"):
+			targets["opencode"] = true
+		case strings.HasPrefix(line, "[WARN] "):
+			diag.Warnings = append(diag.Warnings, strings.TrimPrefix(line, "[WARN] "))
+		}
+	}
+
+	for name := range targets {
+		diag.Targets = append(diag.Targets, name)
+	}
+	sort.Strings(diag.Targets)
+	return diag
+}
+
+func stdoutOrStderr(res execx.CmdResult) string {
+	if strings.TrimSpace(res.Stdout) != "" {
+		return res.Stdout
+	}
+	return res.Stderr
+}

--- a/internal/tools/opencli/adapter_test.go
+++ b/internal/tools/opencli/adapter_test.go
@@ -1,0 +1,144 @@
+package opencli
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/oldwinter/all-cli/internal/execx"
+)
+
+type fakeRunner struct {
+	results map[string]execx.CmdResult
+}
+
+func (f fakeRunner) Run(_ context.Context, name string, args ...string) execx.CmdResult {
+	key := name
+	if len(args) > 0 {
+		key += " " + strings.Join(args, " ")
+	}
+	if res, ok := f.results[key]; ok {
+		return res
+	}
+	return execx.CmdResult{ExitCode: 1, Err: errors.New("unexpected command"), Stderr: "unexpected command"}
+}
+
+func TestCurrentParsesDoctorSummary(t *testing.T) {
+	t.Parallel()
+
+	a := New(fakeRunner{
+		results: map[string]execx.CmdResult{
+			"opencli doctor": {
+				Stdout: `opencli v0.7.10 doctor
+
+[OK] Extension installed in browser
+[OK] Extension token (Chrome LevelDB): detected
+[MISSING] Environment token: missing
+[OK] ~/.zshrc [Shell]: configured
+[OK] ~/.codex/config.toml [Codex]: configured
+[MISSING] ~/.claude.json [Claude Code]: missing
+[WARN] Browser connectivity: not tested (use --live)
+`,
+			},
+		},
+	})
+
+	cur, warnings, errs, err := a.Current(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(errs) != 0 {
+		t.Fatalf("unexpected errs: %#v", errs)
+	}
+	if cur["bridge"] != "installed" {
+		t.Fatalf("expected bridge=installed, got %#v", cur)
+	}
+	if cur["token"] != "detected" {
+		t.Fatalf("expected token=detected, got %#v", cur)
+	}
+	if cur["targets"] != "codex,shell" {
+		t.Fatalf("expected configured targets, got %#v", cur)
+	}
+	if len(warnings) != 1 || !strings.Contains(strings.ToLower(warnings[0]), "browser connectivity") {
+		t.Fatalf("expected browser connectivity warning, got %#v", warnings)
+	}
+}
+
+func TestConfiguredRequiresBridgeAndToken(t *testing.T) {
+	t.Parallel()
+
+	a := New(fakeRunner{
+		results: map[string]execx.CmdResult{
+			"opencli doctor": {
+				Stdout: `opencli v0.7.10 doctor
+
+[OK] Extension installed in browser
+[MISSING] Extension token (Chrome LevelDB): missing
+[MISSING] Environment token: missing
+`,
+			},
+		},
+	})
+
+	ok, warnings, errs, err := a.Configured(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if ok {
+		t.Fatalf("expected ok=false without token")
+	}
+	if len(warnings) != 0 {
+		t.Fatalf("unexpected warnings: %#v", warnings)
+	}
+	if len(errs) != 0 {
+		t.Fatalf("unexpected errs: %#v", errs)
+	}
+}
+
+func TestCurrentParsesDoctorSummaryWithChromeLabel(t *testing.T) {
+	t.Parallel()
+
+	a := New(fakeRunner{
+		results: map[string]execx.CmdResult{
+			"opencli doctor": {
+				Stdout: `opencli v0.7.10 doctor
+
+[OK] Extension installed (Chrome)
+[OK] Extension token (Chrome LevelDB): configured (8f92ee0c)
+[OK] ~/.zshrc [Shell]: configured (8f92ee0c)
+[OK] ~/.codex/config.toml [Codex]: configured (8f92ee0c)
+[OK] ~/.codex/mcp.json [Codex]: configured (8f92ee0c)
+[OK] ~/.cursor/mcp.json [Cursor]: configured (8f92ee0c)
+[OK] ~/.claude.json [Claude Code]: configured (8f92ee0c)
+[OK] ~/.gemini/settings.json [Gemini CLI]: configured (8f92ee0c)
+[OK] ~/.gemini/antigravity/mcp_config.json [Antigravity]: configured (8f92ee0c)
+[OK] ~/.config/opencode/opencode.json [OpenCode]: configured (8f92ee0c)
+[OK] ~/my-code/all-cli/.vscode/mcp.json [VS Code]: configured (8f92ee0c)
+[OK] ~/my-code/all-cli/.mcp.json [Project MCP]: configured (8f92ee0c)
+[WARN] Browser connectivity: not tested (use --live)
+`,
+			},
+		},
+	})
+
+	cur, warnings, errs, err := a.Current(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(errs) != 0 {
+		t.Fatalf("unexpected errs: %#v", errs)
+	}
+	if cur["bridge"] != "installed" {
+		t.Fatalf("expected bridge=installed, got %#v", cur)
+	}
+	if cur["token"] != "detected" {
+		t.Fatalf("expected token=detected, got %#v", cur)
+	}
+	if cur["targets"] != "antigravity,claude,codex,cursor,gemini,opencode,shell" {
+		t.Fatalf("unexpected configured targets: %#v", cur)
+	}
+	if len(warnings) != 1 {
+		t.Fatalf("expected one warning, got %#v", warnings)
+	}
+}

--- a/internal/tools/registry.go
+++ b/internal/tools/registry.go
@@ -21,6 +21,7 @@ import (
 	"github.com/oldwinter/all-cli/internal/tools/kubectl"
 	"github.com/oldwinter/all-cli/internal/tools/mise"
 	"github.com/oldwinter/all-cli/internal/tools/netlify"
+	"github.com/oldwinter/all-cli/internal/tools/opencli"
 	"github.com/oldwinter/all-cli/internal/tools/railway"
 	"github.com/oldwinter/all-cli/internal/tools/vercel"
 	"github.com/oldwinter/all-cli/internal/tools/wrangler"
@@ -174,6 +175,7 @@ func DefaultRegistry() []ToolDefinition {
 		toolNA("gemini", "Gemini CLI", "ai", "gemini"),
 		toolNA("ccusage", "ccusage", "ai", "ccusage"),
 		toolNA("litellm-proxy", "LiteLLM Proxy", "ai", "litellm-proxy"),
+		opencliTool(),
 
 		toolNA("simplex-cli", "simplex-cli", "internal", "simplex-cli"),
 
@@ -202,6 +204,19 @@ func toolNA(id, displayName, category, binary string) ToolDefinition {
 			return model.ConfiguredUnknown, nil, nil
 		},
 	}
+}
+
+func opencliTool() ToolDefinition {
+	return toolFromAdapter(
+		"opencli",
+		"OpenCLI",
+		"web",
+		"opencli",
+		model.Capability{HasContexts: false, CanSwitch: false},
+		func(runner execx.Runner) ToolAdapter {
+			return opencli.New(runner)
+		},
+	)
 }
 
 func toolFileConfigured(id, displayName, category, binary string, fn func() (bool, []string, []string)) ToolDefinition {

--- a/internal/tools/registry_test.go
+++ b/internal/tools/registry_test.go
@@ -37,6 +37,7 @@ func TestDefaultRegistryIncludesToolsFromToolsMD(t *testing.T) {
 		"vercel":        {category: "cloud", binary: "vercel"},
 		"railway":       {category: "cloud", binary: "railway"},
 		"netlify":       {category: "cloud", binary: "netlify"},
+		"opencli":       {category: "web", binary: "opencli"},
 	}
 
 	for id, want := range expected {


### PR DESCRIPTION
## Summary
- add opencli to the tracked all-cli registry and metadata catalog
- parse `opencli doctor` output into install/configuration diagnostics
- add adapter tests and an implementation plan document

## Test Plan
- env -u GOROOT -u GOTOOLDIR /opt/homebrew/bin/go test ./...
- just check
- env -u GOROOT -u GOTOOLDIR /opt/homebrew/bin/go run ./cmd/all-cli status --tools opencli --group-by none