### PR TITLE
test(tools): enforce explicit metadata for all registry tools

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,9 +2,13 @@ module github.com/oldwinter/all-cli
 
 go 1.26.1
 
-require github.com/spf13/cobra v1.10.2
+require (
+	github.com/santhosh-tekuri/jsonschema/v6 v6.0.1
+	github.com/spf13/cobra v1.10.2
+)
 
 require (
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/spf13/pflag v1.0.9 // indirect
+	golang.org/x/text v0.14.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -1,10 +1,16 @@
 github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
+github.com/dlclark/regexp2 v1.11.0 h1:G/nrcoOa7ZXlpoa/91N3X7mM3r8eIlMBBJZvsz/mxKI=
+github.com/dlclark/regexp2 v1.11.0/go.mod h1:DHkYz0B9wPfa6wondMfaivmHpzrQ3v9q8cnmRbL6yW8=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
+github.com/santhosh-tekuri/jsonschema/v6 v6.0.1 h1:PKK9DyHxif4LZo+uQSgXNqs0jj5+xZwwfKHgph2lxBw=
+github.com/santhosh-tekuri/jsonschema/v6 v6.0.1/go.mod h1:JXeL+ps8p7/KNMjDQk3TCwPpBy0wYklyWTfbkIzdIFU=
 github.com/spf13/cobra v1.10.2 h1:DMTTonx5m65Ic0GOoRY2c16WCbHxOOw6xxezuLaBpcU=
 github.com/spf13/cobra v1.10.2/go.mod h1:7C1pvHqHw5A4vrJfjNwvOdzYu0Gml16OCs2GRiTUUS4=
 github.com/spf13/pflag v1.0.9 h1:9exaQaMOCwffKiiiYk6/BndUBv+iRViNW+4lEMi0PvY=
 github.com/spf13/pflag v1.0.9/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
 go.yaml.in/yaml/v3 v3.0.4/go.mod h1:DhzuOOF2ATzADvBadXxruRBLzYTpT36CKvDb3+aBEFg=
+golang.org/x/text v0.14.0 h1:ScX5w1eTa3QqT8oi6+ziP7dTV1S2+ALU0bI+0zXKWiQ=
+golang.org/x/text v0.14.0/go.mod h1:18ZOQIKpY8NJVqYksKHtTdi31H5itFRjB5/qKTNYzSU=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=

--- a/internal/cli/options.go
+++ b/internal/cli/options.go
@@ -1,0 +1,20 @@
+package cli
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+func newOptionsCommand(opts *rootOptions) *cobra.Command {
+	return &cobra.Command{
+		Use:   "options",
+		Short: "Show global CLI options inherited by subcommands",
+		Long: `Prints the effective values of persistent flags (--json, --timeout) that apply
+to all-cli and its subcommands. Similar to kubectl options.`,
+		Run: func(cmd *cobra.Command, _ []string) {
+			fmt.Fprintf(cmd.OutOrStdout(), "json=%v\n", opts.JSON)
+			fmt.Fprintf(cmd.OutOrStdout(), "timeout=%s\n", opts.Timeout)
+		},
+	}
+}

--- a/internal/cli/options_test.go
+++ b/internal/cli/options_test.go
@@ -1,0 +1,28 @@
+package cli
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestOptionsCommandOutputsPersistentFlags(t *testing.T) {
+	t.Parallel()
+
+	opts := &rootOptions{JSON: true, Timeout: 7 * time.Second}
+	cmd := newOptionsCommand(opts)
+	var out strings.Builder
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	cmd.SetArgs([]string{})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("options: %v", err)
+	}
+	got := out.String()
+	if !strings.Contains(got, "json=true") {
+		t.Fatalf("expected json=true in output, got:\n%s", got)
+	}
+	if !strings.Contains(got, "timeout=7s") {
+		t.Fatalf("expected timeout=7s in output, got:\n%s", got)
+	}
+}

