### PR TITLE
feat(cli): filter status by categories

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,11 +102,15 @@ Note about Go toolchain mismatch:
 all-cli status
 all-cli status --json
 all-cli status --tools kubectl,docker
+all-cli status --categories ai,cloud
 all-cli status --group-by none
 all-cli status --sort tool-desc
 all-cli status --sort category-desc
 all-cli status --timeout 10s
 ```
+
+Use `--categories` to check one or more registry categories at once. When combined with
+`--tools`, both filters apply, so the result contains only tools matching both selections.
 
 ### Agent diagnostics
 

--- a/internal/cli/status.go
+++ b/internal/cli/status.go
@@ -35,6 +35,7 @@ var (
 
 func newStatusCommand(opts *rootOptions, runner execx.Runner) *cobra.Command {
 	var toolsFilter string
+	var categoriesFilter string
 	var groupBy string
 	var sortBy string
 	var quiet bool
@@ -49,6 +50,7 @@ configuration state, capabilities, and optional current context snapshot.
 When not using --json, a progress indicator may be shown on stderr while tools are checked.`,
 		Example: `  all-cli status
   all-cli status --tools kubectl,docker --group-by none
+  all-cli status --categories ai,cloud
   all-cli status --installed-only --quiet`,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			groupByValue, err := parseStatusGroupBy(groupBy)
@@ -61,6 +63,10 @@ When not using --json, a progress indicator may be shown on stderr while tools a
 			}
 
 			reg, err := registryForToolsFilter(toolsFilter)
+			if err != nil {
+				return err
+			}
+			reg, err = registryForCategoriesFilter(reg, categoriesFilter)
 			if err != nil {
 				return err
 			}
@@ -112,6 +118,7 @@ When not using --json, a progress indicator may be shown on stderr while tools a
 	}
 
 	cmd.Flags().StringVar(&toolsFilter, "tools", "", "Comma-separated tool IDs to check (e.g. kubectl,docker)")
+	cmd.Flags().StringVar(&categoriesFilter, "categories", "", "Comma-separated categories to check (e.g. ai,cloud)")
 	cmd.Flags().StringVar(&groupBy, "group-by", statusGroupByCategory, "Group output: category|none")
 	cmd.Flags().StringVar(&sortBy, "sort", statusSortTool, "Sort order: tool|tool-desc|category|category-desc")
 	cmd.Flags().BoolVar(&quiet, "quiet", false, "Only show tools with issues (not installed, unconfigured, warnings, or errors)")

--- a/internal/cli/status_categories.go
+++ b/internal/cli/status_categories.go
@@ -1,0 +1,49 @@
+package cli
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/oldwinter/all-cli/internal/tools"
+)
+
+func registryForCategoriesFilter(reg []tools.ToolDefinition, categoriesFilter string) ([]tools.ToolDefinition, error) {
+	if strings.TrimSpace(categoriesFilter) == "" {
+		return reg, nil
+	}
+
+	categories := make(map[string]bool)
+	for _, category := range strings.Split(categoriesFilter, ",") {
+		category = strings.ToLower(strings.TrimSpace(category))
+		if category != "" {
+			categories[category] = true
+		}
+	}
+	if len(categories) == 0 {
+		return nil, fmt.Errorf("invalid --categories value")
+	}
+
+	knownCategories := make(map[string]bool)
+	for _, def := range defaultRegistry() {
+		knownCategories[strings.ToLower(def.Category)] = true
+	}
+	unknown := make([]string, 0)
+	for category := range categories {
+		if !knownCategories[category] {
+			unknown = append(unknown, category)
+		}
+	}
+	if len(unknown) > 0 {
+		sort.Strings(unknown)
+		return nil, fmt.Errorf("unknown categories: %s", strings.Join(unknown, ", "))
+	}
+
+	filtered := make([]tools.ToolDefinition, 0, len(reg))
+	for _, def := range reg {
+		if categories[strings.ToLower(def.Category)] {
+			filtered = append(filtered, def)
+		}
+	}
+	return filtered, nil
+}

