### PR TITLE
feat(cli): describe tracked tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,6 +194,16 @@ Example shape:
 }
 ```
 
+### Tool descriptions
+
+Use `all-cli describe <tool>` to inspect the built-in purpose, configuration
+criteria, context capabilities, and agent actions without running the tool:
+
+```bash
+all-cli describe kubectl
+all-cli describe kubectl --json
+```
+
 ### kubectl
 
 ```bash

--- a/internal/cli/describe.go
+++ b/internal/cli/describe.go
@@ -1,0 +1,109 @@
+package cli
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/oldwinter/all-cli/internal/model"
+	"github.com/oldwinter/all-cli/internal/output"
+	"github.com/oldwinter/all-cli/internal/tools"
+	"github.com/spf13/cobra"
+)
+
+func newDescribeCommand(opts *rootOptions) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "describe <tool>",
+		Short: "Explain a tracked CLI tool without running it",
+		Long: `Shows the built-in description, configuration criteria, context capabilities,
+and agent actions for one tracked tool. This command does not run the tool or inspect
+local configuration.`,
+		Example: `  all-cli describe kubectl
+  all-cli describe aws --json`,
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			def, ok := tools.FindByID(args[0])
+			if !ok {
+				return fmt.Errorf("unknown tool ID %q", args[0])
+			}
+			metadata := tools.MetadataForTool(def.ID)
+			description := struct {
+				ID           string             `json:"id"`
+				DisplayName  string             `json:"display_name"`
+				Category     string             `json:"category"`
+				Binary       string             `json:"binary"`
+				Capabilities model.Capability   `json:"capabilities"`
+				Metadata     model.ToolMetadata `json:"metadata"`
+			}{
+				ID:           def.ID,
+				DisplayName:  def.DisplayName,
+				Category:     def.Category,
+				Binary:       def.Binary,
+				Capabilities: def.Capabilities,
+				Metadata:     metadata,
+			}
+			if opts.JSON {
+				return output.PrintJSON(cmd.OutOrStdout(), description)
+			}
+
+			w := cmd.OutOrStdout()
+			yesNo := func(value bool) string {
+				if value {
+					return "yes"
+				}
+				return "no"
+			}
+			fmt.Fprintf(w, "Tool: %s\n", description.DisplayName)
+			fmt.Fprintf(w, "ID: %s\n", description.ID)
+			fmt.Fprintf(w, "Category: %s\n", description.Category)
+			fmt.Fprintf(w, "Binary: %s\n", description.Binary)
+			fmt.Fprintf(w, "Purpose: %s\n", description.Metadata.Purpose)
+			fmt.Fprintf(w, "Configured when: %s\n", description.Metadata.ConfiguredWhen)
+			fmt.Fprintf(w, "Has contexts: %s\n", yesNo(description.Capabilities.HasContexts))
+			fmt.Fprintf(w, "Can switch: %s\n", yesNo(description.Capabilities.CanSwitch))
+
+			if len(description.Metadata.CurrentFieldDescriptions) > 0 {
+				keys := make([]string, 0, len(description.Metadata.CurrentFieldDescriptions))
+				for key := range description.Metadata.CurrentFieldDescriptions {
+					keys = append(keys, key)
+				}
+				sort.Strings(keys)
+				fmt.Fprintln(w, "Current fields:")
+				for _, key := range keys {
+					fmt.Fprintf(w, "  %s: %s\n", key, description.Metadata.CurrentFieldDescriptions[key])
+				}
+			}
+			if len(description.Metadata.AgentActions) > 0 {
+				fmt.Fprintln(w, "Agent actions:")
+				for _, action := range description.Metadata.AgentActions {
+					fmt.Fprintf(w, "  - %s\n", action)
+				}
+			}
+			if len(description.Metadata.Notes) > 0 {
+				fmt.Fprintln(w, "Notes:")
+				for _, note := range description.Metadata.Notes {
+					fmt.Fprintf(w, "  - %s\n", note)
+				}
+			}
+			return nil
+		},
+	}
+	cmd.SetFlagErrorFunc(func(_ *cobra.Command, err error) error {
+		return fmt.Errorf("parse describe flags: %q", err.Error())
+	})
+
+	cmd.ValidArgsFunction = func(_ *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+		if len(args) > 0 {
+			return nil, cobra.ShellCompDirectiveNoFileComp
+		}
+		candidates := make([]string, 0)
+		for _, def := range tools.DefaultRegistry() {
+			if strings.HasPrefix(def.ID, toComplete) {
+				candidates = append(candidates, def.ID+"\t"+tools.MetadataForTool(def.ID).Purpose)
+			}
+		}
+		sort.Strings(candidates)
+		return candidates, cobra.ShellCompDirectiveNoFileComp
+	}
+	return cmd
+}