--- a/internal/cli/progress.go
+++ b/internal/cli/progress.go
@@ -3,7 +3,6 @@ package cli
 import (
 	"fmt"
 	"io"
-	"os"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -74,12 +73,4 @@ func (p *progressSpinner) Stop() {
 	if p.stoppedCh != nil {
 		<-p.stoppedCh
 	}
-}
-
-func isTerminal(f *os.File) bool {
-	fi, err := f.Stat()
-	if err != nil {
-		return false
-	}
-	return (fi.Mode() & os.ModeCharDevice) != 0
 }

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -73,6 +73,7 @@ respect --timeout.`,
 	cmd.AddCommand(newStatusCommand(opts, runner))
 	cmd.AddCommand(newVersionCommand())
 	cmd.AddCommand(newOptionsCommand(opts))
+	cmd.AddCommand(newSurpriseCommand())
 	cmd.AddCommand(newCompletionCommand())
 
 	cmd.AddCommand(newAWSCommand(opts, runner))
@@ -101,7 +102,7 @@ func setSubcommandGroups(root *cobra.Command) {
 			c.GroupID = "cloud"
 		case "mise", "k9s", "kubectl", "docker", "gh", "glab", "argocd", "kargo":
 			c.GroupID = "tools"
-		case "version", "options", "completion":
+		case "version", "options", "surprise", "completion":
 			c.GroupID = "other"
 		}
 	}

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -28,7 +28,36 @@ func NewRootCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "all-cli",
 		Short: "Inspect and manage common CLI tool contexts",
+		Long: `all-cli inspects locally installed CLI tools and reports configuration and
+current context in one place. Use a broad status overview or per-tool subcommands
+(for example kubectl, docker, gh) that mirror the same read-only checks you use in scripts.
+
+Machine-readable output uses --json on the root command. External tool invocations
+respect --timeout.`,
+		Example: `  # Full overview as JSON (stable schema)
+  all-cli status --json
+
+  # Limit to specific tools
+  all-cli status --tools kubectl,docker --group-by none
+
+  # Per-tool context (same runner options as root)
+  all-cli kubectl current
+  all-cli docker list`,
+		Version: VersionString(),
 	}
+
+	cmd.SetVersionTemplate("{{.Version}}\n")
+	cmd.SilenceUsage = true
+	cmd.CompletionOptions.DisableDefaultCmd = true
+	cmd.SetHelpCommandGroupID("other")
+	cmd.SetCompletionCommandGroupID("other")
+
+	cmd.AddGroup(
+		&cobra.Group{ID: "primary", Title: "Primary commands:"},
+		&cobra.Group{ID: "cloud", Title: "Cloud platforms:"},
+		&cobra.Group{ID: "tools", Title: "Tool integrations:"},
+		&cobra.Group{ID: "other", Title: "Other commands:"},
+	)
 
 	cmd.PersistentFlags().BoolVar(&opts.JSON, "json", false, "Output JSON")
 	cmd.PersistentFlags().DurationVar(&opts.Timeout, "timeout", opts.Timeout, "External command timeout (e.g. 3s)")
@@ -49,5 +78,22 @@ func NewRootCommand() *cobra.Command {
 	cmd.AddCommand(newArgoCDCommand(opts, runner))
 	cmd.AddCommand(newKargoCommand(opts, runner))
 
+	setSubcommandGroups(cmd)
+
 	return cmd
+}
+
+func setSubcommandGroups(root *cobra.Command) {
+	for _, c := range root.Commands() {
+		switch c.Name() {
+		case "status":
+			c.GroupID = "primary"
+		case "aws", "aliyun", "wrangler":
+			c.GroupID = "cloud"
+		case "mise", "k9s", "kubectl", "docker", "gh", "glab", "argocd", "kargo":
+			c.GroupID = "tools"
+		case "version", "completion":
+			c.GroupID = "other"
+		}
+	}
 }

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"fmt"
 	"time"
 
 	"github.com/oldwinter/all-cli/internal/execx"
@@ -61,6 +62,13 @@ respect --timeout.`,
 
 	cmd.PersistentFlags().BoolVar(&opts.JSON, "json", false, "Output JSON")
 	cmd.PersistentFlags().DurationVar(&opts.Timeout, "timeout", opts.Timeout, "External command timeout (e.g. 3s)")
+
+	cmd.PersistentPreRunE = func(_ *cobra.Command, _ []string) error {
+		if opts.Timeout <= 0 {
+			return fmt.Errorf("invalid --timeout: must be positive, got %s", opts.Timeout)
+		}
+		return nil
+	}
 
 	cmd.AddCommand(newStatusCommand(opts, runner))
 	cmd.AddCommand(newVersionCommand())

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -64,6 +64,7 @@ respect --timeout.`,
 
 	cmd.AddCommand(newStatusCommand(opts, runner))
 	cmd.AddCommand(newVersionCommand())
+	cmd.AddCommand(newOptionsCommand(opts))
 	cmd.AddCommand(newCompletionCommand())
 
 	cmd.AddCommand(newAWSCommand(opts, runner))
@@ -92,7 +93,7 @@ func setSubcommandGroups(root *cobra.Command) {
 			c.GroupID = "cloud"
 		case "mise", "k9s", "kubectl", "docker", "gh", "glab", "argocd", "kargo":
 			c.GroupID = "tools"
-		case "version", "completion":
+		case "version", "options", "completion":
 			c.GroupID = "other"
 		}
 	}

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -34,7 +34,13 @@ current context in one place. Use a broad status overview or per-tool subcommand
 (for example kubectl, docker, gh) that mirror the same read-only checks you use in scripts.
 
 Machine-readable output uses --json on the root command. External tool invocations
-respect --timeout.`,
+respect --timeout.
+
+Environment:
+  NO_COLOR            If set (any value), disable ANSI colors and escape sequences.
+  TERM                If "dumb", ANSI output is disabled.
+  CI                  If set, the status command skips the stderr progress spinner.
+  ALL_CLI_NO_PROGRESS If 1, true, yes, or on, disable the status spinner (any environment).`,
 		Example: `  # Full overview as JSON (stable schema)
   all-cli status --json
 

--- a/internal/cli/root_test.go
+++ b/internal/cli/root_test.go
@@ -94,4 +94,14 @@ func TestRootHelpGroupsCommands(t *testing.T) {
 	if !strings.Contains(help, "options") {
 		t.Fatalf("help should list options command, got:\n%s", help)
 	}
+	for _, needle := range []string{
+		"NO_COLOR",
+		"ALL_CLI_NO_PROGRESS",
+		"TERM",
+		"CI",
+	} {
+		if !strings.Contains(help, needle) {
+			t.Fatalf("help should mention %q, got:\n%s", needle, help)
+		}
+	}
 }

--- a/internal/cli/root_test.go
+++ b/internal/cli/root_test.go
@@ -1,0 +1,67 @@
+package cli
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestRootVersionFlagMatchesVersionSubcommand(t *testing.T) {
+	t.Parallel()
+
+	want := strings.TrimSpace(VersionString())
+
+	cmd := NewRootCommand()
+	cmd.SetArgs([]string{"--version"})
+	var out strings.Builder
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("root --version: %v", err)
+	}
+	if got := strings.TrimSpace(out.String()); got != want {
+		t.Fatalf("root --version = %q, want %q", got, want)
+	}
+
+	out.Reset()
+	cmd = NewRootCommand()
+	cmd.SetArgs([]string{"-v"})
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("root -v: %v", err)
+	}
+	if got := strings.TrimSpace(out.String()); got != want {
+		t.Fatalf("root -v = %q, want %q", got, want)
+	}
+
+	out.Reset()
+	cmd = NewRootCommand()
+	cmd.SetArgs([]string{"version"})
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("version subcommand: %v", err)
+	}
+	if got := strings.TrimSpace(out.String()); got != want {
+		t.Fatalf("version subcommand = %q, want %q", got, want)
+	}
+}
+
+func TestRootHelpGroupsCommands(t *testing.T) {
+	t.Parallel()
+
+	cmd := NewRootCommand()
+	var out strings.Builder
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	cmd.SetArgs([]string{"--help"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("help: %v", err)
+	}
+	help := out.String()
+	for _, title := range []string{"Primary commands:", "Cloud platforms:", "Tool integrations:", "Other commands:"} {
+		if !strings.Contains(help, title) {
+			t.Fatalf("help missing %q", title)
+		}
+	}
+}

--- a/internal/cli/root_test.go
+++ b/internal/cli/root_test.go
@@ -64,4 +64,7 @@ func TestRootHelpGroupsCommands(t *testing.T) {
 			t.Fatalf("help missing %q", title)
 		}
 	}
