### PR TITLE
feat: registry index, cloud whoami helper, status JSON schema

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,8 @@ all-cli status --timeout 10s
 
 ### AI-friendly JSON additions
 
+Machine-readable shape for `status --json` is also summarized as [JSON Schema](schemas/status-report-v0.1.json) (`schema_version` `v0.1`).
+
 `all-cli status --json` now includes additive English metadata for machine callers:
 
 - Top-level `legend`: explains shared fields such as `installed`, `configured_state`, `capabilities`, `warnings`, `errors`, and the meaning of metadata fields.

--- a/internal/cli/status.go
+++ b/internal/cli/status.go
@@ -156,14 +156,9 @@ func parseToolsFilter(s string) (map[string]bool, error) {
 		return nil, fmt.Errorf("invalid --tools value")
 	}
 
-	// Validate IDs
-	valid := map[string]bool{}
-	for _, def := range defaultRegistry() {
-		valid[def.ID] = true
-	}
 	var unknown []string
 	for id := range out {
-		if !valid[id] {
+		if _, ok := tools.FindByID(id); !ok {
 			unknown = append(unknown, id)
 		}
 	}

--- a/internal/model/status_schema_contract_test.go
+++ b/internal/model/status_schema_contract_test.go
@@ -1,0 +1,93 @@
+package model
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func moduleRoot(t *testing.T) string {
+	t.Helper()
+	dir, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	for {
+		if _, err := os.Stat(filepath.Join(dir, "go.mod")); err == nil {
+			return dir
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			t.Fatal("go.mod not found from cwd")
+		}
+		dir = parent
+	}
+}
+
+func TestStatusReportSchemaFileIsValidJSON(t *testing.T) {
+	t.Parallel()
+
+	path := filepath.Join(moduleRoot(t), "schemas", "status-report-v0.1.json")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read schema: %v", err)
+	}
+	var doc any
+	if err := json.Unmarshal(data, &doc); err != nil {
+		t.Fatalf("schema file: %v", err)
+	}
+}
+
+func TestStatusReportJSONKeyContract(t *testing.T) {
+	t.Parallel()
+
+	report := NewStatusReport(1)
+	report.GeneratedAt = time.Date(2026, 3, 20, 12, 0, 0, 0, time.UTC)
+	report.Tools[0] = ToolSummary{
+		ID:              "example",
+		DisplayName:     "Example",
+		Category:        "test",
+		Installed:       true,
+		ConfiguredState: ConfiguredNA,
+		Configured:      true,
+		Capabilities:    Capability{},
+	}
+
+	data, err := json.Marshal(report)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+
+	var top map[string]json.RawMessage
+	if err := json.Unmarshal(data, &top); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	for _, key := range []string{"schema_version", "generated_at", "legend", "tools"} {
+		if _, ok := top[key]; !ok {
+			t.Errorf("missing top-level key %q in marshaled status JSON", key)
+		}
+	}
+
+	var tools []json.RawMessage
+	if err := json.Unmarshal(top["tools"], &tools); err != nil {
+		t.Fatalf("tools array: %v", err)
+	}
+	if len(tools) != 1 {
+		t.Fatalf("tools len = %d, want 1", len(tools))
+	}
+
+	var row map[string]json.RawMessage
+	if err := json.Unmarshal(tools[0], &row); err != nil {
+		t.Fatalf("tool row: %v", err)
+	}
+	for _, key := range []string{
+		"id", "display_name", "category", "installed",
+		"configured_state", "configured", "capabilities",
+	} {
+		if _, ok := row[key]; !ok {
+			t.Errorf("missing tool key %q", key)
+		}
+	}
+}

--- a/internal/tools/evaluate.go
+++ b/internal/tools/evaluate.go
@@ -8,16 +8,6 @@ import (
 	"github.com/oldwinter/all-cli/internal/model"
 )
 
