### PR TITLE
feat(cli): read diff snapshot from stdin

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,6 +164,13 @@ all-cli snapshot --json > after.json
 all-cli diff before.json after.json --json
 ```
 
+Use `-` for either diff input to compare a saved snapshot with a live pipeline
+without creating another file. Standard input snapshots are limited to 1 MiB:
+
+```bash
+all-cli snapshot --json | all-cli diff before.json - --json
+```
+
 ### AI-friendly JSON additions
 
 Machine-readable shape for `status --json` is also summarized as [JSON Schema](schemas/status-report-v0.1.json) (`schema_version` `v0.1`).

--- a/internal/cli/agent_commands.go
+++ b/internal/cli/agent_commands.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"encoding/json"
 	"fmt"
+	"io"
 	"os"
 	"sort"
 	"strings"
@@ -13,6 +14,8 @@ import (
 	"github.com/oldwinter/all-cli/internal/output"
 	"github.com/spf13/cobra"
 )
+
+const maxStdinSnapshotBytes int64 = 1 << 20
 
 func newDiagnoseCommand(opts *rootOptions, runner execx.Runner) *cobra.Command {
 	var toolsFilter string
@@ -126,13 +129,21 @@ func newDiffCommand(opts *rootOptions) *cobra.Command {
 	return &cobra.Command{
 		Use:   "diff <snapshot-a> <snapshot-b>",
 		Short: "Diff two status snapshots",
-		Args:  cobra.ExactArgs(2),
+		Long: `Diffs two status snapshots. Use - for either snapshot to read it from
+standard input, which makes it possible to compare a saved snapshot with a live pipeline.
+Standard input snapshots are limited to 1 MiB.`,
+		Example: `  all-cli diff before.json after.json
+  all-cli snapshot --json | all-cli diff before.json - --json`,
+		Args: cobra.ExactArgs(2),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			before, err := readStatusSnapshot(args[0])
+			if args[0] == "-" && args[1] == "-" {
+				return fmt.Errorf(`diff accepts "-" for only one snapshot`)
+			}
+			before, err := readStatusSnapshot(args[0], cmd.InOrStdin())
 			if err != nil {
 				return err
 			}
-			after, err := readStatusSnapshot(args[1])
+			after, err := readStatusSnapshot(args[1], cmd.InOrStdin())
 			if err != nil {
 				return err
 			}
@@ -230,17 +241,28 @@ func printFixPlan(w interface {
 	}
 }
 
-func readStatusSnapshot(path string) (model.StatusReport, error) {
-	data, err := os.ReadFile(path)
+func readStatusSnapshot(path string, stdin io.Reader) (model.StatusReport, error) {
+	source := path
+	var data []byte
+	var err error
+	if path == "-" {
+		source = "stdin"
+		data, err = io.ReadAll(io.LimitReader(stdin, maxStdinSnapshotBytes+1))
+		if int64(len(data)) > maxStdinSnapshotBytes {
+			return model.StatusReport{}, fmt.Errorf("snapshot stdin exceeds 1 MiB limit")
+		}
+	} else {
+		data, err = os.ReadFile(path)
+	}
 	if err != nil {
-		return model.StatusReport{}, fmt.Errorf("read snapshot %s: %w", path, err)
+		return model.StatusReport{}, fmt.Errorf("read snapshot %s: %w", source, err)
 	}
 	var report model.StatusReport
 	if err := json.Unmarshal(data, &report); err != nil {
-		return model.StatusReport{}, fmt.Errorf("parse snapshot %s: %w", path, err)
+		return model.StatusReport{}, fmt.Errorf("parse snapshot %s: %w", source, err)
 	}
 	if strings.TrimSpace(report.SchemaVersion) == "" {
-		return model.StatusReport{}, fmt.Errorf("parse snapshot %s: missing schema_version", path)
+		return model.StatusReport{}, fmt.Errorf("parse snapshot %s: missing schema_version", source)
 	}
 	return report, nil
 }

--- a/internal/cli/agent_commands_test.go
+++ b/internal/cli/agent_commands_test.go
@@ -189,6 +189,74 @@ func TestDiffCommandJSONReportsChangedTools(t *testing.T) {
 	}
 }
 
+func TestDiffCommandReadsSnapshotFromStdin(t *testing.T) {
+	before := model.NewStatusReport(1)
+	before.Tools[0] = model.ToolSummary{ID: "aws", DisplayName: "AWS CLI", Category: "cloud", Installed: false, ConfiguredState: model.ConfiguredUnknown}
+	after := model.NewStatusReport(1)
+	after.Tools[0] = model.ToolSummary{ID: "aws", DisplayName: "AWS CLI", Category: "cloud", Installed: true, ConfiguredState: model.ConfiguredYes}
+
+	tests := []struct {
+		name         string
+		stdinReport  model.StatusReport
+		fileReport   model.StatusReport
+		stdinIsFirst bool
+	}{
+		{name: "before snapshot", stdinReport: before, fileReport: after, stdinIsFirst: true},
+		{name: "after snapshot", stdinReport: after, fileReport: before},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			filePath := writeStatusReportFixture(t, t.TempDir(), "snapshot.json", tt.fileReport)
+			stdin, err := json.Marshal(tt.stdinReport)
+			if err != nil {
+				t.Fatalf("marshal stdin snapshot: %v", err)
+			}
+
+			args := []string{filePath, "-"}
+			if tt.stdinIsFirst {
+				args = []string{"-", filePath}
+			}
+			opts := &rootOptions{JSON: true, Timeout: time.Second}
+			cmd := newDiffCommand(opts)
+			cmd.SetIn(strings.NewReader(string(stdin)))
+			stdout, _, err := executeTestCommand(t, cmd, args...)
+			if err != nil {
+				t.Fatalf("diff from stdin: %v", err)
+			}
+
+			var got model.SnapshotDiffReport
+			if err := json.Unmarshal([]byte(stdout), &got); err != nil {
+				t.Fatalf("decode diff: %v", err)
+			}
+			if got.Summary.Changed != 1 || len(got.Changes) != 1 || got.Changes[0].ToolID != "aws" {
+				t.Fatalf("unexpected stdin diff: %#v", got)
+			}
+		})
+	}
+}
+
+func TestDiffCommandRejectsTwoStdinSnapshots(t *testing.T) {
+	opts := &rootOptions{JSON: true, Timeout: time.Second}
+	_, _, err := executeTestCommand(t, newDiffCommand(opts), "-", "-")
+	if err == nil || !strings.Contains(err.Error(), `accepts "-" for only one snapshot`) {
+		t.Fatalf("expected duplicate stdin error, got %v", err)
+	}
+}
+
+func TestDiffCommandRejectsOversizedStdinSnapshot(t *testing.T) {
+	before := model.NewStatusReport(0)
+	beforePath := writeStatusReportFixture(t, t.TempDir(), "before.json", before)
+
+	opts := &rootOptions{JSON: true, Timeout: time.Second}
+	cmd := newDiffCommand(opts)
+	cmd.SetIn(strings.NewReader(strings.Repeat(" ", int(maxStdinSnapshotBytes)+1)))
+	_, _, err := executeTestCommand(t, cmd, beforePath, "-")
+	if err == nil || !strings.Contains(err.Error(), "snapshot stdin exceeds 1 MiB limit") {
+		t.Fatalf("expected stdin size error, got %v", err)
+	}
+}
+
 func writeStatusReportFixture(t *testing.T, dir, name string, report model.StatusReport) string {
 	t.Helper()
 	path := filepath.Join(dir, name)


### PR DESCRIPTION
Adds `-` as a standard-input operand for `all-cli diff`, so a saved snapshot can be compared directly with a live `snapshot --json` pipeline without creating a second temporary file. It is worth merging because it turns the existing two-file workflow into a composable Unix-style command while preserving file-path behavior and bounding stdin to 1 MiB so endless or oversized producers terminate predictably.

## Validation

- `just check` (tidy verification, vet, full tests, full race tests, gofmt check)
- `just build`
- `go test -race -count=1 ./internal/cli` focused on the diff scenarios
- 20 uncached race repetitions of the stdin, duplicate-stdin, and size-limit tests
- Literal live workflow: `all-cli snapshot --json --tools fd | all-cli diff <(all-cli snapshot --json --tools fd) - --json`
- Real tmux pipeline QA on the exact commit
- Hands-on exact-SHA QA: 29/29 scenarios passed, including both stdin positions, text/JSON, every diff classification, file regression, malformed input, exactly 1 MiB, 1 MiB+1, and an endless producer
- Five-lane exact-SHA review (goal, QA, code quality, security, context): PASS
- Hosted `functional-qa`: PASS
- Hosted GitGuardian Security Checks: PASS

## Sample output

```text
$ all-cli snapshot --json | all-cli diff before.json - --json
{
  "schema_version": "snapshot-diff-v0.1",
  "summary": {
    "added": 0,
    "removed": 0,
    "changed": 1
  }
}
```

## Impact

This is additive and backward compatible. Exactly one diff operand may be `-`; two stdin operands are rejected clearly. Standard-input snapshots are capped at 1 MiB, while existing file-to-file behavior and output schemas are unchanged. The change adds no dependencies and does not alter configuration, CI, infrastructure, authentication, secrets, or machine state.

The feature is distinct from the prior category filter, describe, current overview, catalog, tool-filter completion, and open current-filter Happy Hours.

## Rollback

Revert commit `95d10b0172d7314495b9727c2c7a27c04b0ec304`. There is no migration, persistent state, or compatibility cleanup.

## Blockers

No feature blocker. The repository's prescribed `tuistory` helper was unavailable locally and was not installed because this task forbids machine/dependency changes; equivalent real-binary and tmux QA passed, and hosted `functional-qa` also passed.

The hosted `test` check passes tidy, format, vet, unit tests, and race tests, then fails on the pre-existing `internal/tools/docker/adapter.go:246` staticcheck `S1016`. This branch does not modify that file, and open PR #20 has the identical hosted check failure.

## Related issues

No matching issue was found; this is a self-contained CLI usability improvement.