+	if !strings.Contains(help, "options") {
+		t.Fatalf("help should list options command, got:\n%s", help)
+	}
 }

--- a/internal/cli/root_test.go
+++ b/internal/cli/root_test.go
@@ -5,6 +5,33 @@ import (
 	"testing"
 )
 
+func TestRootRejectsNonPositiveTimeout(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		flag string
+	}{
+		{name: "zero", flag: "0s"},
+		{name: "negative", flag: "-1s"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			cmd := NewRootCommand()
+			cmd.SilenceUsage = true
+			cmd.SilenceErrors = true
+			cmd.SetArgs([]string{"--timeout", tt.flag, "options"})
+			err := cmd.Execute()
+			if err == nil || !strings.Contains(err.Error(), "invalid --timeout") {
+				t.Fatalf("expected invalid --timeout error, got %v", err)
+			}
+		})
+	}
+}
+
 func TestRootVersionFlagMatchesVersionSubcommand(t *testing.T) {
 	t.Parallel()
 

--- a/internal/cli/status.go
+++ b/internal/cli/status.go
@@ -2,7 +2,6 @@ package cli
 
 import (
 	"fmt"
-	"os"
 	"sort"
 	"strings"
 	"sync"
@@ -28,7 +27,7 @@ const (
 var (
 	defaultRegistry   = tools.DefaultRegistry
 	showStatusSpinner = func() bool {
-		return isTerminal(os.Stderr)
+		return statusSpinnerEnabled()
 	}
 )
 

--- a/internal/cli/status.go
+++ b/internal/cli/status.go
@@ -42,6 +42,13 @@ func newStatusCommand(opts *rootOptions, runner execx.Runner) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "status",
 		Short: "Show installed/configured status for common CLI tools",
+		Long: `Evaluates each tracked tool in the built-in registry: installation path,
+configuration state, capabilities, and optional current context snapshot.
+
+When not using --json, a progress indicator may be shown on stderr while tools are checked.`,
+		Example: `  all-cli status
+  all-cli status --tools kubectl,docker --group-by none
+  all-cli status --installed-only --quiet`,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			groupByValue, err := parseStatusGroupBy(groupBy)
 			if err != nil {

--- a/internal/cli/status_command_test.go
+++ b/internal/cli/status_command_test.go
@@ -97,6 +97,23 @@ func TestStatusCommandErrorsOnInvalidSort(t *testing.T) {
 	}
 }
 
+func TestStatusHelpIncludesDescription(t *testing.T) {
+	t.Parallel()
+
+	cmd := newStatusCommand(&rootOptions{Timeout: time.Second}, cliFakeRunner{})
+	var out strings.Builder
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	cmd.SetArgs([]string{"--help"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("help: %v", err)
+	}
+	help := out.String()
+	if !strings.Contains(help, "registry") {
+		t.Fatalf("expected status long help to mention registry, got:\n%s", help)
+	}
+}
+
 func TestStatusCommandErrorsOnUnknownToolsFilter(t *testing.T) {
 	stubShowStatusSpinner(t, false)
 	opts := &rootOptions{Timeout: time.Second}

--- a/internal/cli/surprise.go
+++ b/internal/cli/surprise.go
@@ -31,7 +31,7 @@ func newSurpriseCommand() *cobra.Command {
 }
 
 func rainbowLine(s string) string {
-	if !isTerminal(os.Stdout) {
+	if !terminalAnsiEnabled(os.Stdout) {
 		return s
 	}
 	const reset = "\033[0m"
@@ -52,7 +52,7 @@ func rainbowLine(s string) string {
 }
 
 func dimIfTTY(s string) string {
-	if !isTerminal(os.Stdout) {
+	if !terminalAnsiEnabled(os.Stdout) {
 		return s
 	}
 	return "\033[2m" + s + "\033[0m"

--- a/internal/cli/surprise.go
+++ b/internal/cli/surprise.go
@@ -1,0 +1,59 @@
+package cli
+
+import (
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/spf13/cobra"
+)
+
+func newSurpriseCommand() *cobra.Command {
+	return &cobra.Command{
+		Use:    "surprise",
+		Hidden: true,
+		Short:  "A small thank-you for curious users",
+		Run: func(cmd *cobra.Command, _ []string) {
+			out := cmd.OutOrStdout()
+			fmt.Fprintln(out, rainbowLine("    ★ all-cli ★"))
+			fmt.Fprintln(out)
+			fmt.Fprintln(out, strings.TrimSpace(`
+  You read the flags. You ran the help. You typed a word
+  that is not in the manual. That is the right energy.
+
+  May your contexts always resolve, your tokens never leak,
+  and your next deploy be boring in the best way.
+`))
+			fmt.Fprintln(out)
+			fmt.Fprintln(out, dimIfTTY("  — the maintainers · 好奇的人运气不会太差"))
+		},
+	}
+}
+
+func rainbowLine(s string) string {
+	if !isTerminal(os.Stdout) {
+		return s
+	}
+	const reset = "\033[0m"
+	attrs := []string{"\033[38;5;204m", "\033[38;5;209m", "\033[38;5;214m", "\033[38;5;220m", "\033[38;5;154m", "\033[38;5;80m", "\033[38;5;45m", "\033[38;5;63m"}
+	var b strings.Builder
+	i := 0
+	for _, r := range s {
+		if r == ' ' {
+			b.WriteRune(r)
+			continue
+		}
+		b.WriteString(attrs[i%len(attrs)])
+		b.WriteRune(r)
+		b.WriteString(reset)
+		i++
+	}
+	return b.String()
+}
+
+func dimIfTTY(s string) string {
+	if !isTerminal(os.Stdout) {
+		return s
+	}
+	return "\033[2m" + s + "\033[0m"
+}

--- a/internal/cli/surprise_test.go
+++ b/internal/cli/surprise_test.go
@@ -1,0 +1,40 @@
+package cli
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestSurpriseCommandIsHiddenFromHelp(t *testing.T) {
+	t.Parallel()
+
+	cmd := NewRootCommand()
+	var out strings.Builder
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	cmd.SetArgs([]string{"--help"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("help: %v", err)
+	}
+	if strings.Contains(out.String(), "surprise") {
+		t.Fatalf("surprise should be hidden from help")
+	}
+}
+
+func TestSurpriseCommandPrintsMessage(t *testing.T) {
+	t.Parallel()
+
+	stdout, stderr, err := executeTestCommand(t, NewRootCommand(), "surprise")
+	if err != nil {
+		t.Fatalf("surprise: %v", err)
+	}
+	if stderr != "" {
+		t.Fatalf("expected empty stderr, got %q", stderr)
+	}
+	if !strings.Contains(stdout, "all-cli") {
+		t.Fatalf("expected banner, got:\n%s", stdout)
+	}
+	if !strings.Contains(stdout, "manual") {
+		t.Fatalf("expected easter egg copy, got:\n%s", stdout)
+	}
+}

--- a/internal/cli/terminal.go
+++ b/internal/cli/terminal.go
@@ -1,0 +1,62 @@
+package cli
+
+import (
+	"os"
+	"strings"
+)
+
+// isTerminal reports whether f is an interactive character device (TTY).
+func isTerminal(f *os.File) bool {
+	fi, err := f.Stat()
+	if err != nil {
+		return false
+	}
+	return (fi.Mode() & os.ModeCharDevice) != 0
+}
+
+// ansiDisabledByEnv reports NO_COLOR / TERM=dumb (https://no-color.org/).
+func ansiDisabledByEnv() bool {
+	if os.Getenv("NO_COLOR") != "" {
+		return true
+	}
+	if strings.EqualFold(os.Getenv("TERM"), "dumb") {
+		return true
+	}
+	return false
+}
+
+// terminalAnsiEnabled is true when it is reasonable to emit ANSI styling on f.
+func terminalAnsiEnabled(f *os.File) bool {
+	if !isTerminal(f) {
+		return false
+	}
+	return !ansiDisabledByEnv()
+}
+
+func ciEnvSet() bool {
+	return strings.TrimSpace(os.Getenv("CI")) != ""
+}
+
+func allCliNoProgressEnvSet() bool {
+	switch strings.ToLower(strings.TrimSpace(os.Getenv("ALL_CLI_NO_PROGRESS"))) {
+	case "1", "true", "yes", "on":
+		return true
+	default:
+		return false
+	}
+}
+
+// statusSpinnerEnabled controls the status command progress line on stderr.
+// Disabled when not a TTY, when ANSI is opted out, in CI, or when ALL_CLI_NO_PROGRESS is set.
+func statusSpinnerEnabled() bool {
+	if !terminalAnsiEnabled(os.Stderr) {
+		return false
+	}
+	if ciEnvSet() {
+		return false
+	}
+	if allCliNoProgressEnvSet() {
+		return false
+	}
+	return true
+}

--- a/internal/cli/terminal_test.go
+++ b/internal/cli/terminal_test.go
@@ -1,0 +1,95 @@
+package cli
+
+import (
+	"os"
+	"testing"
+)
+
+func TestAnsiDisabledByEnv(t *testing.T) {
+	t.Parallel()
+
+	oldNO, oldTERM := os.Getenv("NO_COLOR"), os.Getenv("TERM")
+	t.Cleanup(func() {
+		restoreEnv(t, "NO_COLOR", oldNO)
+		restoreEnv(t, "TERM", oldTERM)
+	})
+
+	if err := os.Unsetenv("NO_COLOR"); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Unsetenv("TERM"); err != nil {
+		t.Fatal(err)
+	}
+	if ansiDisabledByEnv() {
+		t.Fatal("expected ansi not disabled with empty env")
+	}
+
+	if err := os.Setenv("NO_COLOR", "1"); err != nil {
+		t.Fatal(err)
+	}
+	if !ansiDisabledByEnv() {
+		t.Fatal("expected NO_COLOR to disable ansi")
+	}
+	if err := os.Unsetenv("NO_COLOR"); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := os.Setenv("TERM", "dumb"); err != nil {
+		t.Fatal(err)
+	}
+	if !ansiDisabledByEnv() {
+		t.Fatal("expected TERM=dumb to disable ansi")
+	}
+}
+
+func TestStatusSpinnerEnvHelpers(t *testing.T) {
+	t.Parallel()
+
+	oldCI := os.Getenv("CI")
+	oldProg := os.Getenv("ALL_CLI_NO_PROGRESS")
+	t.Cleanup(func() {
+		restoreEnv(t, "CI", oldCI)
+		restoreEnv(t, "ALL_CLI_NO_PROGRESS", oldProg)
+	})
+
+	if err := os.Unsetenv("CI"); err != nil {
+		t.Fatal(err)
+	}
+	if ciEnvSet() {
+		t.Fatal("expected CI unset to be false")
+	}
+	if err := os.Setenv("CI", "true"); err != nil {
+		t.Fatal(err)
+	}
+	if !ciEnvSet() {
+		t.Fatal("expected CI set")
+	}
+
+	if err := os.Unsetenv("ALL_CLI_NO_PROGRESS"); err != nil {
+		t.Fatal(err)
+	}
+	if allCliNoProgressEnvSet() {
+		t.Fatal("expected ALL_CLI_NO_PROGRESS unset")
+	}
+	for _, v := range []string{"1", "true", "yes", "on", "TRUE"} {
+		if err := os.Setenv("ALL_CLI_NO_PROGRESS", v); err != nil {
+			t.Fatal(err)
+		}
+		if !allCliNoProgressEnvSet() {
+			t.Fatalf("expected ALL_CLI_NO_PROGRESS=%q to be set", v)
+		}
+	}
+}
+
+func restoreEnv(t *testing.T, key, value string) {
+	t.Helper()
+	if value == "" {
+		if err := os.Unsetenv(key); err != nil {
+			t.Fatal(err)
+		}
+		return
+	}
+	if err := os.Setenv(key, value); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/internal/cli/version.go
+++ b/internal/cli/version.go
@@ -11,12 +11,7 @@ func newVersionCommand() *cobra.Command {
 		Use:   "version",
 		Short: "Print version information",
 		Run: func(cmd *cobra.Command, _ []string) {
-			v := version
-			if commit != "" || date != "" {
-				fmt.Fprintf(cmd.OutOrStdout(), "%s (commit=%s date=%s)\n", v, commit, date)
-				return
-			}
-			fmt.Fprintln(cmd.OutOrStdout(), v)
+			fmt.Fprintln(cmd.OutOrStdout(), VersionString())
 		},
 	}
 }

--- a/internal/cli/version_info.go
+++ b/internal/cli/version_info.go
@@ -1,0 +1,11 @@
+package cli
+
+import "fmt"
+
+// VersionString returns the full version line for CLI output (e.g. all-cli --version, version subcommand).
+func VersionString() string {
+	if commit != "" || date != "" {
+		return fmt.Sprintf("%s (commit=%s date=%s)", version, commit, date)
+	}
+	return version
+}

--- a/internal/cli/version_test.go
+++ b/internal/cli/version_test.go
@@ -6,6 +6,20 @@ import (
 	"testing"
 )
 
+func TestVersionStringDev(t *testing.T) {
+	oldVersion, oldCommit, oldDate := version, commit, date
+	version = "dev"
+	commit = ""
+	date = ""
+	defer func() {
+		version, commit, date = oldVersion, oldCommit, oldDate
+	}()
+
+	if got := VersionString(); got != "dev" {
+		t.Fatalf("VersionString = %q, want dev", got)
+	}
+}
+
 func TestVersionCommandDevOutput(t *testing.T) {
 	buf := &bytes.Buffer{}
 	cmd := newVersionCommand()

--- a/internal/model/status_schema_contract_test.go
+++ b/internal/model/status_schema_contract_test.go
@@ -6,6 +6,8 @@ import (
 	"path/filepath"
 	"testing"
 	"time"
+
+	jsonschema "github.com/santhosh-tekuri/jsonschema/v6"
 )
 
 func moduleRoot(t *testing.T) string {
@@ -89,5 +91,71 @@ func TestStatusReportJSONKeyContract(t *testing.T) {
 		if _, ok := row[key]; !ok {
 			t.Errorf("missing tool key %q", key)
 		}
+	}
+}
+
+const statusReportSchemaURL = "https://github.com/oldwinter/all-cli/schemas/status-report-v0.1.json"
+
+func TestStatusReportMarshalsAgainstStatusSchema(t *testing.T) {
+	t.Parallel()
+
+	path := filepath.Join(moduleRoot(t), "schemas", "status-report-v0.1.json")
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read schema: %v", err)
+	}
+	var schemaDoc any
+	if err := json.Unmarshal(raw, &schemaDoc); err != nil {
+		t.Fatalf("parse schema: %v", err)
+	}
+
+	c := jsonschema.NewCompiler()
+	if err := c.AddResource(statusReportSchemaURL, schemaDoc); err != nil {
+		t.Fatalf("add schema resource: %v", err)
+	}
+	sch, err := c.Compile(statusReportSchemaURL)
+	if err != nil {
+		t.Fatalf("compile schema: %v", err)
+	}
+
+	report := NewStatusReport(1)
+	report.GeneratedAt = time.Date(2026, 3, 20, 12, 0, 0, 0, time.UTC)
+	report.Tools[0] = ToolSummary{
+		ID:              "example",
+		DisplayName:     "Example",
+		Category:        "test",
+		Installed:       true,
+		InstallPath:     "/usr/bin/example",
+		ConfiguredState: ConfiguredYes,
+		Configured:      true,
+		Capabilities: Capability{
+			HasContexts: true,
+			CanSwitch:   false,
+		},
+		Current: map[string]string{"context": "dev"},
+		Metadata: ToolMetadata{
+			Purpose:        "Exercise every metadata field for schema validation.",
+			ConfiguredWhen: "A synthetic positive case for contract testing.",
+			CurrentFieldDescriptions: map[string]string{
+				"context": "Synthetic current field for schema validation.",
+			},
+			AgentActions: []string{"inspect_status"},
+			Notes:        []string{"Synthetic note for schema validation."},
+		},
+		Warnings: []string{"synthetic warning"},
+		Errors:   []string{"synthetic error"},
+	}
+
+	payload, err := json.Marshal(report)
+	if err != nil {
+		t.Fatalf("marshal report: %v", err)
+	}
+	var instance any
+	if err := json.Unmarshal(payload, &instance); err != nil {
+		t.Fatalf("unmarshal instance: %v", err)
+	}
+
+	if err := sch.Validate(instance); err != nil {
+		t.Fatalf("instance does not validate against %s: %v", statusReportSchemaURL, err)
 	}
 }

--- a/internal/tools/metadata.go
+++ b/internal/tools/metadata.go
@@ -241,11 +241,15 @@ func MetadataForTool(id string) model.ToolMetadata {
 			[]string{"inspect_status", "show_current"},
 		)
 	default:
-		return model.ToolMetadata{
-			Purpose:        "Command-line tool tracked by all-cli.",
-			ConfiguredWhen: "Configuration semantics are tool-specific and may not be available in this build.",
-			AgentActions:   []string{"inspect_status"},
-		}
+		return defaultToolMetadata()
+	}
+}
+
+func defaultToolMetadata() model.ToolMetadata {
+	return model.ToolMetadata{
+		Purpose:        "Command-line tool tracked by all-cli.",
+		ConfiguredWhen: "Configuration semantics are tool-specific and may not be available in this build.",
+		AgentActions:   []string{"inspect_status"},
 	}
 }
 

--- a/internal/tools/metadata_test.go
+++ b/internal/tools/metadata_test.go
@@ -2,6 +2,7 @@ package tools
 
 import (
 	"context"
+	"reflect"
 	"testing"
 
 	"github.com/oldwinter/all-cli/internal/execx"
@@ -88,6 +89,18 @@ func TestMetadataForOpenCLI(t *testing.T) {
 	}
 	if len(meta.AgentActions) == 0 {
 		t.Fatalf("expected agent actions for opencli")
+	}
+}
+
+func TestMetadataRegistryCoversAllTools(t *testing.T) {
+	t.Parallel()
+
+	fallback := defaultToolMetadata()
+	for _, def := range DefaultRegistry() {
+		meta := MetadataForTool(def.ID)
+		if reflect.DeepEqual(meta, fallback) {
+			t.Fatalf("registry tool %q still uses generic metadata; add an explicit case in MetadataForTool", def.ID)
+		}
 	}
 }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Purpose

Prevent new tools added to `DefaultRegistry()` from silently using the generic `MetadataForTool` fallback, so `status --json` always carries intentional AI-oriented metadata for every tracked tool.

Also validate that a representative marshaled `StatusReport` conforms to the bundled JSON Schema (`schemas/status-report-v0.1.json`), so drift between Go structs and the published schema is caught in CI.

Improve root CLI ergonomics toward kubectl-style UX: grouped `all-cli --help`, Long/Examples, unified `--version` / `-v` / `version`, and `SilenceUsage` on the root so failed runs are not cluttered with full usage.

Add `all-cli options` (like `kubectl options`) to print effective `--json` and `--timeout`, and expand `status` help with Long/Example text.

Reject non-positive `--timeout` at the root before subcommands run (avoids accidental instant timeouts).

Hidden `all-cli surprise` subcommand: a small easter egg for curious users (not listed in `--help`; rainbow banner when stdout is a TTY and ANSI is allowed).

Terminal polish: respect `NO_COLOR` and `TERM=dumb` for ANSI (surprise + status spinner); disable the `status` stderr spinner when `CI` is set or `ALL_CLI_NO_PROGRESS` is `1|true|yes|on`. Root `--help` Long documents these environment variables.

## Changes

- Extract `defaultToolMetadata()` for the fallback case in `MetadataForTool`.
- Add `TestMetadataRegistryCoversAllTools`, which fails if any registry ID still resolves to the generic metadata.
- Add `github.com/santhosh-tekuri/jsonschema/v6` and `TestStatusReportMarshalsAgainstStatusSchema`.
- Root command: Cobra command groups (primary / cloud / tools / other), Long + Examples, `Version` + `SetVersionTemplate`, `VersionString` helper, `DisableDefaultCmd` for duplicate completion, tests.
- `options` subcommand and tests; `status` Long + Example; help tests.
- Root `PersistentPreRunE`: `--timeout` must be positive; `TestRootRejectsNonPositiveTimeout`.
- Hidden `surprise` subcommand + tests.
- `internal/cli/terminal.go`: `NO_COLOR` / `TERM=dumb`, `CI` / `ALL_CLI_NO_PROGRESS` for status spinner; tests.
- Root Long: Environment section for `NO_COLOR`, `TERM`, `CI`, `ALL_CLI_NO_PROGRESS`; help test keywords.

## Testing

- `just check`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-239987ca-28f9-44e0-a6c1-cf3e1f58a49c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-239987ca-28f9-44e0-a6c1-cf3e1f58a49c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

