### PR TITLE
feat(cli): show current contexts at a glance

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,15 @@ all-cli current
 all-cli current --json
 ```
 
+Example text output:
+
+```text
+TOOL     CURRENT
+aws      profile=work region=us-west-2
+docker   context=desktop-linux
+railway  none
+```
+
 ### Agent diagnostics
 
 `all-cli diagnose` turns the same status facts into agent-readable diagnostic items with severity, evidence, suggested actions, autofix safety, and related tool IDs.

--- a/README.md
+++ b/README.md
@@ -108,6 +108,16 @@ all-cli status --sort category-desc
 all-cli status --timeout 10s
 ```
 
+### Current contexts at a glance
+
+`all-cli current` shows the active accounts, clusters, projects, and environments
+reported by every installed context-aware tool in one compact view.
+
+```bash
+all-cli current
+all-cli current --json
+```
+
 ### Agent diagnostics
 
 `all-cli diagnose` turns the same status facts into agent-readable diagnostic items with severity, evidence, suggested actions, autofix safety, and related tool IDs.

--- a/internal/cli/current.go
+++ b/internal/cli/current.go
@@ -1,0 +1,57 @@
+package cli
+
+import (
+	"github.com/oldwinter/all-cli/internal/diagnose"
+	"github.com/oldwinter/all-cli/internal/execx"
+	"github.com/oldwinter/all-cli/internal/output"
+	"github.com/oldwinter/all-cli/internal/tools"
+	"github.com/spf13/cobra"
+)
+
+func newCurrentCommand(opts *rootOptions, runner execx.Runner) *cobra.Command {
+	return &cobra.Command{
+		Use:   "current",
+		Short: "Show current contexts across installed CLI tools",
+		Long: `Shows one compact view of the active accounts, clusters, projects, and
+environments reported by installed tools that expose context-like state.`,
+		Example: `  all-cli current
+  all-cli current --json`,
+		Args: cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			registry := defaultRegistry()
+			contextRegistry := make([]tools.ToolDefinition, 0, len(registry))
+			for _, definition := range registry {
+				if definition.Capabilities.HasContexts {
+					contextRegistry = append(contextRegistry, definition)
+				}
+			}
+
+			var spinner *progressSpinner
+			if !opts.JSON && showStatusSpinner() {
+				spinner = newProgressSpinner(cmd.ErrOrStderr(), len(contextRegistry))
+				spinner.Start()
+			}
+
+			report := evaluateStatusRegistry(cmd.Context(), contextRegistry, runner, opts.Timeout, spinner)
+			if spinner != nil {
+				spinner.Stop()
+			}
+
+			installed := report.Tools[:0]
+			for _, tool := range report.Tools {
+				if tool.Installed {
+					installed = append(installed, tool)
+				}
+			}
+			report.Tools = installed
+			sortToolSummaries(report.Tools, statusSortTool)
+
+			if opts.JSON {
+				report.Diagnostics = diagnose.Generate(report, diagnose.Options{Profile: diagnose.ProfileAgent}).Diagnostics
+				return output.PrintJSON(cmd.OutOrStdout(), report)
+			}
+			output.PrintCurrentTable(cmd.OutOrStdout(), report)
+			return nil
+		},
+	}
+}

