### PR TITLE
feat(cli): complete tool filter values

### DIFF
--- a/internal/cli/completion.go
+++ b/internal/cli/completion.go
@@ -2,9 +2,83 @@ package cli
 
 import (
 	"fmt"
+	"io"
+	"sort"
+	"strings"
+	"unicode"
 
+	"github.com/oldwinter/all-cli/internal/tools"
 	"github.com/spf13/cobra"
 )
+
+func registerToolFilterCompletions(root *cobra.Command) {
+	for _, cmd := range root.Commands() {
+		if cmd.Flags().Lookup("tools") == nil {
+			continue
+		}
+		if err := cmd.RegisterFlagCompletionFunc("tools", completeToolFilter); err != nil {
+			panic(fmt.Sprintf("register --tools completion for %s: %v", cmd.CommandPath(), err))
+		}
+	}
+}
+
+func completeToolFilter(_ *cobra.Command, _ []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+	prefix := ""
+	fragment := toComplete
+	selected := map[string]bool{}
+	if comma := strings.LastIndex(toComplete, ","); comma >= 0 {
+		suffix := toComplete[comma+1:]
+		fragment = strings.TrimLeftFunc(suffix, unicode.IsSpace)
+		prefix = toComplete[:len(toComplete)-len(fragment)]
+		fragment = strings.TrimSpace(fragment)
+		for _, id := range strings.Split(toComplete[:comma], ",") {
+			selected[strings.TrimSpace(id)] = true
+		}
+	}
+
+	candidates := make([]string, 0)
+	for _, def := range tools.DefaultRegistry() {
+		if !selected[def.ID] && strings.HasPrefix(def.ID, fragment) {
+			candidates = append(candidates, prefix+def.ID)
+		}
+	}
+	sort.Strings(candidates)
+	return candidates, cobra.ShellCompDirectiveNoFileComp | cobra.ShellCompDirectiveNoSpace
+}
+
+func writePatchedCompletion(cmd *cobra.Command, generate func(io.Writer) error, replacements ...string) error {
+	var script strings.Builder
+	if err := generate(&script); err != nil {
+		return err
+	}
+
+	// Cobra v1.10.2 re-evaluates unquoted args, splitting quoted flag values.
+	completion := script.String()
+	for i := 0; i < len(replacements); i += 2 {
+		patched := strings.Replace(completion, replacements[i], replacements[i+1], 1)
+		if patched == completion {
+			return fmt.Errorf("patch completion argument quoting")
+		}
+		completion = patched
+	}
+	_, err := cmd.OutOrStdout().Write([]byte(completion))
+	return err
+}
+
+func writeBashCompletion(cmd *cobra.Command) error {
+	const unquotedRequest = `requestComp="${words[0]} __completeNoDesc ${args[*]}"`
+	const quotedRequest = `printf -v requestComp '%q ' "${words[0]}" __completeNoDesc "${args[@]}"`
+	generate := func(w io.Writer) error { return cmd.Root().GenBashCompletionV2(w, false) }
+	return writePatchedCompletion(cmd, generate, unquotedRequest, quotedRequest)
+}
+
+func writeZshCompletion(cmd *cobra.Command) error {
+	const splitWords = `words=("${=words[1,CURRENT]}")`
+	const quotedWords = `words=("${words[@]:0:$CURRENT}")`
+	const unquotedRequest = `requestComp="${words[1]} __complete ${words[2,-1]}"`
+	const quotedRequest = `printf -v requestComp '%q ' "${words[1]}" __complete "${words[@]:1}"`
+	return writePatchedCompletion(cmd, cmd.Root().GenZshCompletion, splitWords, quotedWords, unquotedRequest, quotedRequest)
+}
 
 func newCompletionCommand() *cobra.Command {
 	return &cobra.Command{
@@ -31,9 +105,9 @@ To load completions:
 		RunE: func(cmd *cobra.Command, args []string) error {
 			switch args[0] {
 			case "bash":
-				return cmd.Root().GenBashCompletion(cmd.OutOrStdout())
+				return writeBashCompletion(cmd)
 			case "zsh":
-				return cmd.Root().GenZshCompletion(cmd.OutOrStdout())
+				return writeZshCompletion(cmd)
 			case "fish":
 				return cmd.Root().GenFishCompletion(cmd.OutOrStdout(), true)
 			case "powershell":

--- a/internal/cli/completion_test.go
+++ b/internal/cli/completion_test.go
@@ -1,8 +1,14 @@
 package cli
 
 import (
+	"context"
+	"os"
+	"os/exec"
 	"strings"
 	"testing"
+	"time"
+
+	"github.com/spf13/cobra"
 )
 
 func TestCompletionCommandGeneratesScripts(t *testing.T) {
@@ -28,5 +34,181 @@ func TestCompletionCommandRejectsUnsupportedShell(t *testing.T) {
 	err := cmd.RunE(cmd, []string{"unknown"})
 	if err == nil || !strings.Contains(err.Error(), "unsupported shell: unknown") {
 		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func runShellCompletionProbe(t *testing.T, shell string, args []string, probe string) string {
+	t.Helper()
+	path, err := exec.LookPath(shell)
+	if err != nil {
+		t.Skipf("%s is not available", shell)
+	}
+	sentinel := t.TempDir() + "/executed"
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, path, args...)
+	cmd.Env = append(os.Environ(), "COMPLETION_SENTINEL="+sentinel)
+	cmd.Stdin = strings.NewReader(probe)
+	output, err := cmd.CombinedOutput()
+	if ctx.Err() == context.DeadlineExceeded {
+		t.Fatalf("generated %s completion timed out\n%s", shell, output)
+	}
+	if err != nil {
+		t.Fatalf("run generated %s completion: %v\n%s", shell, err, output)
+	}
+	if _, err := os.Stat(sentinel); !os.IsNotExist(err) {
+		t.Fatalf("generated %s completion executed input: %v", shell, err)
+	}
+	return strings.TrimSpace(string(output))
+}
+
+func TestBashCompletionHandlesWhitespaceInCandidates(t *testing.T) {
+	completion, stderr, err := executeTestCommand(t, NewRootCommand(), "completion", "bash")
+	if err != nil {
+		t.Fatalf("generate bash completion: %v", err)
+	}
+	if stderr != "" {
+		t.Fatalf("expected empty stderr, got %q", stderr)
+	}
+
+	probe := completion + `
+all-cli() {
+  if [[ "$#" -ne 4 || "$1" != '__completeNoDesc' || "$4" != 'kubectl, do' ]]; then
+    return 1
+  fi
+  printf 'kubectl, docker\n:6\n'
+}
+compopt() { :; }
+_init_completion() {
+  cur="${COMP_WORDS[COMP_CWORD]}"
+  prev="${COMP_WORDS[COMP_CWORD-1]}"
+  words=("${COMP_WORDS[@]}")
+  cword="$COMP_CWORD"
+}
+COMP_WORDS=(all-cli status --tools 'kubectl, do')
+COMP_CWORD=3
+COMP_LINE='all-cli status --tools kubectl, do'
+COMP_POINT=${#COMP_LINE}
+COMPREPLY=()
+__start_all-cli
+printf '%s\n' "${COMPREPLY[@]}"
+COMP_WORDS=(all-cli status --tools 'kubectl,$(touch "$COMPLETION_SENTINEL")')
+COMP_LINE='all-cli status --tools hostile'
+COMP_POINT=${#COMP_LINE}
+COMPREPLY=()
+__start_all-cli
+`
+	if got := runShellCompletionProbe(t, "bash", []string{"-s"}, probe); !strings.Contains(got, "docker") {
+		t.Fatalf("bash completion = %q, want a docker candidate", got)
+	}
+}
+
+func TestZshCompletionHandlesWhitespaceInCandidates(t *testing.T) {
+	completion, stderr, err := executeTestCommand(t, NewRootCommand(), "completion", "zsh")
+	if err != nil {
+		t.Fatalf("generate zsh completion: %v", err)
+	}
+	if stderr != "" {
+		t.Fatalf("expected empty stderr, got %q", stderr)
+	}
+
+	probe := `compdef() { : }
+` + completion + `
+all-cli() {
+  if [[ "$#" -ne 4 || "$1" != '__complete' || "$4" != 'kubectl, do' ]]; then
+    return 1
+  fi
+  print -r -- 'kubectl, docker'
+  print -r -- ':6'
+}
+_describe() { print -r -- "${completions[@]}"; return 0 }
+words=(all-cli status --tools 'kubectl, do')
+CURRENT=4
+_all-cli
+words=(all-cli status --tools 'kubectl,$(touch "$COMPLETION_SENTINEL")')
+CURRENT=4
+_all-cli
+`
+	if got := runShellCompletionProbe(t, "zsh", []string{"-f"}, probe); !strings.Contains(got, "docker") {
+		t.Fatalf("zsh completion = %q, want a docker candidate", got)
+	}
+}
+
+func TestToolFilterFlagsCompleteToolIDs(t *testing.T) {
+	commands := []string{"status", "diagnose", "doctor", "fix", "snapshot"}
+	for _, name := range commands {
+		t.Run(name, func(t *testing.T) {
+			// Given
+			root := NewRootCommand()
+
+			// When
+			stdout, _, err := executeTestCommand(t, root, "__complete", name, "--tools", "kube")
+
+			// Then
+			if err != nil {
+				t.Fatalf("complete %s --tools: %v", name, err)
+			}
+			if !strings.Contains(stdout, "kubectl") {
+				t.Fatalf("kubectl completion missing for %s: %q", name, stdout)
+			}
+		})
+	}
+}
+
+func TestToolFilterCompletionPreservesSelectedIDs(t *testing.T) {
+	// Given
+	root := NewRootCommand()
+
+	// When
+	stdout, _, err := executeTestCommand(t, root, "__complete", "status", "--tools", "kubectl,do")
+
+	// Then
+	if err != nil {
+		t.Fatalf("complete comma-separated --tools: %v", err)
+	}
+	if !strings.Contains(stdout, "kubectl,docker") {
+		t.Fatalf("comma-separated completion missing: %q", stdout)
+	}
+}
+
+func TestToolFilterCompletionOmitsAlreadySelectedIDs(t *testing.T) {
+	// Given
+	root := NewRootCommand()
+
+	// When
+	stdout, _, err := executeTestCommand(t, root, "__complete", "status", "--tools", "kubectl,")
+
+	// Then
+	if err != nil {
+		t.Fatalf("complete duplicate --tools: %v", err)
+	}
+	if !strings.Contains(stdout, "kubectl,kargo") {
+		t.Fatalf("remaining tool completion missing: %q", stdout)
+	}
+	if strings.Contains(stdout, "kubectl,kubectl") {
+		t.Fatalf("duplicate completion offered: %q", stdout)
+	}
+}
+
+func TestToolFilterCompletionCandidatesAndDirective(t *testing.T) {
+	tests := []struct {
+		name       string
+		toComplete string
+		want       string
+	}{
+		{name: "single item", toComplete: "dock", want: "docker"},
+		{name: "whitespace after comma", toComplete: "kubectl, do", want: "kubectl, docker"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, directive := completeToolFilter(nil, nil, tt.toComplete)
+			if len(got) != 1 || got[0] != tt.want {
+				t.Fatalf("completion = %#v, want %q", got, tt.want)
+			}
+			wantDirective := cobra.ShellCompDirectiveNoFileComp | cobra.ShellCompDirectiveNoSpace
+			if directive != wantDirective {
+				t.Fatalf("directive = %v, want NoFileComp|NoSpace", directive)
+			}
+		})
 	}
 }

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -102,6 +102,7 @@ Environment:
 	cmd.AddCommand(newKargoCommand(opts, runner))
 
 	setSubcommandGroups(cmd)
+	registerToolFilterCompletions(cmd)
 
 	return cmd
 }


### PR DESCRIPTION
This adds tool-ID-aware shell completion to every command with a `--tools` filter, including comma-separated selections such as `kubectl,docker`. It is worth merging because users no longer need to memorize the built-in registry while composing focused status and diagnostic commands.

## Validation
- `just check`
- `go build ./cmd/all-cli`
- Real CLI: `all-cli __complete status --tools kubectl,do` returns `kubectl,docker` with no-file/no-space directives

## Impact
- Applies to `status`, `diagnose`, `doctor`, `fix`, and `snapshot`
- Reads only the static tool registry and does not execute external tools
- No dependency, schema, configuration, or infrastructure changes

## Rollback
Revert commit `93fc0ee65481ab3ed4e70f9257f66273a03bd275`; existing command behavior remains unchanged without the completion hook.

## Issues
No related open issue; this is a self-contained interactive CLI improvement.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新功能**
  * 增强命令行工具过滤参数的补全，支持逗号分隔、前缀筛选、自动排序，并排除已选择的工具。
  * 改进 Bash 和 Zsh 补全脚本生成，提升对带空格或引号参数的处理能力。
  * 补全候选项不再触发不必要的文件路径补全。

* **错误修复**
  * 当补全脚本无法应用必要修补时，现会返回明确错误。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->