-// FindByID looks up a tool definition by its unique ID.
-func FindByID(id string) (ToolDefinition, bool) {
-	for _, def := range DefaultRegistry() {
-		if def.ID == id {
-			return def, true
-		}
-	}
-	return ToolDefinition{}, false
-}
-
 // Evaluate checks whether a tool is installed and configured, returning a ToolSummary.
 func Evaluate(ctx context.Context, def ToolDefinition, runner execx.Runner) model.ToolSummary {
 	installPath, err := execx.LookPath(def.Binary)

--- a/internal/tools/registry.go
+++ b/internal/tools/registry.go
@@ -123,8 +123,7 @@ type ToolDefinition struct {
 	Current     func(ctx context.Context, runner execx.Runner, installed bool) (map[string]string, []string, []string)
 }
 
-// DefaultRegistry returns the built-in list of tracked CLI tools.
-func DefaultRegistry() []ToolDefinition {
+func buildDefaultRegistrySlice() []ToolDefinition {
 	return []ToolDefinition{
 		toolNA("fd", "fd", "navigation", "fd"),
 		toolNA("rg", "ripgrep", "navigation", "rg"),
@@ -329,19 +328,9 @@ func wranglerTool() ToolDefinition {
 }
 
 func vercelTool() ToolDefinition {
-	var (
-		once   sync.Once
-		cached vercel.Whoami
-		cWarn  []string
-		cErrs  []string
-		cErr   error
-	)
-	get := func(ctx context.Context, runner execx.Runner) (vercel.Whoami, []string, []string, error) {
-		once.Do(func() {
-			a := vercel.New(runner)
-			cached, cWarn, cErrs, cErr = a.Whoami(ctx)
-		})
-		return cached, cWarn, cErrs, cErr
+	var cache whoamiOnce[vercel.Whoami]
+	fetch := func(ctx context.Context, runner execx.Runner) (vercel.Whoami, []string, []string, error) {
+		return vercel.New(runner).Whoami(ctx)
 	}
 
 	return ToolDefinition{
@@ -358,7 +347,7 @@ func vercelTool() ToolDefinition {
 			if !installed {
 				return model.ConfiguredUnknown, nil, nil
 			}
-			who, warnings, errs, err := get(ctx, runner)
+			who, warnings, errs, err := cache.load(ctx, runner, fetch)
 			if err != nil {
 				errs = append(errs, err.Error())
 				return model.ConfiguredUnknown, warnings, errs
@@ -383,19 +372,9 @@ func vercelTool() ToolDefinition {
 }
 
 func railwayTool() ToolDefinition {
-	var (
-		once   sync.Once
-		cached railway.Whoami
-		cWarn  []string
-		cErrs  []string
-		cErr   error
-	)
-	get := func(ctx context.Context, runner execx.Runner) (railway.Whoami, []string, []string, error) {
-		once.Do(func() {
-			a := railway.New(runner)
-			cached, cWarn, cErrs, cErr = a.Whoami(ctx)
-		})
-		return cached, cWarn, cErrs, cErr
+	var cache whoamiOnce[railway.Whoami]
+	fetch := func(ctx context.Context, runner execx.Runner) (railway.Whoami, []string, []string, error) {
+		return railway.New(runner).Whoami(ctx)
 	}
 
 	return ToolDefinition{
@@ -412,7 +391,7 @@ func railwayTool() ToolDefinition {
 			if !installed {
 				return model.ConfiguredUnknown, nil, nil
 			}
-			who, warnings, errs, err := get(ctx, runner)
+			who, warnings, errs, err := cache.load(ctx, runner, fetch)
 			if err != nil {
 				errs = append(errs, err.Error())
 				return model.ConfiguredUnknown, warnings, errs
@@ -437,19 +416,9 @@ func railwayTool() ToolDefinition {
 }
 
 func netlifyTool() ToolDefinition {
-	var (
-		once   sync.Once
-		cached netlify.CurrentUser
-		cWarn  []string
-		cErrs  []string
-		cErr   error
-	)
-	get := func(ctx context.Context, runner execx.Runner) (netlify.CurrentUser, []string, []string, error) {
-		once.Do(func() {
-			a := netlify.New(runner)
-			cached, cWarn, cErrs, cErr = a.CurrentUser(ctx)
-		})
-		return cached, cWarn, cErrs, cErr
+	var cache whoamiOnce[netlify.CurrentUser]
+	fetch := func(ctx context.Context, runner execx.Runner) (netlify.CurrentUser, []string, []string, error) {
+		return netlify.New(runner).CurrentUser(ctx)
 	}
 
 	return ToolDefinition{
@@ -466,7 +435,7 @@ func netlifyTool() ToolDefinition {
 			if !installed {
 				return model.ConfiguredUnknown, nil, nil
 			}
-			user, warnings, errs, err := get(ctx, runner)
+			user, warnings, errs, err := cache.load(ctx, runner, fetch)
 			if err != nil {
 				errs = append(errs, err.Error())
 				return model.ConfiguredUnknown, warnings, errs
@@ -502,4 +471,36 @@ func argocdTool() ToolDefinition {
 		model.Capability{HasContexts: true, CanSwitch: true},
 		func(r execx.Runner) ToolAdapter { return argocd.New(r) },
 	)
+}
+
+var (
+	defaultRegistryOnce sync.Once
+	defaultRegistryList []ToolDefinition
+	defaultRegistryByID map[string]ToolDefinition
+)
+
+func initBuiltInRegistry() {
+	defaultRegistryList = buildDefaultRegistrySlice()
+	defaultRegistryByID = make(map[string]ToolDefinition, len(defaultRegistryList))
+	for _, def := range defaultRegistryList {
+		if _, exists := defaultRegistryByID[def.ID]; exists {
+			panic("tools: duplicate registry id " + def.ID)
+		}
+		defaultRegistryByID[def.ID] = def
+	}
+}
+
+// DefaultRegistry returns a copy of the built-in list of tracked CLI tools.
+func DefaultRegistry() []ToolDefinition {
+	defaultRegistryOnce.Do(initBuiltInRegistry)
+	out := make([]ToolDefinition, len(defaultRegistryList))
+	copy(out, defaultRegistryList)
+	return out
+}
+
+// FindByID looks up a tool definition by its unique ID.
+func FindByID(id string) (ToolDefinition, bool) {
+	defaultRegistryOnce.Do(initBuiltInRegistry)
+	def, ok := defaultRegistryByID[id]
+	return def, ok
 }

--- a/internal/tools/registry_cloud.go
+++ b/internal/tools/registry_cloud.go
@@ -1,0 +1,24 @@
+package tools
+
+import (
+	"context"
+	"sync"
+
+	"github.com/oldwinter/all-cli/internal/execx"
+)
+
+// whoamiOnce runs fetch at most once per ToolDefinition closure (for ConfigCheck).
+type whoamiOnce[T any] struct {
+	once sync.Once
+	val  T
+	warn []string
+	errs []string
+	err  error
+}
+
+func (w *whoamiOnce[T]) load(ctx context.Context, r execx.Runner, fetch func(context.Context, execx.Runner) (T, []string, []string, error)) (T, []string, []string, error) {
+	w.once.Do(func() {
+		w.val, w.warn, w.errs, w.err = fetch(ctx, r)
+	})
+	return w.val, w.warn, w.errs, w.err
+}

--- a/internal/tools/registry_test.go
+++ b/internal/tools/registry_test.go
@@ -2,6 +2,20 @@ package tools
 
 import "testing"
 
+func TestRegistryToolIDsAreUnique(t *testing.T) {
+	t.Parallel()
+
+	seen := map[string]int{}
+	for _, def := range DefaultRegistry() {
+		seen[def.ID]++
+	}
+	for id, n := range seen {
+		if n != 1 {
+			t.Errorf("tool id %q appears %d times in registry", id, n)
+		}
+	}
+}
+
 func TestDefaultRegistryIncludesToolsFromToolsMD(t *testing.T) {
 	t.Parallel()
 

--- a/schemas/README.md
+++ b/schemas/README.md
@@ -1,0 +1,5 @@
+# JSON schemas
+
+- `status-report-v0.1.json` describes the object emitted by `all-cli status --json` (`internal/model.StatusReport`). The `schema_version` field matches `model.SchemaVersionV01`.
+
+When evolving the Go structs, update this file and run `go test ./internal/model/...`.

--- a/schemas/status-report-v0.1.json
+++ b/schemas/status-report-v0.1.json
@@ -1,0 +1,116 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/oldwinter/all-cli/schemas/status-report-v0.1.json",
+  "title": "all-cli status report",
+  "type": "object",
+  "required": ["schema_version", "generated_at", "tools"],
+  "properties": {
+    "schema_version": {
+      "type": "string",
+      "description": "JSON output schema version; matches model.SchemaVersionV01."
+    },
+    "generated_at": {
+      "type": "string",
+      "format": "date-time",
+      "description": "RFC 3339 timestamp when the report was built."
+    },
+    "legend": {
+      "type": "object",
+      "description": "Human- and agent-oriented explanations of status fields.",
+      "properties": {
+        "installed": { "type": "string" },
+        "configured_state": {
+          "type": "object",
+          "additionalProperties": { "type": "string" }
+        },
+        "capabilities": {
+          "type": "object",
+          "additionalProperties": { "type": "string" }
+        },
+        "current": { "type": "string" },
+        "warnings": { "type": "string" },
+        "errors": { "type": "string" },
+        "metadata_fields": {
+          "type": "object",
+          "additionalProperties": { "type": "string" }
+        }
+      },
+      "additionalProperties": true
+    },
+    "tools": {
+      "type": "array",
+      "items": { "$ref": "#/$defs/tool_summary" }
+    }
+  },
+  "additionalProperties": true,
+  "$defs": {
+    "capability": {
+      "type": "object",
+      "required": ["has_contexts", "can_switch"],
+      "properties": {
+        "has_contexts": { "type": "boolean" },
+        "can_switch": { "type": "boolean" }
+      },
+      "additionalProperties": false
+    },
+    "tool_metadata": {
+      "type": "object",
+      "properties": {
+        "purpose": { "type": "string" },
+        "configured_when": { "type": "string" },
+        "current_field_descriptions": {
+          "type": "object",
+          "additionalProperties": { "type": "string" }
+        },
+        "agent_actions": {
+          "type": "array",
+          "items": { "type": "string" }
+        },
+        "notes": {
+          "type": "array",
+          "items": { "type": "string" }
+        }
+      },
+      "additionalProperties": true
+    },
+    "tool_summary": {
+      "type": "object",
+      "required": [
+        "id",
+        "display_name",
+        "category",
+        "installed",
+        "configured_state",
+        "configured",
+        "capabilities"
+      ],
+      "properties": {
+        "id": { "type": "string" },
+        "display_name": { "type": "string" },
+        "category": { "type": "string" },
+        "installed": { "type": "boolean" },
+        "install_path": { "type": "string" },
+        "configured_state": {
+          "type": "string",
+          "enum": ["yes", "no", "n/a", "unknown"]
+        },
+        "configured": { "type": "boolean" },
+        "capabilities": { "$ref": "#/$defs/capability" },
+        "current": {
+          "type": "object",
+          "additionalProperties": { "type": "string" }
+        },
+        "metadata": { "$ref": "#/$defs/tool_metadata" },
+        "warnings": {
+          "type": "array",
+          "items": { "type": "string" }
+        },
+        "errors": {
+          "type": "array",
+          "items": { "type": "string" }
+        }
+      },
+      "additionalProperties": true
+    }
+  }
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Purpose
 follow-up on ergonomics and integrator-facing docs for `status --json`.

## Changes
- **Registry**: build default tool list once (`sync.Once`), copy on `DefaultRegistry()`, O(1) `FindByID`, panic on duplicate IDs (programmer error).
- **Cloud adapters**: `vercel` / `railway` / `netlify` share `whoamiOnce[T]` for ConfigCheck caching (`internal/tools/registry_cloud.go`).
- **CLI**: `status --tools` validation uses `FindByID` instead of scanning the full registry each time.
- **Docs / contract**: add `schemas/status-report-v0.1.json` + `schemas/README.md`, README link, and `internal/model` tests (schema file is valid JSON; marshaled report has expected top-level and per-tool keys).

## Testing
- `just ci` (tidy, vet, test)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e55080d4-38c1-4587-9dbf-56a2043e119d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e55080d4-38c1-4587-9dbf-56a2043e119d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **新功能**
  * 发布了 `all-cli status --json` 输出的 JSON Schema 文档（v0.1），定义了状态报告的结构规范。
  * 改进了工具 ID 验证机制。

* **测试**
  * 添加了 JSON Schema 有效性验证测试。
  * 添加了工具 ID 唯一性检查测试。

* **优化**
  * 优化了内部工具注册表实现，提高了查询效率。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->