--- a/internal/cli/describe_test.go
+++ b/internal/cli/describe_test.go
@@ -1,0 +1,171 @@
+package cli
+
+import (
+	"encoding/json"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/oldwinter/all-cli/internal/model"
+)
+
+func TestDescribeCommandPrintsHumanReadableMetadata(t *testing.T) {
+	// Given
+	opts := &rootOptions{}
+
+	// When
+	stdout, stderr, err := executeTestCommand(t, newDescribeCommand(opts), "kubectl")
+
+	// Then
+	if err != nil {
+		t.Fatalf("describe kubectl: %v", err)
+	}
+	if stderr != "" {
+		t.Fatalf("stderr = %q, want empty", stderr)
+	}
+	for _, want := range []string{
+		"Tool: kubectl",
+		"Category: k8s",
+		"Binary: kubectl",
+		"Purpose:",
+		"Configured when:",
+		"Has contexts: yes",
+		"Can switch: yes",
+		"Current fields:",
+		"  context:",
+		"Agent actions:",
+		"  - inspect_status",
+	} {
+		if !strings.Contains(stdout, want) {
+			t.Fatalf("stdout missing %q:\n%s", want, stdout)
+		}
+	}
+}
+
+func TestDescribeCommandPrintsJSONMetadata(t *testing.T) {
+	// Given
+	opts := &rootOptions{JSON: true}
+
+	// When
+	stdout, stderr, err := executeTestCommand(t, newDescribeCommand(opts), "kubectl")
+
+	// Then
+	if err != nil {
+		t.Fatalf("describe kubectl --json: %v", err)
+	}
+	if stderr != "" {
+		t.Fatalf("stderr = %q, want empty", stderr)
+	}
+	var got struct {
+		ID           string             `json:"id"`
+		DisplayName  string             `json:"display_name"`
+		Category     string             `json:"category"`
+		Binary       string             `json:"binary"`
+		Capabilities model.Capability   `json:"capabilities"`
+		Metadata     model.ToolMetadata `json:"metadata"`
+	}
+	if err := json.Unmarshal([]byte(stdout), &got); err != nil {
+		t.Fatalf("decode describe json: %v", err)
+	}
+	if got.ID != "kubectl" || got.DisplayName != "kubectl" || got.Category != "k8s" || got.Binary != "kubectl" {
+		t.Fatalf("unexpected identity: %#v", got)
+	}
+	if !got.Capabilities.HasContexts || !got.Capabilities.CanSwitch {
+		t.Fatalf("unexpected capabilities: %#v", got.Capabilities)
+	}
+	if got.Metadata.Purpose == "" || got.Metadata.ConfiguredWhen == "" || len(got.Metadata.AgentActions) == 0 {
+		t.Fatalf("unexpected metadata: %#v", got.Metadata)
+	}
+}
+
+func TestDescribeCommandRejectsUnknownTool(t *testing.T) {
+	// Given
+	opts := &rootOptions{}
+
+	// When
+	_, _, err := executeTestCommand(t, newDescribeCommand(opts), "not-a-tool")
+
+	// Then
+	if err == nil || !strings.Contains(err.Error(), `unknown tool ID "not-a-tool"`) {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestDescribeCommandEscapesUnknownToolID(t *testing.T) {
+	// Given
+	opts := &rootOptions{}
+	toolID := "bad\x1b[31m"
+
+	// When
+	_, _, err := executeTestCommand(t, newDescribeCommand(opts), toolID)
+
+	// Then
+	if err == nil {
+		t.Fatal("expected unknown tool error")
+	}
+	if strings.Contains(err.Error(), "\x1b") {
+		t.Fatalf("error contains a terminal escape: %q", err)
+	}
+	if !strings.Contains(err.Error(), strconv.Quote(toolID)) {
+		t.Fatalf("error does not quote the tool ID: %q", err)
+	}
+}
+
+func TestDescribeCommandEscapesFlagParserErrors(t *testing.T) {
+	// Given
+	root := NewRootCommand()
+	toolID := "--bad\x1b[31m"
+
+	// When
+	_, _, err := executeTestCommand(t, root, "describe", toolID)
+
+	// Then
+	if err == nil {
+		t.Fatal("expected flag parser error")
+	}
+	if strings.Contains(err.Error(), "\x1b") {
+		t.Fatalf("error contains a terminal escape: %q", err)
+	}
+	if !strings.Contains(err.Error(), `\x1b`) {
+		t.Fatalf("error does not escape the terminal control: %q", err)
+	}
+}
+
+func TestDescribeCommandCompletesToolIDs(t *testing.T) {
+	// Given
+	cmd := newDescribeCommand(&rootOptions{})
+
+	// When
+	got, directive := cmd.ValidArgsFunction(cmd, nil, "kube")
+
+	// Then
+	if directive == 0 {
+		t.Fatal("expected a completion directive")
+	}
+	found := false
+	for _, candidate := range got {
+		if strings.HasPrefix(candidate, "kubectl\t") {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("kubectl completion missing: %#v", got)
+	}
+}
+
+func TestRootCommandIncludesDescribe(t *testing.T) {
+	// Given
+	root := NewRootCommand()
+
+	// When
+	cmd, _, err := root.Find([]string{"describe"})
+
+	// Then
+	if err != nil {
+		t.Fatalf("find describe command: %v", err)
+	}
+	if cmd.Name() != "describe" {
+		t.Fatalf("command name = %q, want describe", cmd.Name())
+	}
+}

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -77,6 +77,7 @@ Environment:
 	}
 
 	cmd.AddCommand(newStatusCommand(opts, runner))
+	cmd.AddCommand(newDescribeCommand(opts))
 	cmd.AddCommand(newDiagnoseCommand(opts, runner))
 	cmd.AddCommand(newDoctorCommand(opts, runner))
 	cmd.AddCommand(newFixCommand(opts, runner))
@@ -107,7 +108,7 @@ Environment:
 func setSubcommandGroups(root *cobra.Command) {
 	for _, c := range root.Commands() {
 		switch c.Name() {
-		case "status", "diagnose", "doctor", "fix", "snapshot", "diff":
+		case "status", "describe", "diagnose", "doctor", "fix", "snapshot", "diff":
 			c.GroupID = "primary"
 		case "aws", "aliyun", "wrangler":
 			c.GroupID = "cloud"


### PR DESCRIPTION
This PR adds `all-cli describe <tool>`, a fast, read-only way to inspect a tracked CLI's purpose, configuration criteria, context capabilities, current-field meanings, and agent actions without executing that tool. It is worth merging because the metadata already makes JSON status useful for agents; this command turns the same catalog into a discoverable, pleasant human workflow with shell completion and structured output.

## What changed

- Added human-readable and `--json` descriptions backed by the existing registry metadata.
- Added sorted shell completion for tool IDs with purpose descriptions.
- Added clear arity and unknown-tool errors, including terminal-safe quoting for control-bearing ordinary and flag-shaped inputs.
- Registered `describe` in the Primary command group and documented it in a dedicated README section.
- Added command-level coverage for text, JSON, errors, parser-boundary escaping, completion, and root wiring.

## Verification

- `just check`
- `just build`
- Real CLI text, JSON, help, completion, arity, and hostile-input scenarios
- All 46 registry IDs via `describe --json` with `PATH=/nonexistent`
- Five-lane review gate plus independent Go runtime audit: PASS on `bdb5339ef56b1e397cb7a2285ccb6a8293597e0d`
- Virtual merge with open Happy Hour PR #15: clean

Known repository baseline: CI's `golangci-lint` currently reports pre-existing staticcheck S1016 at `internal/tools/docker/adapter.go:246`; this PR does not touch that file. Tidy, formatting, vet, full tests, and race tests pass.

## Impact

The change is additive and limited to the CLI command layer, tests, root registration, and README. It adds no dependencies, shared refactor, schema change, configuration, infrastructure, external execution, or machine-state mutation.

## Rollback

Revert commit `bdb5339ef56b1e397cb7a2285ccb6a8293597e0d`; no migration or cleanup is required.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
  - 新增 `describe <tool>` 命令，可查看已跟踪工具的用途、配置条件、能力、当前字段、Agent 操作及备注。
  - 支持人类可读文本和 `--json` 输出格式。
  - 提供工具 ID 的 Shell 自动补全，并对未知工具和无效参数显示错误信息。

- **文档**
  - 补充 `describe` 命令及其 JSON 选项的使用说明。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->