--- a/internal/cli/current_test.go
+++ b/internal/cli/current_test.go
@@ -1,0 +1,118 @@
+package cli
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/oldwinter/all-cli/internal/execx"
+	"github.com/oldwinter/all-cli/internal/model"
+	"github.com/oldwinter/all-cli/internal/tools"
+)
+
+func TestCurrentCommand_shows_current_contexts_for_installed_context_tools(t *testing.T) {
+	// Given
+	stubStatusRegistry(t, []tools.ToolDefinition{
+		{ID: "aws", Category: "cloud", Binary: "aws", Capabilities: model.Capability{HasContexts: true}},
+		{ID: "fd", Category: "navigation", Binary: "fd"},
+		{ID: "kubectl", Category: "k8s", Binary: "kubectl", Capabilities: model.Capability{HasContexts: true}},
+	})
+	var evaluatedNonContext atomic.Bool
+	oldEvaluate := evaluateToolSummary
+	evaluateToolSummary = func(_ context.Context, def tools.ToolDefinition, _ execx.Runner) model.ToolSummary {
+		switch def.ID {
+		case "aws":
+			return model.ToolSummary{
+				ID:           "aws",
+				Installed:    true,
+				Capabilities: def.Capabilities,
+				Current:      map[string]string{"region": "us-west-2", "profile": "work"},
+			}
+		case "fd":
+			evaluatedNonContext.Store(true)
+		case "kubectl":
+			return model.ToolSummary{ID: "kubectl", Capabilities: def.Capabilities}
+		}
+		return model.ToolSummary{ID: def.ID, Capabilities: def.Capabilities}
+	}
+	t.Cleanup(func() { evaluateToolSummary = oldEvaluate })
+	stubShowStatusSpinner(t, false)
+
+	// When
+	stdout, stderr, err := executeTestCommand(t, newCurrentCommand(&rootOptions{Timeout: time.Second}, cliFakeRunner{}))
+
+	// Then
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if stderr != "" {
+		t.Fatalf("expected empty stderr, got %q", stderr)
+	}
+	if evaluatedNonContext.Load() {
+		t.Fatal("expected tools without context support to be skipped")
+	}
+	if !strings.Contains(stdout, "TOOL  CURRENT") || !strings.Contains(stdout, "aws   profile=work region=us-west-2") {
+		t.Fatalf("expected compact current overview, got:\n%s", stdout)
+	}
+	if strings.Contains(stdout, "fd") || strings.Contains(stdout, "kubectl") {
+		t.Fatalf("expected non-context and uninstalled tools to be hidden, got:\n%s", stdout)
+	}
+}
+
+func TestCurrentCommand_JSON_preserves_status_report_shape(t *testing.T) {
+	// Given
+	stubStatusRegistry(t, []tools.ToolDefinition{
+		{ID: "docker", Category: "containers", Binary: "docker", Capabilities: model.Capability{HasContexts: true, CanSwitch: true}},
+	})
+	oldEvaluate := evaluateToolSummary
+	evaluateToolSummary = func(_ context.Context, def tools.ToolDefinition, _ execx.Runner) model.ToolSummary {
+		return model.ToolSummary{
+			ID:              def.ID,
+			Category:        def.Category,
+			Installed:       true,
+			ConfiguredState: model.ConfiguredYes,
+			Configured:      true,
+			Capabilities:    def.Capabilities,
+			Current:         map[string]string{"context": "desktop-linux"},
+		}
+	}
+	t.Cleanup(func() { evaluateToolSummary = oldEvaluate })
+	stubShowStatusSpinner(t, false)
+
+	// When
+	stdout, _, err := executeTestCommand(t, newCurrentCommand(&rootOptions{JSON: true, Timeout: time.Second}, cliFakeRunner{}))
+
+	// Then
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	var got model.StatusReport
+	if err := json.Unmarshal([]byte(stdout), &got); err != nil {
+		t.Fatalf("decode json: %v", err)
+	}
+	if got.SchemaVersion != model.SchemaVersionV01 || got.Legend.Current == "" || got.GeneratedAt.IsZero() {
+		t.Fatalf("expected status report metadata, got %#v", got)
+	}
+	if len(got.Tools) != 1 || got.Tools[0].ID != "docker" || got.Tools[0].Current["context"] != "desktop-linux" {
+		t.Fatalf("unexpected tools payload: %#v", got.Tools)
+	}
+}
+
+func TestRoot_registers_current_as_primary_command(t *testing.T) {
+	// Given
+	root := NewRootCommand()
+
+	// When
+	current, _, err := root.Find([]string{"current"})
+
+	// Then
+	if err != nil {
+		t.Fatalf("find current command: %v", err)
+	}
+	if current.Name() != "current" || current.GroupID != "primary" {
+		t.Fatalf("unexpected current command registration: name=%q group=%q", current.Name(), current.GroupID)
+	}
+}

--- a/internal/cli/current_test.go
+++ b/internal/cli/current_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/oldwinter/all-cli/internal/tools"
 )
 