--- a/internal/cli/status_categories_test.go
+++ b/internal/cli/status_categories_test.go
@@ -1,0 +1,55 @@
+package cli
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/oldwinter/all-cli/internal/execx"
+	"github.com/oldwinter/all-cli/internal/model"
+	"github.com/oldwinter/all-cli/internal/tools"
+)
+
+func TestStatusCommandFiltersToolsByCategories(t *testing.T) {
+	stubStatusRegistry(t, []tools.ToolDefinition{
+		{ID: "aws", DisplayName: "AWS CLI", Category: "cloud", Binary: "aws"},
+		{ID: "kubectl", DisplayName: "kubectl", Category: "k8s", Binary: "kubectl"},
+		{ID: "gh", DisplayName: "gh", Category: "code", Binary: "gh"},
+	})
+	oldEvaluate := evaluateToolSummary
+	evaluateToolSummary = func(_ context.Context, def tools.ToolDefinition, _ execx.Runner) model.ToolSummary {
+		return model.ToolSummary{ID: def.ID, Category: def.Category, Installed: true}
+	}
+	t.Cleanup(func() { evaluateToolSummary = oldEvaluate })
+	stubShowStatusSpinner(t, false)
+
+	opts := &rootOptions{JSON: true, Timeout: time.Second}
+	stdout, _, err := executeTestCommand(t, newStatusCommand(opts, cliFakeRunner{}),
+		"--tools", "aws,kubectl", "--categories", "cloud,code")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var got model.StatusReport
+	if err := json.Unmarshal([]byte(stdout), &got); err != nil {
+		t.Fatalf("decode json: %v", err)
+	}
+	if len(got.Tools) != 1 || got.Tools[0].ID != "aws" {
+		t.Fatalf("unexpected category-filtered tools: %#v", got.Tools)
+	}
+}
+
+func TestStatusCommandRejectsUnknownCategories(t *testing.T) {
+	stubStatusRegistry(t, []tools.ToolDefinition{
+		{ID: "aws", DisplayName: "AWS CLI", Category: "cloud", Binary: "aws"},
+	})
+	stubShowStatusSpinner(t, false)
+
+	opts := &rootOptions{JSON: true, Timeout: time.Second}
+	_, _, err := executeTestCommand(t, newStatusCommand(opts, cliFakeRunner{}), "--categories", "cloud,workflows")
+	if err == nil || !strings.Contains(err.Error(), "unknown categories: workflows") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}


### PR DESCRIPTION
This PR adds `all-cli status --categories ai,cloud`, allowing users to focus the broad CLI inventory by registry category and combine it with `--tools` as an intersection. It is worth merging because category-level checks are faster to scan and avoid maintaining long tool lists, while preserving the existing text and JSON contracts.

## What changed

- Added the comma-separated `--categories` flag to `all-cli status`.
- Normalized category input for case, whitespace, and duplicates.
- Rejected unknown categories with deterministic, sorted errors.
- Documented category filtering and its intersection with `--tools`.
- Added command-level tests for successful intersection and invalid categories.

## Verification

- `just check`
- `just build`
- Real text output: `status --categories navigation --group-by none`
- Real JSON intersection: `--json status --tools aws,kubectl --categories cloud`
- Real error path: `status --categories workflows` exits 1
- Five-lane review gate plus independent Go runtime audit: PASS on `e8458069b65e5350ca4d5799d5cb6b430053f5e9`

## Impact

The change is additive and limited to status selection before existing evaluation and rendering. It adds no dependencies, schema changes, configuration, infrastructure, or machine-state mutation.

## Rollback

Revert commit `e8458069b65e5350ca4d5799d5cb6b430053f5e9`; no migration or cleanup is required.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新功能**
  * `all-cli status` 新增 `--categories` 筛选参数，支持按一个或多个类别过滤工具。
  * 可与 `--tools` 同时使用，结果需同时符合两项筛选条件。
  * 类别名称支持逗号分隔，筛选时不区分大小写并忽略多余空格。

* **错误提示**
  * 输入空类别或未知类别时，命令会返回明确的错误信息。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->