### PR TITLE
feat: add agent diagnostics workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,39 @@ all-cli status --sort category-desc
 all-cli status --timeout 10s
 ```
 
+### Agent diagnostics
+
+`all-cli diagnose` turns the same status facts into agent-readable diagnostic items with severity, evidence, suggested actions, autofix safety, and related tool IDs.
+
+```bash
+all-cli diagnose
+all-cli diagnose --json
+all-cli diagnose --tools kubectl,docker,gh --json
+all-cli diagnose --profile ci --json
+```
+
+`all-cli doctor` is the read-only health-check entrypoint for humans or automation. It returns the same diagnostic report shape as `diagnose`.
+
+```bash
+all-cli doctor
+all-cli doctor --tools kubectl,docker,gh --json
+```
+
+`all-cli fix` is dry-run only in this release. It builds a fix plan from diagnostics and explicitly reports which items are blocked because automatic mutation is not allowlisted.
+
+```bash
+all-cli fix --dry-run
+all-cli fix --dry-run --tools aws,gh --json
+```
+
+Snapshots can be saved and compared later:
+
+```bash
+all-cli snapshot --json > before.json
+all-cli snapshot --json > after.json
+all-cli diff before.json after.json --json
+```
+
 ### AI-friendly JSON additions
 
 Machine-readable shape for `status --json` is also summarized as [JSON Schema](schemas/status-report-v0.1.json) (`schema_version` `v0.1`).
@@ -116,6 +149,13 @@ Machine-readable shape for `status --json` is also summarized as [JSON Schema](s
 
 - Top-level `legend`: explains shared fields such as `installed`, `configured_state`, `capabilities`, `warnings`, `errors`, and the meaning of metadata fields.
 - Per-tool `metadata`: explains `purpose`, `configured_when`, known keys inside `current`, suggested `agent_actions`, and short interpretation notes.
+- Optional top-level `diagnostics`: structured diagnostic items derived from the tool summaries.
+
+`all-cli diagnose --json` and `all-cli doctor --json` emit [diagnostic-report-v0.1](schemas/diagnostic-report-v0.1.json), which includes:
+
+- `summary`: counts by `info`, `warning`, and `error`.
+- `tools`: the source status summaries used for diagnosis.
+- `diagnostics`: `severity`, `problem`, `evidence`, `suggested_actions`, `safe_to_autofix`, and `related_tool`.
 
 Example shape:
 

--- a/internal/cli/agent_commands.go
+++ b/internal/cli/agent_commands.go
@@ -1,0 +1,271 @@
+package cli
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"sort"
+	"strings"
+
+	diag "github.com/oldwinter/all-cli/internal/diagnose"
+	"github.com/oldwinter/all-cli/internal/execx"
+	"github.com/oldwinter/all-cli/internal/model"
+	"github.com/oldwinter/all-cli/internal/output"
+	"github.com/spf13/cobra"
+)
+
+func newDiagnoseCommand(opts *rootOptions, runner execx.Runner) *cobra.Command {
+	var toolsFilter string
+	var profile string
+
+	cmd := &cobra.Command{
+		Use:   "diagnose",
+		Short: "Generate agent-readable diagnostics from CLI status",
+		Long: `Generates structured diagnostics from the same tool evaluation used by status.
+Diagnostics include severity, evidence, suggested actions, autofix safety, and related tool IDs.`,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			report, err := buildDiagnosticReport(cmd, opts, runner, toolsFilter, profile)
+			if err != nil {
+				return err
+			}
+			if opts.JSON {
+				return output.PrintJSON(cmd.OutOrStdout(), report)
+			}
+			printDiagnosticReport(cmd.OutOrStdout(), report)
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVar(&toolsFilter, "tools", "", "Comma-separated tool IDs to diagnose (e.g. kubectl,docker)")
+	cmd.Flags().StringVar(&profile, "profile", diag.ProfileAgent, "Output profile: agent|human|ci")
+	return cmd
+}
+
+func newDoctorCommand(opts *rootOptions, runner execx.Runner) *cobra.Command {
+	var toolsFilter string
+	var profile string
+
+	cmd := &cobra.Command{
+		Use:   "doctor",
+		Short: "Run read-only health checks for local CLI tools",
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			report, err := buildDiagnosticReport(cmd, opts, runner, toolsFilter, profile)
+			if err != nil {
+				return err
+			}
+			if opts.JSON {
+				return output.PrintJSON(cmd.OutOrStdout(), report)
+			}
+			printDoctorReport(cmd.OutOrStdout(), report)
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVar(&toolsFilter, "tools", "", "Comma-separated tool IDs to check (e.g. kubectl,docker)")
+	cmd.Flags().StringVar(&profile, "profile", diag.ProfileHuman, "Output profile: agent|human|ci")
+	return cmd
+}
+
+func newFixCommand(opts *rootOptions, runner execx.Runner) *cobra.Command {
+	var dryRun bool
+	var toolsFilter string
+	var profile string
+
+	cmd := &cobra.Command{
+		Use:   "fix",
+		Short: "Preview safe diagnostic fixes",
+		Long: `Builds a fix plan from diagnostics. The first implementation is dry-run only:
+it does not run commands or mutate global CLI configuration.`,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			if !dryRun {
+				return fmt.Errorf("fix currently requires --dry-run")
+			}
+			report, err := buildDiagnosticReport(cmd, opts, runner, toolsFilter, profile)
+			if err != nil {
+				return err
+			}
+			plan := diag.BuildFixPlan(report, diag.FixOptions{DryRun: true})
+			if opts.JSON {
+				return output.PrintJSON(cmd.OutOrStdout(), plan)
+			}
+			printFixPlan(cmd.OutOrStdout(), plan)
+			return nil
+		},
+	}
+
+	cmd.Flags().BoolVar(&dryRun, "dry-run", false, "Preview fixes without running commands or changing configuration")
+	cmd.Flags().StringVar(&toolsFilter, "tools", "", "Comma-separated tool IDs to plan fixes for")
+	cmd.Flags().StringVar(&profile, "profile", diag.ProfileAgent, "Output profile: agent|human|ci")
+	return cmd
+}
+
+func newSnapshotCommand(opts *rootOptions, runner execx.Runner) *cobra.Command {
+	var toolsFilter string
+
+	cmd := &cobra.Command{
+		Use:   "snapshot",
+		Short: "Capture a status snapshot for later diffing",
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			report, err := buildStatusReport(cmd.Context(), runner, opts.Timeout, toolsFilter)
+			if err != nil {
+				return err
+			}
+			if opts.JSON {
+				return output.PrintJSON(cmd.OutOrStdout(), report)
+			}
+			output.PrintStatusTable(cmd.OutOrStdout(), report)
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVar(&toolsFilter, "tools", "", "Comma-separated tool IDs to snapshot")
+	return cmd
+}
+
+func newDiffCommand(opts *rootOptions) *cobra.Command {
+	return &cobra.Command{
+		Use:   "diff <snapshot-a> <snapshot-b>",
+		Short: "Diff two status snapshots",
+		Args:  cobra.ExactArgs(2),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			before, err := readStatusSnapshot(args[0])
+			if err != nil {
+				return err
+			}
+			after, err := readStatusSnapshot(args[1])
+			if err != nil {
+				return err
+			}
+			report := diag.DiffSnapshots(before, after)
+			if opts.JSON {
+				return output.PrintJSON(cmd.OutOrStdout(), report)
+			}
+			printSnapshotDiff(cmd.OutOrStdout(), report)
+			return nil
+		},
+	}
+}
+
+func buildDiagnosticReport(cmd *cobra.Command, opts *rootOptions, runner execx.Runner, toolsFilter, profile string) (model.DiagnosticReport, error) {
+	if err := validateAgentProfile(profile); err != nil {
+		return model.DiagnosticReport{}, err
+	}
+	statusReport, err := buildStatusReport(cmd.Context(), runner, opts.Timeout, toolsFilter)
+	if err != nil {
+		return model.DiagnosticReport{}, err
+	}
+	return diag.Generate(statusReport, diag.Options{Profile: profile}), nil
+}
+
+func validateAgentProfile(profile string) error {
+	switch strings.ToLower(strings.TrimSpace(profile)) {
+	case "", diag.ProfileAgent, diag.ProfileHuman, diag.ProfileCI:
+		return nil
+	default:
+		return fmt.Errorf("invalid --profile value %q (allowed: agent, human, ci)", profile)
+	}
+}
+
+func printDiagnosticReport(w interface {
+	Write([]byte) (int, error)
+}, report model.DiagnosticReport) {
+	fmt.Fprintf(w, "Diagnostics: total=%d info=%d warning=%d error=%d profile=%s\n",
+		report.Summary.Total,
+		report.Summary.Info,
+		report.Summary.Warning,
+		report.Summary.Error,
+		report.Profile,
+	)
+	if len(report.Diagnostics) == 0 {
+		fmt.Fprintln(w, "No diagnostics found.")
+		return
+	}
+	for _, item := range report.Diagnostics {
+		fmt.Fprintf(w, "\n[%s] %s: %s\n", item.Severity, item.RelatedTool, item.Problem)
+		for _, evidence := range item.Evidence {
+			fmt.Fprintf(w, "  evidence: %s\n", evidence)
+		}
+		for _, action := range item.SuggestedActions {
+			fmt.Fprintf(w, "  action: %s", action.ID)
+			if strings.TrimSpace(action.Title) != "" {
+				fmt.Fprintf(w, " - %s", action.Title)
+			}
+			if len(action.Command) > 0 {
+				fmt.Fprintf(w, " (%s)", strings.Join(action.Command, " "))
+			}
+			fmt.Fprintln(w)
+		}
+		fmt.Fprintf(w, "  safe_to_autofix: %t\n", item.SafeToAutofix)
+	}
+}
+
+func printDoctorReport(w interface {
+	Write([]byte) (int, error)
+}, report model.DiagnosticReport) {
+	fmt.Fprintln(w, "Doctor")
+	printDiagnosticReport(w, report)
+}
+
+func printFixPlan(w interface {
+	Write([]byte) (int, error)
+}, plan model.FixPlan) {
+	fmt.Fprintf(w, "Fix plan: dry_run=%t total=%d supported=%d blocked=%d\n",
+		plan.DryRun,
+		plan.Summary.Total,
+		plan.Summary.Supported,
+		plan.Summary.Blocked,
+	)
+	if len(plan.Items) == 0 {
+		fmt.Fprintln(w, "No fixes planned.")
+		return
+	}
+	for _, item := range plan.Items {
+		fmt.Fprintf(w, "- %s %s supported=%t will_run=%t reason=%s\n",
+			item.RelatedTool,
+			item.Action.ID,
+			item.Supported,
+			item.WillRun,
+			item.Reason,
+		)
+	}
+}
+
+func readStatusSnapshot(path string) (model.StatusReport, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return model.StatusReport{}, fmt.Errorf("read snapshot %s: %w", path, err)
+	}
+	var report model.StatusReport
+	if err := json.Unmarshal(data, &report); err != nil {
+		return model.StatusReport{}, fmt.Errorf("parse snapshot %s: %w", path, err)
+	}
+	if strings.TrimSpace(report.SchemaVersion) == "" {
+		return model.StatusReport{}, fmt.Errorf("parse snapshot %s: missing schema_version", path)
+	}
+	return report, nil
+}
+
+func printSnapshotDiff(w interface {
+	Write([]byte) (int, error)
+}, report model.SnapshotDiffReport) {
+	fmt.Fprintf(w, "Snapshot diff: added=%d removed=%d changed=%d\n",
+		report.Summary.Added,
+		report.Summary.Removed,
+		report.Summary.Changed,
+	)
+	if len(report.Changes) == 0 {
+		fmt.Fprintln(w, "No changes.")
+		return
+	}
+	changes := append([]model.SnapshotToolChange(nil), report.Changes...)
+	sort.SliceStable(changes, func(i, j int) bool {
+		return changes[i].ToolID < changes[j].ToolID
+	})
+	for _, change := range changes {
+		fields := ""
+		if len(change.Fields) > 0 {
+			fields = " fields=" + strings.Join(change.Fields, ",")
+		}
+		fmt.Fprintf(w, "- %s %s%s\n", change.ToolID, change.ChangeType, fields)
+	}
+}

--- a/internal/cli/agent_commands_test.go
+++ b/internal/cli/agent_commands_test.go
@@ -1,0 +1,203 @@
+package cli
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/oldwinter/all-cli/internal/execx"
+	"github.com/oldwinter/all-cli/internal/model"
+	"github.com/oldwinter/all-cli/internal/tools"
+)
+
+func stubAgentStatusEvaluation(t *testing.T) {
+	t.Helper()
+
+	stubStatusRegistry(t, []tools.ToolDefinition{
+		{ID: "aws", DisplayName: "AWS CLI", Category: "cloud", Binary: "aws"},
+		{ID: "kubectl", DisplayName: "kubectl", Category: "k8s", Binary: "kubectl"},
+	})
+
+	oldEvaluate := evaluateToolSummary
+	evaluateToolSummary = func(_ context.Context, def tools.ToolDefinition, _ execx.Runner) model.ToolSummary {
+		switch def.ID {
+		case "aws":
+			return model.ToolSummary{
+				ID:              "aws",
+				DisplayName:     "AWS CLI",
+				Category:        "cloud",
+				Installed:       true,
+				ConfiguredState: model.ConfiguredUnknown,
+				Errors:          []string{"context deadline exceeded"},
+			}
+		case "kubectl":
+			return model.ToolSummary{
+				ID:              "kubectl",
+				DisplayName:     "kubectl",
+				Category:        "k8s",
+				Installed:       true,
+				ConfiguredState: model.ConfiguredYes,
+				Configured:      true,
+				Current:         map[string]string{"context": "orbstack"},
+			}
+		default:
+			t.Fatalf("unexpected tool %s", def.ID)
+			return model.ToolSummary{}
+		}
+	}
+	t.Cleanup(func() {
+		evaluateToolSummary = oldEvaluate
+	})
+	stubShowStatusSpinner(t, false)
+}
+
+func TestDiagnoseCommandJSONUsesToolsFilter(t *testing.T) {
+	stubAgentStatusEvaluation(t)
+
+	opts := &rootOptions{JSON: true, Timeout: time.Second}
+	stdout, stderr, err := executeTestCommand(t, newDiagnoseCommand(opts, cliFakeRunner{}), "--tools", "aws", "--profile", "agent")
+	if err != nil {
+		t.Fatalf("diagnose: %v", err)
+	}
+	if stderr != "" {
+		t.Fatalf("stderr = %q, want empty", stderr)
+	}
+
+	var got model.DiagnosticReport
+	if err := json.Unmarshal([]byte(stdout), &got); err != nil {
+		t.Fatalf("decode diagnose json: %v", err)
+	}
+	if got.SchemaVersion != model.DiagnosticSchemaVersionV01 || got.Profile != "agent" {
+		t.Fatalf("unexpected report header: %#v", got)
+	}
+	if len(got.Tools) != 1 || got.Tools[0].ID != "aws" {
+		t.Fatalf("expected only aws tool, got %#v", got.Tools)
+	}
+	if got.Summary.Error != 1 || len(got.Diagnostics) != 1 {
+		t.Fatalf("expected one error diagnostic, got %#v", got)
+	}
+}
+
+func TestDiagnoseCommandPlainPrintsDiagnosticEvidence(t *testing.T) {
+	stubAgentStatusEvaluation(t)
+
+	opts := &rootOptions{Timeout: time.Second}
+	stdout, _, err := executeTestCommand(t, newDiagnoseCommand(opts, cliFakeRunner{}), "--tools", "aws")
+	if err != nil {
+		t.Fatalf("diagnose: %v", err)
+	}
+	for _, needle := range []string{"Diagnostics", "aws", "context deadline exceeded", "rerun_with_timeout"} {
+		if !strings.Contains(stdout, needle) {
+			t.Fatalf("stdout missing %q:\n%s", needle, stdout)
+		}
+	}
+}
+
+func TestDoctorCommandJSONUsesDiagnosticReport(t *testing.T) {
+	stubAgentStatusEvaluation(t)
+
+	opts := &rootOptions{JSON: true, Timeout: time.Second}
+	stdout, _, err := executeTestCommand(t, newDoctorCommand(opts, cliFakeRunner{}), "--tools", "aws")
+	if err != nil {
+		t.Fatalf("doctor: %v", err)
+	}
+	var got model.DiagnosticReport
+	if err := json.Unmarshal([]byte(stdout), &got); err != nil {
+		t.Fatalf("decode doctor json: %v", err)
+	}
+	if got.Summary.Error != 1 {
+		t.Fatalf("expected doctor to return diagnostic report, got %#v", got)
+	}
+}
+
+func TestFixCommandRequiresDryRun(t *testing.T) {
+	stubAgentStatusEvaluation(t)
+
+	opts := &rootOptions{Timeout: time.Second}
+	_, _, err := executeTestCommand(t, newFixCommand(opts, cliFakeRunner{}), "--tools", "aws")
+	if err == nil || !strings.Contains(err.Error(), "--dry-run") {
+		t.Fatalf("expected --dry-run error, got %v", err)
+	}
+}
+
+func TestFixCommandDryRunJSONReturnsBlockedPlan(t *testing.T) {
+	stubAgentStatusEvaluation(t)
+
+	opts := &rootOptions{JSON: true, Timeout: time.Second}
+	stdout, _, err := executeTestCommand(t, newFixCommand(opts, cliFakeRunner{}), "--dry-run", "--tools", "aws")
+	if err != nil {
+		t.Fatalf("fix --dry-run: %v", err)
+	}
+	var got model.FixPlan
+	if err := json.Unmarshal([]byte(stdout), &got); err != nil {
+		t.Fatalf("decode fix plan: %v", err)
+	}
+	if !got.DryRun || got.Summary.Blocked != 1 || got.Summary.Supported != 0 {
+		t.Fatalf("unexpected fix plan: %#v", got)
+	}
+	if len(got.Items) != 1 || got.Items[0].WillRun || got.Items[0].Mutates {
+		t.Fatalf("expected non-mutating blocked item, got %#v", got.Items)
+	}
+}
+
+func TestSnapshotCommandJSONReturnsStatusReport(t *testing.T) {
+	stubAgentStatusEvaluation(t)
+
+	opts := &rootOptions{JSON: true, Timeout: time.Second}
+	stdout, _, err := executeTestCommand(t, newSnapshotCommand(opts, cliFakeRunner{}), "--tools", "kubectl")
+	if err != nil {
+		t.Fatalf("snapshot: %v", err)
+	}
+	var got model.StatusReport
+	if err := json.Unmarshal([]byte(stdout), &got); err != nil {
+		t.Fatalf("decode snapshot: %v", err)
+	}
+	if got.SchemaVersion != model.SchemaVersionV01 || len(got.Tools) != 1 || got.Tools[0].ID != "kubectl" {
+		t.Fatalf("unexpected snapshot: %#v", got)
+	}
+}
+
+func TestDiffCommandJSONReportsChangedTools(t *testing.T) {
+	dir := t.TempDir()
+	before := model.NewStatusReport(1)
+	before.Tools[0] = model.ToolSummary{ID: "aws", DisplayName: "AWS CLI", Category: "cloud", Installed: false, ConfiguredState: model.ConfiguredUnknown}
+	after := model.NewStatusReport(1)
+	after.Tools[0] = model.ToolSummary{ID: "aws", DisplayName: "AWS CLI", Category: "cloud", Installed: true, ConfiguredState: model.ConfiguredYes}
+
+	beforePath := writeStatusReportFixture(t, dir, "before.json", before)
+	afterPath := writeStatusReportFixture(t, dir, "after.json", after)
+
+	opts := &rootOptions{JSON: true, Timeout: time.Second}
+	stdout, _, err := executeTestCommand(t, newDiffCommand(opts), beforePath, afterPath)
+	if err != nil {
+		t.Fatalf("diff: %v", err)
+	}
+
+	var got model.SnapshotDiffReport
+	if err := json.Unmarshal([]byte(stdout), &got); err != nil {
+		t.Fatalf("decode diff: %v", err)
+	}
+	if got.SchemaVersion != model.SnapshotDiffSchemaVersionV01 || got.Summary.Changed != 1 {
+		t.Fatalf("unexpected diff summary: %#v", got)
+	}
+	if len(got.Changes) != 1 || got.Changes[0].ToolID != "aws" || got.Changes[0].ChangeType != model.SnapshotChangeChanged {
+		t.Fatalf("unexpected diff changes: %#v", got.Changes)
+	}
+}
+
+func writeStatusReportFixture(t *testing.T, dir, name string, report model.StatusReport) string {
+	t.Helper()
+	path := filepath.Join(dir, name)
+	data, err := json.Marshal(report)
+	if err != nil {
+		t.Fatalf("marshal fixture: %v", err)
+	}
+	if err := os.WriteFile(path, data, 0o600); err != nil {
+		t.Fatalf("write fixture: %v", err)
+	}
+	return path
+}

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -77,6 +77,11 @@ Environment:
 	}
 
 	cmd.AddCommand(newStatusCommand(opts, runner))
+	cmd.AddCommand(newDiagnoseCommand(opts, runner))
+	cmd.AddCommand(newDoctorCommand(opts, runner))
+	cmd.AddCommand(newFixCommand(opts, runner))
+	cmd.AddCommand(newSnapshotCommand(opts, runner))
+	cmd.AddCommand(newDiffCommand(opts))
 	cmd.AddCommand(newVersionCommand())
 	cmd.AddCommand(newOptionsCommand(opts))
 	cmd.AddCommand(newSurpriseCommand())
@@ -102,7 +107,7 @@ Environment:
 func setSubcommandGroups(root *cobra.Command) {
 	for _, c := range root.Commands() {
 		switch c.Name() {
-		case "status":
+		case "status", "diagnose", "doctor", "fix", "snapshot", "diff":
 			c.GroupID = "primary"
 		case "aws", "aliyun", "wrangler":
 			c.GroupID = "cloud"

--- a/internal/cli/status.go
+++ b/internal/cli/status.go
@@ -1,12 +1,14 @@
 package cli
 
 import (
+	"context"
 	"fmt"
 	"sort"
 	"strings"
 	"sync"
 	"time"
 
+	diag "github.com/oldwinter/all-cli/internal/diagnose"
 	"github.com/oldwinter/all-cli/internal/execx"
 	"github.com/oldwinter/all-cli/internal/model"
 	"github.com/oldwinter/all-cli/internal/output"
@@ -58,23 +60,10 @@ When not using --json, a progress indicator may be shown on stderr while tools a
 				return err
 			}
 
-			reg := defaultRegistry()
-			if strings.TrimSpace(toolsFilter) != "" {
-				filterSet, err := parseToolsFilter(toolsFilter)
-				if err != nil {
-					return err
-				}
-				var filtered []tools.ToolDefinition
-				for _, def := range reg {
-					if filterSet[def.ID] {
-						filtered = append(filtered, def)
-					}
-				}
-				reg = filtered
+			reg, err := registryForToolsFilter(toolsFilter)
+			if err != nil {
+				return err
 			}
-
-			report := model.NewStatusReport(len(reg))
-			report.GeneratedAt = time.Now()
 
 			var spinner *progressSpinner
 			if !opts.JSON && showStatusSpinner() {
@@ -82,19 +71,7 @@ When not using --json, a progress indicator may be shown on stderr while tools a
 				spinner.Start()
 			}
 
-			baseCtx := cmd.Context()
-			var wg sync.WaitGroup
-			for i, def := range reg {
-				wg.Add(1)
-				go func(i int, def tools.ToolDefinition) {
-					defer wg.Done()
-					report.Tools[i] = evaluateToolSummary(baseCtx, def, runnerForTool(runner, opts.Timeout, def))
-					if spinner != nil {
-						spinner.Inc(def.ID)
-					}
-				}(i, def)
-			}
-			wg.Wait()
+			report := evaluateStatusRegistry(cmd.Context(), reg, runner, opts.Timeout, spinner)
 
 			if spinner != nil {
 				spinner.Stop()
@@ -123,6 +100,7 @@ When not using --json, a progress indicator may be shown on stderr while tools a
 			}
 
 			if opts.JSON {
+				report.Diagnostics = diag.Generate(report, diag.Options{Profile: diag.ProfileAgent}).Diagnostics
 				return output.PrintJSON(cmd.OutOrStdout(), report)
 			}
 			output.PrintStatusTableWithOptions(cmd.OutOrStdout(), report, output.StatusTableOptions{
@@ -139,6 +117,53 @@ When not using --json, a progress indicator may be shown on stderr while tools a
 	cmd.Flags().BoolVar(&quiet, "quiet", false, "Only show tools with issues (not installed, unconfigured, warnings, or errors)")
 	cmd.Flags().BoolVar(&installedOnly, "installed-only", false, "Only show installed tools")
 	return cmd
+}
+
+func buildStatusReport(ctx context.Context, runner execx.Runner, defaultTimeout time.Duration, toolsFilter string) (model.StatusReport, error) {
+	reg, err := registryForToolsFilter(toolsFilter)
+	if err != nil {
+		return model.StatusReport{}, err
+	}
+	report := evaluateStatusRegistry(ctx, reg, runner, defaultTimeout, nil)
+	sortToolSummaries(report.Tools, statusSortTool)
+	return report, nil
+}
+
+func registryForToolsFilter(toolsFilter string) ([]tools.ToolDefinition, error) {
+	reg := defaultRegistry()
+	if strings.TrimSpace(toolsFilter) == "" {
+		return reg, nil
+	}
+	filterSet, err := parseToolsFilter(toolsFilter)
+	if err != nil {
+		return nil, err
+	}
+	filtered := make([]tools.ToolDefinition, 0, len(filterSet))
+	for _, def := range reg {
+		if filterSet[def.ID] {
+			filtered = append(filtered, def)
+		}
+	}
+	return filtered, nil
+}
+
+func evaluateStatusRegistry(ctx context.Context, reg []tools.ToolDefinition, runner execx.Runner, defaultTimeout time.Duration, spinner *progressSpinner) model.StatusReport {
+	report := model.NewStatusReport(len(reg))
+	report.GeneratedAt = time.Now()
+
+	var wg sync.WaitGroup
+	for i, def := range reg {
+		wg.Add(1)
+		go func(i int, def tools.ToolDefinition) {
+			defer wg.Done()
+			report.Tools[i] = evaluateToolSummary(ctx, def, runnerForTool(runner, defaultTimeout, def))
+			if spinner != nil {
+				spinner.Inc(def.ID)
+			}
+		}(i, def)
+	}
+	wg.Wait()
+	return report
 }
 
 func runnerForTool(baseRunner execx.Runner, defaultTimeout time.Duration, def tools.ToolDefinition) execx.Runner {

--- a/internal/cli/status_command_test.go
+++ b/internal/cli/status_command_test.go
@@ -81,6 +81,39 @@ func TestStatusCommandPlainToolsFilterAndSpinner(t *testing.T) {
 	}
 }
 
+func TestStatusCommandJSONIncludesAdditiveDiagnostics(t *testing.T) {
+	stubStatusRegistry(t, []tools.ToolDefinition{
+		{ID: "aws", DisplayName: "AWS CLI", Category: "cloud", Binary: "aws"},
+	})
+	oldEvaluate := evaluateToolSummary
+	evaluateToolSummary = func(_ context.Context, def tools.ToolDefinition, _ execx.Runner) model.ToolSummary {
+		return model.ToolSummary{
+			ID:              def.ID,
+			DisplayName:     def.DisplayName,
+			Category:        def.Category,
+			Installed:       true,
+			ConfiguredState: model.ConfiguredUnknown,
+			Errors:          []string{"context deadline exceeded"},
+		}
+	}
+	t.Cleanup(func() { evaluateToolSummary = oldEvaluate })
+	stubShowStatusSpinner(t, false)
+
+	opts := &rootOptions{JSON: true, Timeout: time.Second}
+	stdout, _, err := executeTestCommand(t, newStatusCommand(opts, cliFakeRunner{}), "--tools", "aws")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var got model.StatusReport
+	if err := json.Unmarshal([]byte(stdout), &got); err != nil {
+		t.Fatalf("decode json: %v", err)
+	}
+	if len(got.Diagnostics) != 1 || got.Diagnostics[0].RelatedTool != "aws" {
+		t.Fatalf("expected aws diagnostic in status payload, got %#v", got.Diagnostics)
+	}
+}
+
 func TestStatusCommandErrorsOnInvalidGroupBy(t *testing.T) {
 	opts := &rootOptions{Timeout: time.Second}
 	_, _, err := executeTestCommand(t, newStatusCommand(opts, cliFakeRunner{}), "--group-by", "bad")

--- a/internal/diagnose/diagnose.go
+++ b/internal/diagnose/diagnose.go
@@ -1,0 +1,395 @@
+package diagnose
+
+import (
+	"fmt"
+	"reflect"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/oldwinter/all-cli/internal/model"
+)
+
+const (
+	ProfileAgent = "agent"
+	ProfileHuman = "human"
+	ProfileCI    = "ci"
+)
+
+type Options struct {
+	Profile string
+}
+
+type FixOptions struct {
+	DryRun bool
+}
+
+func Generate(status model.StatusReport, opts Options) model.DiagnosticReport {
+	profile := normalizeProfile(opts.Profile)
+	sourceSchema := strings.TrimSpace(status.SchemaVersion)
+	if sourceSchema == "" {
+		sourceSchema = model.SchemaVersionV01
+	}
+
+	report := model.DiagnosticReport{
+		SchemaVersion:       model.DiagnosticSchemaVersionV01,
+		GeneratedAt:         time.Now(),
+		SourceSchemaVersion: sourceSchema,
+		Profile:             profile,
+		Tools:               append([]model.ToolSummary(nil), status.Tools...),
+		Diagnostics:         []model.DiagnosticItem{},
+	}
+	if !status.GeneratedAt.IsZero() {
+		report.GeneratedAt = status.GeneratedAt
+	}
+
+	for _, tool := range status.Tools {
+		report.Diagnostics = append(report.Diagnostics, diagnosticsForTool(tool)...)
+	}
+	report.Summary = summarizeDiagnostics(report.Diagnostics)
+	return report
+}
+
+func BuildFixPlan(report model.DiagnosticReport, opts FixOptions) model.FixPlan {
+	plan := model.FixPlan{
+		SchemaVersion: model.FixPlanSchemaVersionV01,
+		GeneratedAt:   time.Now(),
+		DryRun:        opts.DryRun,
+		Items:         make([]model.FixPlanItem, 0, len(report.Diagnostics)),
+	}
+	if !report.GeneratedAt.IsZero() {
+		plan.GeneratedAt = report.GeneratedAt
+	}
+
+	for _, diagnostic := range report.Diagnostics {
+		action := firstAction(diagnostic)
+		supported := diagnostic.SafeToAutofix && action.ID != "" && !action.Mutates
+		item := model.FixPlanItem{
+			DiagnosticID: diagnostic.ID,
+			RelatedTool:  diagnostic.RelatedTool,
+			Action:       action,
+			Supported:    supported,
+			WillRun:      false,
+			Mutates:      action.Mutates,
+		}
+		if supported {
+			item.Reason = "automatic execution is disabled in dry-run mode"
+		} else {
+			item.Reason = "automatic mutation is not allowlisted; use the suggested manual action"
+		}
+		plan.Items = append(plan.Items, item)
+	}
+
+	plan.Summary.Total = len(plan.Items)
+	for _, item := range plan.Items {
+		if item.Supported {
+			plan.Summary.Supported++
+		} else {
+			plan.Summary.Blocked++
+		}
+	}
+	return plan
+}
+
+func DiffSnapshots(before, after model.StatusReport) model.SnapshotDiffReport {
+	report := model.SnapshotDiffReport{
+		SchemaVersion: model.SnapshotDiffSchemaVersionV01,
+		GeneratedAt:   time.Now(),
+		Changes:       []model.SnapshotToolChange{},
+	}
+
+	beforeByID := indexTools(before.Tools)
+	afterByID := indexTools(after.Tools)
+	ids := make([]string, 0, len(beforeByID)+len(afterByID))
+	seen := map[string]bool{}
+	for id := range beforeByID {
+		ids = append(ids, id)
+		seen[id] = true
+	}
+	for id := range afterByID {
+		if !seen[id] {
+			ids = append(ids, id)
+		}
+	}
+	sort.Strings(ids)
+
+	for _, id := range ids {
+		beforeTool, hadBefore := beforeByID[id]
+		afterTool, hasAfter := afterByID[id]
+		switch {
+		case !hadBefore && hasAfter:
+			tool := afterTool
+			report.Changes = append(report.Changes, model.SnapshotToolChange{
+				ToolID:     id,
+				ChangeType: model.SnapshotChangeAdded,
+				After:      &tool,
+			})
+			report.Summary.Added++
+		case hadBefore && !hasAfter:
+			tool := beforeTool
+			report.Changes = append(report.Changes, model.SnapshotToolChange{
+				ToolID:     id,
+				ChangeType: model.SnapshotChangeRemoved,
+				Before:     &tool,
+			})
+			report.Summary.Removed++
+		default:
+			fields := changedFields(beforeTool, afterTool)
+			if len(fields) == 0 {
+				continue
+			}
+			beforeCopy := beforeTool
+			afterCopy := afterTool
+			report.Changes = append(report.Changes, model.SnapshotToolChange{
+				ToolID:     id,
+				ChangeType: model.SnapshotChangeChanged,
+				Fields:     fields,
+				Before:     &beforeCopy,
+				After:      &afterCopy,
+			})
+			report.Summary.Changed++
+		}
+	}
+
+	return report
+}
+
+func diagnosticsForTool(tool model.ToolSummary) []model.DiagnosticItem {
+	var out []model.DiagnosticItem
+	if !tool.Installed {
+		out = append(out, model.DiagnosticItem{
+			ID:            tool.ID + ".not_installed",
+			Severity:      model.DiagnosticInfo,
+			Problem:       fmt.Sprintf("%s is not installed.", displayName(tool)),
+			Evidence:      []string{fmt.Sprintf("binary for %s was not found in PATH", tool.ID)},
+			RelatedTool:   tool.ID,
+			SafeToAutofix: false,
+			SuggestedActions: []model.SuggestedAction{{
+				ID:          "install_tool",
+				Title:       "Install " + displayName(tool),
+				Description: "Install the CLI binary, then rerun all-cli status or all-cli diagnose.",
+				Kind:        "install",
+				Mutates:     true,
+			}},
+		})
+		return out
+	}
+
+	if len(tool.Errors) > 0 {
+		out = append(out, model.DiagnosticItem{
+			ID:            tool.ID + ".collection_errors",
+			Severity:      model.DiagnosticError,
+			Problem:       fmt.Sprintf("%s status collection reported errors.", displayName(tool)),
+			Evidence:      appendPrefixed("error: ", tool.Errors),
+			RelatedTool:   tool.ID,
+			SafeToAutofix: false,
+			SuggestedActions: []model.SuggestedAction{{
+				ID:          "rerun_with_timeout",
+				Title:       "Rerun with a longer timeout",
+				Description: "Inspect whether the underlying CLI is slow, blocked on login, or returning a non-zero exit.",
+				Kind:        "inspect",
+				Command:     []string{"all-cli", "status", "--tools", tool.ID, "--timeout", "15s"},
+				Mutates:     false,
+			}},
+		})
+	}
+
+	if len(tool.Warnings) > 0 {
+		out = append(out, model.DiagnosticItem{
+			ID:            tool.ID + ".warnings",
+			Severity:      model.DiagnosticWarning,
+			Problem:       fmt.Sprintf("%s status collection reported warnings.", displayName(tool)),
+			Evidence:      appendPrefixed("warning: ", tool.Warnings),
+			RelatedTool:   tool.ID,
+			SafeToAutofix: false,
+			SuggestedActions: []model.SuggestedAction{{
+				ID:          "inspect_warning",
+				Title:       "Inspect warning",
+				Description: "Read the warning and decide whether this is expected for the current environment.",
+				Kind:        "inspect",
+				Command:     []string{"all-cli", "status", "--tools", tool.ID},
+				Mutates:     false,
+			}},
+		})
+	}
+
+	switch tool.ConfiguredState {
+	case model.ConfiguredNo:
+		out = append(out, model.DiagnosticItem{
+			ID:            tool.ID + ".configured_state",
+			Severity:      model.DiagnosticWarning,
+			Problem:       fmt.Sprintf("%s is installed but not configured.", displayName(tool)),
+			Evidence:      configuredEvidence(tool),
+			RelatedTool:   tool.ID,
+			SafeToAutofix: false,
+			SuggestedActions: []model.SuggestedAction{{
+				ID:          "configure_tool",
+				Title:       "Configure " + displayName(tool),
+				Description: configureDescription(tool),
+				Kind:        "configure",
+				Command:     []string{"all-cli", tool.ID, "status"},
+				Mutates:     false,
+			}},
+		})
+	case model.ConfiguredUnknown:
+		if len(tool.Errors) == 0 {
+			out = append(out, model.DiagnosticItem{
+				ID:            tool.ID + ".configured_state_unknown",
+				Severity:      model.DiagnosticWarning,
+				Problem:       fmt.Sprintf("%s configuration state is unknown.", displayName(tool)),
+				Evidence:      configuredEvidence(tool),
+				RelatedTool:   tool.ID,
+				SafeToAutofix: false,
+				SuggestedActions: []model.SuggestedAction{{
+					ID:          "inspect_status",
+					Title:       "Inspect status",
+					Description: "Run the focused status command and inspect any tool-specific diagnostics.",
+					Kind:        "inspect",
+					Command:     []string{"all-cli", "status", "--tools", tool.ID},
+					Mutates:     false,
+				}},
+			})
+		}
+	}
+
+	if tool.Capabilities.HasContexts && tool.Configured && len(tool.Current) == 0 {
+		out = append(out, model.DiagnosticItem{
+			ID:            tool.ID + ".missing_current_context",
+			Severity:      model.DiagnosticWarning,
+			Problem:       fmt.Sprintf("%s is configured but has no current context snapshot.", displayName(tool)),
+			Evidence:      []string{"capabilities.has_contexts=true", "current is empty"},
+			RelatedTool:   tool.ID,
+			SafeToAutofix: false,
+			SuggestedActions: []model.SuggestedAction{{
+				ID:          "list_contexts",
+				Title:       "List contexts",
+				Description: "List available contexts and choose the intended target before operating.",
+				Kind:        "inspect",
+				Command:     []string{"all-cli", tool.ID, "list"},
+				Mutates:     false,
+			}},
+		})
+	}
+
+	return out
+}
+
+func summarizeDiagnostics(items []model.DiagnosticItem) model.DiagnosticSummary {
+	summary := model.DiagnosticSummary{Total: len(items)}
+	for _, item := range items {
+		switch item.Severity {
+		case model.DiagnosticInfo:
+			summary.Info++
+		case model.DiagnosticWarning:
+			summary.Warning++
+		case model.DiagnosticError:
+			summary.Error++
+		}
+	}
+	return summary
+}
+
+func normalizeProfile(profile string) string {
+	switch strings.ToLower(strings.TrimSpace(profile)) {
+	case ProfileHuman:
+		return ProfileHuman
+	case ProfileCI:
+		return ProfileCI
+	default:
+		return ProfileAgent
+	}
+}
+
+func displayName(tool model.ToolSummary) string {
+	if strings.TrimSpace(tool.DisplayName) != "" {
+		return strings.TrimSpace(tool.DisplayName)
+	}
+	return tool.ID
+}
+
+func appendPrefixed(prefix string, messages []string) []string {
+	out := make([]string, 0, len(messages))
+	for _, msg := range messages {
+		msg = strings.TrimSpace(msg)
+		if msg == "" {
+			continue
+		}
+		out = append(out, prefix+msg)
+	}
+	return out
+}
+
+func configuredEvidence(tool model.ToolSummary) []string {
+	evidence := []string{"configured_state=" + string(tool.ConfiguredState)}
+	if strings.TrimSpace(tool.Metadata.ConfiguredWhen) != "" {
+		evidence = append(evidence, "configured_when: "+strings.TrimSpace(tool.Metadata.ConfiguredWhen))
+	}
+	return evidence
+}
+
+func configureDescription(tool model.ToolSummary) string {
+	if strings.TrimSpace(tool.Metadata.ConfiguredWhen) != "" {
+		return "Expected configured condition: " + strings.TrimSpace(tool.Metadata.ConfiguredWhen)
+	}
+	return "Authenticate or create local configuration for this CLI, then rerun diagnostics."
+}
+
+func firstAction(diagnostic model.DiagnosticItem) model.SuggestedAction {
+	if len(diagnostic.SuggestedActions) == 0 {
+		return model.SuggestedAction{
+			ID:          "inspect_diagnostic",
+			Title:       "Inspect diagnostic",
+			Description: "Read the diagnostic evidence and decide the appropriate manual fix.",
+			Kind:        "inspect",
+			Mutates:     false,
+		}
+	}
+	return diagnostic.SuggestedActions[0]
+}
+
+func indexTools(tools []model.ToolSummary) map[string]model.ToolSummary {
+	out := make(map[string]model.ToolSummary, len(tools))
+	for _, tool := range tools {
+		id := strings.TrimSpace(tool.ID)
+		if id == "" {
+			continue
+		}
+		out[id] = tool
+	}
+	return out
+}
+
+func changedFields(before, after model.ToolSummary) []string {
+	var fields []string
+	if before.DisplayName != after.DisplayName {
+		fields = append(fields, "display_name")
+	}
+	if before.Category != after.Category {
+		fields = append(fields, "category")
+	}
+	if before.Installed != after.Installed {
+		fields = append(fields, "installed")
+	}
+	if before.InstallPath != after.InstallPath {
+		fields = append(fields, "install_path")
+	}
+	if before.ConfiguredState != after.ConfiguredState {
+		fields = append(fields, "configured_state")
+	}
+	if before.Configured != after.Configured {
+		fields = append(fields, "configured")
+	}
+	if !reflect.DeepEqual(before.Capabilities, after.Capabilities) {
+		fields = append(fields, "capabilities")
+	}
+	if !reflect.DeepEqual(before.Current, after.Current) {
+		fields = append(fields, "current")
+	}
+	if !reflect.DeepEqual(before.Warnings, after.Warnings) {
+		fields = append(fields, "warnings")
+	}
+	if !reflect.DeepEqual(before.Errors, after.Errors) {
+		fields = append(fields, "errors")
+	}
+	return fields
+}

--- a/internal/diagnose/diagnose_test.go
+++ b/internal/diagnose/diagnose_test.go
@@ -1,0 +1,145 @@
+package diagnose
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/oldwinter/all-cli/internal/model"
+)
+
+func TestGenerateCreatesInfoDiagnosticForMissingTool(t *testing.T) {
+	status := model.NewStatusReport(1)
+	status.GeneratedAt = time.Date(2026, 5, 2, 12, 0, 0, 0, time.UTC)
+	status.Tools[0] = model.ToolSummary{
+		ID:              "rg",
+		DisplayName:     "ripgrep",
+		Category:        "navigation",
+		Installed:       false,
+		ConfiguredState: model.ConfiguredUnknown,
+		Metadata: model.ToolMetadata{
+			AgentActions: []string{"inspect_status"},
+		},
+	}
+
+	report := Generate(status, Options{Profile: ProfileAgent})
+
+	if report.SchemaVersion != model.DiagnosticSchemaVersionV01 {
+		t.Fatalf("schema version = %q, want %q", report.SchemaVersion, model.DiagnosticSchemaVersionV01)
+	}
+	if report.Profile != ProfileAgent {
+		t.Fatalf("profile = %q, want %q", report.Profile, ProfileAgent)
+	}
+	if report.Summary.Total != 1 || report.Summary.Info != 1 {
+		t.Fatalf("unexpected summary: %#v", report.Summary)
+	}
+	if len(report.Diagnostics) != 1 {
+		t.Fatalf("diagnostics len = %d, want 1", len(report.Diagnostics))
+	}
+	item := report.Diagnostics[0]
+	if item.RelatedTool != "rg" || item.Severity != model.DiagnosticInfo {
+		t.Fatalf("unexpected diagnostic item: %#v", item)
+	}
+	if !strings.Contains(item.Problem, "not installed") {
+		t.Fatalf("problem should explain missing binary, got %q", item.Problem)
+	}
+	if item.SafeToAutofix {
+		t.Fatalf("missing tools should not be marked safe to autofix")
+	}
+	if len(item.SuggestedActions) == 0 || item.SuggestedActions[0].ID != "install_tool" {
+		t.Fatalf("expected install action, got %#v", item.SuggestedActions)
+	}
+}
+
+func TestGenerateCreatesWarningForUnconfiguredInstalledTool(t *testing.T) {
+	status := model.NewStatusReport(1)
+	status.Tools[0] = model.ToolSummary{
+		ID:              "docker",
+		DisplayName:     "Docker",
+		Category:        "containers",
+		Installed:       true,
+		InstallPath:     "/usr/local/bin/docker",
+		ConfiguredState: model.ConfiguredNo,
+		Metadata: model.ToolMetadata{
+			ConfiguredWhen: "At least one Docker context is available.",
+			AgentActions:   []string{"inspect_status", "show_current"},
+		},
+	}
+
+	report := Generate(status, Options{Profile: ProfileCI})
+
+	if report.Profile != ProfileCI {
+		t.Fatalf("profile = %q, want %q", report.Profile, ProfileCI)
+	}
+	if report.Summary.Warning != 1 {
+		t.Fatalf("expected one warning, got %#v", report.Summary)
+	}
+	item := report.Diagnostics[0]
+	if item.Severity != model.DiagnosticWarning {
+		t.Fatalf("severity = %q, want %q", item.Severity, model.DiagnosticWarning)
+	}
+	if !strings.Contains(strings.Join(item.Evidence, "\n"), "configured_state=no") {
+		t.Fatalf("expected configured_state evidence, got %#v", item.Evidence)
+	}
+	if len(item.SuggestedActions) == 0 || item.SuggestedActions[0].ID != "configure_tool" {
+		t.Fatalf("expected configure action, got %#v", item.SuggestedActions)
+	}
+}
+
+func TestGenerateCreatesErrorDiagnosticForCollectionErrors(t *testing.T) {
+	status := model.NewStatusReport(1)
+	status.Tools[0] = model.ToolSummary{
+		ID:              "aws",
+		DisplayName:     "AWS CLI",
+		Category:        "cloud",
+		Installed:       true,
+		ConfiguredState: model.ConfiguredUnknown,
+		Errors:          []string{"context deadline exceeded"},
+	}
+
+	report := Generate(status, Options{})
+
+	if report.Summary.Error != 1 {
+		t.Fatalf("expected one error, got %#v", report.Summary)
+	}
+	item := report.Diagnostics[0]
+	if item.Severity != model.DiagnosticError {
+		t.Fatalf("severity = %q, want %q", item.Severity, model.DiagnosticError)
+	}
+	if !strings.Contains(strings.Join(item.Evidence, "\n"), "context deadline exceeded") {
+		t.Fatalf("expected error evidence, got %#v", item.Evidence)
+	}
+	if len(item.SuggestedActions) == 0 || item.SuggestedActions[0].ID != "rerun_with_timeout" {
+		t.Fatalf("expected timeout/retry action, got %#v", item.SuggestedActions)
+	}
+}
+
+func TestBuildFixPlanIsDryRunOnlyAndNonMutating(t *testing.T) {
+	status := model.NewStatusReport(1)
+	status.Tools[0] = model.ToolSummary{
+		ID:              "gh",
+		DisplayName:     "GitHub CLI",
+		Installed:       true,
+		ConfiguredState: model.ConfiguredNo,
+	}
+	report := Generate(status, Options{})
+
+	plan := BuildFixPlan(report, FixOptions{DryRun: true})
+
+	if !plan.DryRun {
+		t.Fatalf("fix plan should preserve dry_run=true")
+	}
+	if plan.Summary.Total != 1 || plan.Summary.Supported != 0 || plan.Summary.Blocked != 1 {
+		t.Fatalf("unexpected fix summary: %#v", plan.Summary)
+	}
+	if len(plan.Items) != 1 {
+		t.Fatalf("items len = %d, want 1", len(plan.Items))
+	}
+	item := plan.Items[0]
+	if item.WillRun || item.Mutates {
+		t.Fatalf("dry-run baseline must not run or mutate, got %#v", item)
+	}
+	if !strings.Contains(item.Reason, "not allowlisted") {
+		t.Fatalf("expected allowlist reason, got %q", item.Reason)
+	}
+}

--- a/internal/model/model.go
+++ b/internal/model/model.go
@@ -6,6 +6,15 @@ import "time"
 // SchemaVersionV01 is the current JSON schema version for status output.
 const SchemaVersionV01 = "v0.1"
 
+// DiagnosticSchemaVersionV01 is the current JSON schema version for diagnostic output.
+const DiagnosticSchemaVersionV01 = "diagnostic-v0.1"
+
+// FixPlanSchemaVersionV01 is the current JSON schema version for fix dry-run output.
+const FixPlanSchemaVersionV01 = "fix-plan-v0.1"
+
+// SnapshotDiffSchemaVersionV01 is the current JSON schema version for snapshot diff output.
+const SnapshotDiffSchemaVersionV01 = "snapshot-diff-v0.1"
+
 // ConfiguredState represents the configuration status of a CLI tool.
 type ConfiguredState string
 
@@ -29,6 +38,115 @@ type ToolMetadata struct {
 	CurrentFieldDescriptions map[string]string `json:"current_field_descriptions,omitempty"`
 	AgentActions             []string          `json:"agent_actions,omitempty"`
 	Notes                    []string          `json:"notes,omitempty"`
+}
+
+// DiagnosticSeverity describes how urgently a diagnostic item should be handled.
+type DiagnosticSeverity string
+
+const (
+	DiagnosticInfo    DiagnosticSeverity = "info"
+	DiagnosticWarning DiagnosticSeverity = "warning"
+	DiagnosticError   DiagnosticSeverity = "error"
+)
+
+// SuggestedAction is a stable, agent-readable next step for a diagnostic item.
+type SuggestedAction struct {
+	ID          string   `json:"id"`
+	Title       string   `json:"title"`
+	Description string   `json:"description,omitempty"`
+	Kind        string   `json:"kind,omitempty"`
+	Command     []string `json:"command,omitempty"`
+	Mutates     bool     `json:"mutates"`
+}
+
+// DiagnosticItem describes one issue or observation derived from status output.
+type DiagnosticItem struct {
+	ID               string             `json:"id"`
+	Severity         DiagnosticSeverity `json:"severity"`
+	Problem          string             `json:"problem"`
+	Evidence         []string           `json:"evidence,omitempty"`
+	SuggestedActions []SuggestedAction  `json:"suggested_actions,omitempty"`
+	SafeToAutofix    bool               `json:"safe_to_autofix"`
+	RelatedTool      string             `json:"related_tool,omitempty"`
+}
+
+// DiagnosticSummary stores aggregate diagnostic counts.
+type DiagnosticSummary struct {
+	Total   int `json:"total"`
+	Info    int `json:"info"`
+	Warning int `json:"warning"`
+	Error   int `json:"error"`
+}
+
+// DiagnosticReport is the top-level structure for diagnose/doctor output.
+type DiagnosticReport struct {
+	SchemaVersion       string            `json:"schema_version"`
+	GeneratedAt         time.Time         `json:"generated_at"`
+	SourceSchemaVersion string            `json:"source_schema_version"`
+	Profile             string            `json:"profile,omitempty"`
+	Summary             DiagnosticSummary `json:"summary"`
+	Tools               []ToolSummary     `json:"tools,omitempty"`
+	Diagnostics         []DiagnosticItem  `json:"diagnostics"`
+}
+
+// FixPlanSummary stores aggregate fix plan counts.
+type FixPlanSummary struct {
+	Total     int `json:"total"`
+	Supported int `json:"supported"`
+	Blocked   int `json:"blocked"`
+}
+
+// FixPlanItem describes how a diagnostic would be handled by fix --dry-run.
+type FixPlanItem struct {
+	DiagnosticID string          `json:"diagnostic_id"`
+	RelatedTool  string          `json:"related_tool,omitempty"`
+	Action       SuggestedAction `json:"action"`
+	Supported    bool            `json:"supported"`
+	WillRun      bool            `json:"will_run"`
+	Mutates      bool            `json:"mutates"`
+	Reason       string          `json:"reason,omitempty"`
+}
+
+// FixPlan is the top-level structure for fix --dry-run output.
+type FixPlan struct {
+	SchemaVersion string         `json:"schema_version"`
+	GeneratedAt   time.Time      `json:"generated_at"`
+	DryRun        bool           `json:"dry_run"`
+	Summary       FixPlanSummary `json:"summary"`
+	Items         []FixPlanItem  `json:"items"`
+}
+
+// SnapshotChangeType describes how a tool differs between two snapshots.
+type SnapshotChangeType string
+
+const (
+	SnapshotChangeAdded   SnapshotChangeType = "added"
+	SnapshotChangeRemoved SnapshotChangeType = "removed"
+	SnapshotChangeChanged SnapshotChangeType = "changed"
+)
+
+// SnapshotDiffSummary stores aggregate snapshot diff counts.
+type SnapshotDiffSummary struct {
+	Added   int `json:"added"`
+	Removed int `json:"removed"`
+	Changed int `json:"changed"`
+}
+
+// SnapshotToolChange describes one changed tool between two status snapshots.
+type SnapshotToolChange struct {
+	ToolID     string             `json:"tool_id"`
+	ChangeType SnapshotChangeType `json:"change_type"`
+	Fields     []string           `json:"fields,omitempty"`
+	Before     *ToolSummary       `json:"before,omitempty"`
+	After      *ToolSummary       `json:"after,omitempty"`
+}
+
+// SnapshotDiffReport is the top-level structure for snapshot diff output.
+type SnapshotDiffReport struct {
+	SchemaVersion string               `json:"schema_version"`
+	GeneratedAt   time.Time            `json:"generated_at"`
+	Summary       SnapshotDiffSummary  `json:"summary"`
+	Changes       []SnapshotToolChange `json:"changes"`
 }
 
 type StatusLegend struct {
@@ -59,10 +177,11 @@ type ToolSummary struct {
 
 // StatusReport is the top-level structure for status output.
 type StatusReport struct {
-	SchemaVersion string        `json:"schema_version"`
-	GeneratedAt   time.Time     `json:"generated_at"`
-	Legend        StatusLegend  `json:"legend,omitempty"`
-	Tools         []ToolSummary `json:"tools"`
+	SchemaVersion string           `json:"schema_version"`
+	GeneratedAt   time.Time        `json:"generated_at"`
+	Legend        StatusLegend     `json:"legend,omitempty"`
+	Tools         []ToolSummary    `json:"tools"`
+	Diagnostics   []DiagnosticItem `json:"diagnostics,omitempty"`
 }
 
 // UseResult is returned by context-switching commands.

--- a/internal/model/status_schema_contract_test.go
+++ b/internal/model/status_schema_contract_test.go
@@ -159,3 +159,87 @@ func TestStatusReportMarshalsAgainstStatusSchema(t *testing.T) {
 		t.Fatalf("instance does not validate against %s: %v", statusReportSchemaURL, err)
 	}
 }
+
+const diagnosticReportSchemaURL = "https://github.com/oldwinter/all-cli/schemas/diagnostic-report-v0.1.json"
+
+func TestDiagnosticReportMarshalsAgainstDiagnosticSchema(t *testing.T) {
+	t.Parallel()
+
+	path := filepath.Join(moduleRoot(t), "schemas", "diagnostic-report-v0.1.json")
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read schema: %v", err)
+	}
+	var schemaDoc any
+	if err := json.Unmarshal(raw, &schemaDoc); err != nil {
+		t.Fatalf("parse schema: %v", err)
+	}
+
+	c := jsonschema.NewCompiler()
+	if err := c.AddResource(diagnosticReportSchemaURL, schemaDoc); err != nil {
+		t.Fatalf("add schema resource: %v", err)
+	}
+	statusRaw, err := os.ReadFile(filepath.Join(moduleRoot(t), "schemas", "status-report-v0.1.json"))
+	if err != nil {
+		t.Fatalf("read status schema: %v", err)
+	}
+	var statusSchemaDoc any
+	if err := json.Unmarshal(statusRaw, &statusSchemaDoc); err != nil {
+		t.Fatalf("parse status schema: %v", err)
+	}
+	if err := c.AddResource(statusReportSchemaURL, statusSchemaDoc); err != nil {
+		t.Fatalf("add status schema resource: %v", err)
+	}
+	sch, err := c.Compile(diagnosticReportSchemaURL)
+	if err != nil {
+		t.Fatalf("compile schema: %v", err)
+	}
+
+	report := DiagnosticReport{
+		SchemaVersion:       DiagnosticSchemaVersionV01,
+		GeneratedAt:         time.Date(2026, 5, 2, 12, 0, 0, 0, time.UTC),
+		SourceSchemaVersion: SchemaVersionV01,
+		Profile:             "agent",
+		Summary: DiagnosticSummary{
+			Total:   1,
+			Warning: 1,
+		},
+		Tools: []ToolSummary{{
+			ID:              "kubectl",
+			DisplayName:     "kubectl",
+			Category:        "k8s",
+			Installed:       true,
+			ConfiguredState: ConfiguredNo,
+			Capabilities:    Capability{HasContexts: true, CanSwitch: true},
+		}},
+		Diagnostics: []DiagnosticItem{{
+			ID:            "kubectl.configured_state",
+			Severity:      DiagnosticWarning,
+			Problem:       "kubectl is installed but not configured.",
+			Evidence:      []string{"configured_state=no"},
+			RelatedTool:   "kubectl",
+			SafeToAutofix: false,
+			SuggestedActions: []SuggestedAction{{
+				ID:          "configure_tool",
+				Title:       "Configure kubectl",
+				Description: "Authenticate or create local configuration before using kubectl.",
+				Kind:        "configure",
+				Command:     []string{"kubectl", "config", "get-contexts"},
+				Mutates:     false,
+			}},
+		}},
+	}
+
+	payload, err := json.Marshal(report)
+	if err != nil {
+		t.Fatalf("marshal report: %v", err)
+	}
+	var instance any
+	if err := json.Unmarshal(payload, &instance); err != nil {
+		t.Fatalf("unmarshal instance: %v", err)
+	}
+
+	if err := sch.Validate(instance); err != nil {
+		t.Fatalf("instance does not validate against %s: %v", diagnosticReportSchemaURL, err)
+	}
+}

--- a/schemas/README.md
+++ b/schemas/README.md
@@ -1,5 +1,6 @@
 # JSON schemas
 
 - `status-report-v0.1.json` describes the object emitted by `all-cli status --json` (`internal/model.StatusReport`). The `schema_version` field matches `model.SchemaVersionV01`.
+- `diagnostic-report-v0.1.json` describes the object emitted by `all-cli diagnose --json` and `all-cli doctor --json` (`internal/model.DiagnosticReport`). It embeds status tool summaries and adds agent-readable diagnostic items.
 
 When evolving the Go structs, update this file and run `go test ./internal/model/...`.

--- a/schemas/diagnostic-report-v0.1.json
+++ b/schemas/diagnostic-report-v0.1.json
@@ -1,0 +1,99 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/oldwinter/all-cli/schemas/diagnostic-report-v0.1.json",
+  "title": "all-cli diagnostic report",
+  "type": "object",
+  "required": [
+    "schema_version",
+    "generated_at",
+    "source_schema_version",
+    "summary",
+    "diagnostics"
+  ],
+  "properties": {
+    "schema_version": {
+      "type": "string",
+      "const": "diagnostic-v0.1"
+    },
+    "generated_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "source_schema_version": {
+      "type": "string"
+    },
+    "profile": {
+      "type": "string",
+      "enum": ["agent", "human", "ci"]
+    },
+    "summary": {
+      "$ref": "#/$defs/diagnostic_summary"
+    },
+    "tools": {
+      "type": "array",
+      "items": { "$ref": "status-report-v0.1.json#/$defs/tool_summary" }
+    },
+    "diagnostics": {
+      "type": "array",
+      "items": { "$ref": "#/$defs/diagnostic_item" }
+    }
+  },
+  "additionalProperties": true,
+  "$defs": {
+    "diagnostic_summary": {
+      "type": "object",
+      "required": ["total", "info", "warning", "error"],
+      "properties": {
+        "total": { "type": "integer", "minimum": 0 },
+        "info": { "type": "integer", "minimum": 0 },
+        "warning": { "type": "integer", "minimum": 0 },
+        "error": { "type": "integer", "minimum": 0 }
+      },
+      "additionalProperties": false
+    },
+    "suggested_action": {
+      "type": "object",
+      "required": ["id", "title", "mutates"],
+      "properties": {
+        "id": { "type": "string" },
+        "title": { "type": "string" },
+        "description": { "type": "string" },
+        "kind": { "type": "string" },
+        "command": {
+          "type": "array",
+          "items": { "type": "string" }
+        },
+        "mutates": { "type": "boolean" }
+      },
+      "additionalProperties": true
+    },
+    "diagnostic_item": {
+      "type": "object",
+      "required": [
+        "id",
+        "severity",
+        "problem",
+        "safe_to_autofix"
+      ],
+      "properties": {
+        "id": { "type": "string" },
+        "severity": {
+          "type": "string",
+          "enum": ["info", "warning", "error"]
+        },
+        "problem": { "type": "string" },
+        "evidence": {
+          "type": "array",
+          "items": { "type": "string" }
+        },
+        "suggested_actions": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/suggested_action" }
+        },
+        "safe_to_autofix": { "type": "boolean" },
+        "related_tool": { "type": "string" }
+      },
+      "additionalProperties": true
+    }
+  }
+}

--- a/schemas/status-report-v0.1.json
+++ b/schemas/status-report-v0.1.json
@@ -40,6 +40,11 @@
     "tools": {
       "type": "array",
       "items": { "$ref": "#/$defs/tool_summary" }
+    },
+    "diagnostics": {
+      "type": "array",
+      "description": "Optional additive diagnostics derived from tool summaries for agent callers.",
+      "items": { "$ref": "#/$defs/diagnostic_item" }
     }
   },
   "additionalProperties": true,
@@ -109,6 +114,50 @@
           "type": "array",
           "items": { "type": "string" }
         }
+      },
+      "additionalProperties": true
+    },
+    "suggested_action": {
+      "type": "object",
+      "required": ["id", "title", "mutates"],
+      "properties": {
+        "id": { "type": "string" },
+        "title": { "type": "string" },
+        "description": { "type": "string" },
+        "kind": { "type": "string" },
+        "command": {
+          "type": "array",
+          "items": { "type": "string" }
+        },
+        "mutates": { "type": "boolean" }
+      },
+      "additionalProperties": true
+    },
+    "diagnostic_item": {
+      "type": "object",
+      "required": [
+        "id",
+        "severity",
+        "problem",
+        "safe_to_autofix"
+      ],
+      "properties": {
+        "id": { "type": "string" },
+        "severity": {
+          "type": "string",
+          "enum": ["info", "warning", "error"]
+        },
+        "problem": { "type": "string" },
+        "evidence": {
+          "type": "array",
+          "items": { "type": "string" }
+        },
+        "suggested_actions": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/suggested_action" }
+        },
+        "safe_to_autofix": { "type": "boolean" },
+        "related_tool": { "type": "string" }
       },
       "additionalProperties": true
     }


### PR DESCRIPTION
## Summary
- add diagnose/doctor/fix dry-run/snapshot/diff agent workflow commands
- add diagnostic, fix-plan, and snapshot-diff model types plus diagnostic rules
- document new JSON schema and additive status diagnostics

## Test Plan
- just ci
- just check
- .context/all-cli-smoke diagnose --json --tools kubectl,docker,gh --timeout 2s
- .context/all-cli-smoke doctor --tools kubectl,docker,gh --json --timeout 2s
- .context/all-cli-smoke fix --dry-run --tools aws,gh --json --timeout 2s

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **新增特性**
  * 新增 `diagnose` 命令，支持工具筛选和诊断报告生成
  * 新增 `doctor` 命令作为健康检查入口
  * 新增 `fix` 命令用于干运行模式修复计划
  * 新增 `snapshot` 和 `diff` 命令用于状态快照对比
  * `status --json` 输出现包含诊断信息

* **文档**
  * 更新 README 文档，说明新的 CLI 工作流和 JSON 输出格式

* **测试**
  * 新增全面的命令行和诊断功能测试覆盖

<!-- end of auto-generated comment: release notes by coderabbit.ai -->