-func TestCurrentCommand_shows_current_contexts_for_installed_context_tools(t *testing.T) {
+func TestCurrentCommandShowsCurrentContextsForInstalledContextTools(t *testing.T) {
 	// Given
 	stubStatusRegistry(t, []tools.ToolDefinition{
 		{ID: "aws", Category: "cloud", Binary: "aws", Capabilities: model.Capability{HasContexts: true}},
@@ -62,7 +62,7 @@ func TestCurrentCommand_shows_current_contexts_for_installed_context_tools(t *te
 	}
 }
 
-func TestCurrentCommand_JSON_preserves_status_report_shape(t *testing.T) {
+func TestCurrentCommandJSONPreservesStatusReportShape(t *testing.T) {
 	// Given
 	stubStatusRegistry(t, []tools.ToolDefinition{
 		{ID: "docker", Category: "containers", Binary: "docker", Capabilities: model.Capability{HasContexts: true, CanSwitch: true}},
@@ -101,7 +101,7 @@ func TestCurrentCommand_JSON_preserves_status_report_shape(t *testing.T) {
 	}
 }
 
-func TestRoot_registers_current_as_primary_command(t *testing.T) {
+func TestRootRegistersCurrentAsPrimaryCommand(t *testing.T) {
 	// Given
 	root := NewRootCommand()
 

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -77,6 +77,7 @@ Environment:
 	}
 
 	cmd.AddCommand(newStatusCommand(opts, runner))
+	cmd.AddCommand(newCurrentCommand(opts, runner))
 	cmd.AddCommand(newDiagnoseCommand(opts, runner))
 	cmd.AddCommand(newDoctorCommand(opts, runner))
 	cmd.AddCommand(newFixCommand(opts, runner))
@@ -107,7 +108,7 @@ Environment:
 func setSubcommandGroups(root *cobra.Command) {
 	for _, c := range root.Commands() {
 		switch c.Name() {
-		case "status", "diagnose", "doctor", "fix", "snapshot", "diff":
+		case "status", "current", "diagnose", "doctor", "fix", "snapshot", "diff":
 			c.GroupID = "primary"
 		case "aws", "aliyun", "wrangler":
 			c.GroupID = "cloud"

--- a/internal/output/current_table.go
+++ b/internal/output/current_table.go
@@ -1,0 +1,29 @@
+package output
+
+import (
+	"fmt"
+	"io"
+	"text/tabwriter"
+
+	"github.com/oldwinter/all-cli/internal/model"
+)
+
+func PrintCurrentTable(w io.Writer, report model.StatusReport) {
+	if len(report.Tools) == 0 {
+		fmt.Fprintln(w, "No installed context-aware tools found.")
+		return
+	}
+
+	tw := tabwriter.NewWriter(w, 0, 4, 2, ' ', 0)
+	fmt.Fprintln(tw, "TOOL\tCURRENT")
+	for _, tool := range report.Tools {
+		current := formatCurrentSummary(tool)
+		if current == "" {
+			current = "none"
+		}
+		fmt.Fprintf(tw, "%s\t%s\n", tool.ID, current)
+	}
+	_ = tw.Flush()
+
+	printStatusDiagnostics(w, report)
+}

--- a/internal/output/current_table_test.go
+++ b/internal/output/current_table_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/oldwinter/all-cli/internal/model"
 )
 
-func TestPrintCurrentTable_shows_none_when_context_is_empty(t *testing.T) {
+func TestPrintCurrentTableShowsNoneWhenContextIsEmpty(t *testing.T) {
 	// Given
 	report := model.StatusReport{
 		Tools: []model.ToolSummary{{ID: "mise", Installed: true}},
@@ -24,7 +24,7 @@ func TestPrintCurrentTable_shows_none_when_context_is_empty(t *testing.T) {
 	}
 }
 
-func TestPrintCurrentTable_explains_when_no_context_tools_are_installed(t *testing.T) {
+func TestPrintCurrentTableExplainsWhenNoContextToolsAreInstalled(t *testing.T) {
 	// Given
 	report := model.StatusReport{}
 	var out bytes.Buffer

--- a/internal/output/current_table_test.go
+++ b/internal/output/current_table_test.go
@@ -1,0 +1,39 @@
+package output
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/oldwinter/all-cli/internal/model"
+)
+
+func TestPrintCurrentTable_shows_none_when_context_is_empty(t *testing.T) {
+	// Given
+	report := model.StatusReport{
+		Tools: []model.ToolSummary{{ID: "mise", Installed: true}},
+	}
+	var out bytes.Buffer
+
+	// When
+	PrintCurrentTable(&out, report)
+
+	// Then
+	if !strings.Contains(out.String(), "mise  none") {
+		t.Fatalf("expected explicit empty context, got:\n%s", out.String())
+	}
+}
+
+func TestPrintCurrentTable_explains_when_no_context_tools_are_installed(t *testing.T) {
+	// Given
+	report := model.StatusReport{}
+	var out bytes.Buffer
+
+	// When
+	PrintCurrentTable(&out, report)
+
+	// Then
+	if got := out.String(); got != "No installed context-aware tools found.\n" {
+		t.Fatalf("unexpected empty overview: %q", got)
+	}
+}


### PR DESCRIPTION
This PR adds `all-cli current`, a compact read-only overview of the active accounts, clusters, projects, and environments reported by every installed context-aware CLI. It feels worth merging because `all-cli` already knows these contexts, but today users must scan the broad status table or run several per-tool commands; this turns that existing knowledge into one calm, memorable command for answering “where am I operating right now?” without changing any machine state.

## What changed

- Added the top-level `current` command in the Primary command group.
- Evaluates only registry tools with `has_contexts`, then hides tools that are not installed.
- Renders deterministic `TOOL / CURRENT` text output with explicit `none` values and preserved warnings/errors.
- Reuses the existing `StatusReport` contract for `--json`, including additive diagnostics.
- Documented text/JSON workflows with representative output and added focused command/output tests.
- Addressed review feedback by aligning test names with the repository's `TestXxx` convention.

## Verification

- `just check`
- `just build`
- `go test -race -shuffle=on -count=1 ./...`
- TDD red/green: focused packages first failed on missing `newCurrentCommand` and `PrintCurrentTable`, then passed after implementation.
- Real CLI text and JSON on installed tools, including diagnostics and deterministic current fields.
- `jq` assertion over real JSON: schema `v0.1`, current legend present, tools array contains only installed context-aware tools.
- Real empty-PATH text and JSON states.
- Real help, unexpected-argument, zero/negative-timeout, `NO_COLOR`, and CI-spinner scenarios.
- Regression smoke for `version`, `status`, and `diagnose`.
- Hands-on QA: 20/20 surface scenarios and 7/7 adversarial cases passed.
- Five-lane review plus independent Go runtime audit: PASS on `c033d73e1dfe8418d0c0de6f324a1181bb243b62`.
- Review-feedback delta verified by full `just check`, build, real text/JSON/help, and focused tests on `32bde7c`.
- Remote functional QA, CodeRabbit pre-merge checks, and GitGuardian: PASS before the feedback update.

Known repository baseline: CI's `golangci-lint` reports pre-existing staticcheck S1016 at `internal/tools/docker/adapter.go:246`; this PR does not touch that file. Local lint on the final branch reproduces only that exact unchanged finding. This is the same baseline already documented by PR #16.

## Impact

The change is additive and limited to CLI wiring, a small renderer, tests, and README documentation. It adds no dependencies, schema changes, shared refactors, configuration, infrastructure, CI, deployment, permissions, secrets, or machine-state mutation.

Related: #15, #16. These features are complementary. If either lands first, retain both the category/current README sections and both `current`/`describe` root registrations while resolving adjacent-line conflicts.

No open issue is closed by this change.

## Rollback

Revert commits `32bde7c` and `c033d73`; no migration or cleanup is required.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新功能**
  * 新增 `current` 命令，集中查看已安装工具报告的当前账户、集群、项目和环境。
  * 支持普通表格输出及 JSON 输出，便于快速查看或进一步处理状态信息。
  * 无可用上下文工具或上下文为空时，提供清晰的提示信息。
  * 支持在执行状态检查时显示进度指示器。

* **文档**
  * 新增使用说明、输出格式及示例，帮助用户快速了解 `current` 命令。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->