### PR TITLE
feat(cli): add searchable tool catalog

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,6 +215,16 @@ Example shape:
 
 ### Tool descriptions
 
+Use `all-cli catalog` to browse every tracked tool without running any external
+commands. Add an optional search term to match tool IDs, names, categories,
+binary names, and purposes:
+
+```bash
+all-cli catalog
+all-cli catalog kubernetes
+all-cli catalog cloud --json
+```
+
 Use `all-cli describe <tool>` to inspect the built-in purpose, configuration
 criteria, context capabilities, and agent actions without running the tool:
 

--- a/internal/cli/catalog.go
+++ b/internal/cli/catalog.go
@@ -1,0 +1,101 @@
+package cli
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+	"text/tabwriter"
+
+	"github.com/oldwinter/all-cli/internal/output"
+	"github.com/oldwinter/all-cli/internal/tools"
+	"github.com/spf13/cobra"
+)
+
+type catalogTool struct {
+	ID          string `json:"id"`
+	DisplayName string `json:"display_name"`
+	Category    string `json:"category"`
+	Binary      string `json:"binary"`
+	Purpose     string `json:"purpose"`
+}
+
+type catalogReport struct {
+	Query string        `json:"query,omitempty"`
+	Count int           `json:"count"`
+	Tools []catalogTool `json:"tools"`
+}
+
+func newCatalogCommand(opts *rootOptions) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "catalog [search]",
+		Short: "Browse and search tracked CLI tools",
+		Long: `Lists the built-in tool catalog without running external commands. An optional
+search term matches tool IDs, names, categories, binary names, and purposes.`,
+		Example: `  all-cli catalog
+  all-cli catalog kubernetes
+  all-cli catalog cloud --json`,
+		Args: cobra.MaximumNArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			query := ""
+			if len(args) == 1 {
+				query = args[0]
+			}
+			report := buildCatalogReport(query)
+			if opts.JSON {
+				return output.PrintJSON(cmd.OutOrStdout(), report)
+			}
+			if report.Count == 0 {
+				fmt.Fprintf(cmd.OutOrStdout(), "No tracked tools match %q.\n", query)
+				return nil
+			}
+
+			w := tabwriter.NewWriter(cmd.OutOrStdout(), 0, 4, 2, ' ', 0)
+			fmt.Fprintln(w, "CATEGORY\tTOOL\tBINARY\tPURPOSE")
+			for _, tool := range report.Tools {
+				fmt.Fprintf(w, "%s\t%s\t%s\t%s\n", tool.Category, tool.ID, tool.Binary, tool.Purpose)
+			}
+			return w.Flush()
+		},
+		ValidArgsFunction: func(_ *cobra.Command, _ []string, _ string) ([]string, cobra.ShellCompDirective) {
+			return nil, cobra.ShellCompDirectiveNoFileComp
+		},
+	}
+	return cmd
+}
+
+func buildCatalogReport(query string) catalogReport {
+	normalizedQuery := strings.ToLower(strings.TrimSpace(query))
+	registry := tools.DefaultRegistry()
+	entries := make([]catalogTool, 0, len(registry))
+	for _, def := range registry {
+		metadata := tools.MetadataForTool(def.ID)
+		entry := catalogTool{
+			ID:          def.ID,
+			DisplayName: def.DisplayName,
+			Category:    def.Category,
+			Binary:      def.Binary,
+			Purpose:     metadata.Purpose,
+		}
+		if normalizedQuery != "" && !catalogToolMatches(entry, normalizedQuery) {
+			continue
+		}
+		entries = append(entries, entry)
+	}
+	sort.Slice(entries, func(i, j int) bool {
+		if entries[i].Category != entries[j].Category {
+			return entries[i].Category < entries[j].Category
+		}
+		return entries[i].ID < entries[j].ID
+	})
+	return catalogReport{Query: query, Count: len(entries), Tools: entries}
+}
+
+func catalogToolMatches(tool catalogTool, query string) bool {
+	searchable := []string{tool.ID, tool.DisplayName, tool.Category, tool.Binary, tool.Purpose}
+	for _, value := range searchable {
+		if strings.Contains(strings.ToLower(value), query) {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/cli/catalog_test.go
+++ b/internal/cli/catalog_test.go
@@ -1,0 +1,109 @@
+package cli
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+func TestCatalogCommandListsTrackedTools(t *testing.T) {
+	// Given
+	opts := &rootOptions{}
+
+	// When
+	stdout, stderr, err := executeTestCommand(t, newCatalogCommand(opts))
+
+	// Then
+	if err != nil {
+		t.Fatalf("catalog: %v", err)
+	}
+	if stderr != "" {
+		t.Fatalf("stderr = %q, want empty", stderr)
+	}
+	for _, want := range []string{
+		"CATEGORY",
+		"TOOL",
+		"BINARY",
+		"PURPOSE",
+		"k8s",
+		"kubectl",
+		"Kubernetes CLI",
+	} {
+		if !strings.Contains(stdout, want) {
+			t.Fatalf("stdout missing %q:\n%s", want, stdout)
+		}
+	}
+}
+
+func TestCatalogCommandSearchesToolMetadata(t *testing.T) {
+	// Given
+	opts := &rootOptions{JSON: true}
+
+	// When
+	stdout, stderr, err := executeTestCommand(t, newCatalogCommand(opts), "GITLAB")
+
+	// Then
+	if err != nil {
+		t.Fatalf("catalog GITLAB --json: %v", err)
+	}
+	if stderr != "" {
+		t.Fatalf("stderr = %q, want empty", stderr)
+	}
+	var got struct {
+		Query string `json:"query"`
+		Count int    `json:"count"`
+		Tools []struct {
+			ID       string `json:"id"`
+			Category string `json:"category"`
+			Binary   string `json:"binary"`
+			Purpose  string `json:"purpose"`
+		} `json:"tools"`
+	}
+	if err := json.Unmarshal([]byte(stdout), &got); err != nil {
+		t.Fatalf("decode catalog json: %v", err)
+	}
+	if got.Query != "GITLAB" || got.Count != 1 || len(got.Tools) != 1 {
+		t.Fatalf("unexpected catalog summary: %#v", got)
+	}
+	if got.Tools[0].ID != "glab" || got.Tools[0].Category != "code" || got.Tools[0].Binary != "glab" {
+		t.Fatalf("unexpected search result: %#v", got.Tools[0])
+	}
+	if !strings.Contains(strings.ToLower(got.Tools[0].Purpose), "gitlab") {
+		t.Fatalf("purpose does not explain search match: %q", got.Tools[0].Purpose)
+	}
+}
+
+func TestCatalogCommandExplainsNoMatches(t *testing.T) {
+	// Given
+	opts := &rootOptions{}
+
+	// When
+	stdout, stderr, err := executeTestCommand(t, newCatalogCommand(opts), "not-a-real-tool")
+
+	// Then
+	if err != nil {
+		t.Fatalf("catalog no match: %v", err)
+	}
+	if stderr != "" {
+		t.Fatalf("stderr = %q, want empty", stderr)
+	}
+	if got, want := stdout, "No tracked tools match \"not-a-real-tool\".\n"; got != want {
+		t.Fatalf("stdout = %q, want %q", got, want)
+	}
+}
+
+func TestRootCommandIncludesCatalog(t *testing.T) {
+	// Given
+	root := NewRootCommand()
+
+	// When
+	catalog, _, err := root.Find([]string{"catalog"})
+
+	// Then
+	if err != nil {
+		t.Fatalf("find catalog command: %v", err)
+	}
+	if catalog.Name() != "catalog" || catalog.GroupID != "primary" {
+		t.Fatalf("unexpected catalog command registration: name=%q group=%q", catalog.Name(), catalog.GroupID)
+	}
+}

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -78,6 +78,7 @@ Environment:
 
 	cmd.AddCommand(newStatusCommand(opts, runner))
 	cmd.AddCommand(newCurrentCommand(opts, runner))
+	cmd.AddCommand(newCatalogCommand(opts))
 	cmd.AddCommand(newDescribeCommand(opts))
 	cmd.AddCommand(newDiagnoseCommand(opts, runner))
 	cmd.AddCommand(newDoctorCommand(opts, runner))
@@ -109,7 +110,7 @@ Environment:
 func setSubcommandGroups(root *cobra.Command) {
 	for _, c := range root.Commands() {
 		switch c.Name() {
-		case "status", "current", "describe", "diagnose", "doctor", "fix", "snapshot", "diff":
+		case "status", "current", "catalog", "describe", "diagnose", "doctor", "fix", "snapshot", "diff":
 			c.GroupID = "primary"
 		case "aws", "aliyun", "wrangler":
 			c.GroupID = "cloud"


### PR DESCRIPTION
This PR builds `all-cli catalog [search]`, a static, searchable directory of every CLI tracked by all-cli, with readable table output and structured JSON. It feels worth merging because the project now has a natural discovery path: users can browse what all-cli knows, search by tool, category, binary, or purpose, then use `describe` when they want the details, all without invoking any external tool.

## What changed

- Added `all-cli catalog` to list the built-in registry by category.
- Added optional case-insensitive search across tool IDs, display names, categories, binary names, and purposes.
- Added `--json` output with the original query, match count, and structured tool entries.
- Added deterministic category/tool ordering, an informative no-match result, help registration, tests, and README examples.

## Verification

- `just check`
- `just build`
- Red-to-green targeted tests for catalog behavior and root registration
- Real CLI QA: full catalog, field-based searches, case/whitespace/Unicode/special inputs, JSON, no-match, invalid arguments, help, and existing command regressions
- PATH trap confirmed catalog does not execute tracked tools
- Five-lane review gate passed at `5cc45712027cd89d6a518a5f2e4ff530d3791b03`: goal, hands-on QA, code quality, security, and context history

## Impact

The change is additive and limited to a new read-only primary command, its root registration, tests, and documentation. It adds no dependencies, schemas, configuration, infrastructure, or machine-state mutation, and it does not execute registered tool adapters.

## Rollback

Revert commit `5cc45712027cd89d6a518a5f2e4ff530d3791b03`. No migration, configuration cleanup, or external state rollback is required.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新功能**
  * 新增 `catalog` 命令，可浏览所有已追踪工具。
  * 支持按工具 ID、名称、类别、二进制名称和用途搜索。
  * 支持表格和 JSON 输出，并提供无匹配结果提示。
  * 新增 Shell 补全支持配置及相关使用说明。

* **测试**
  * 新增目录展示、搜索、无结果提示和命令注册的覆盖测试。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->