### PR TITLE
feat(cli): suggest tool IDs for typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,6 +237,13 @@ all-cli describe kubectl
 all-cli describe kubectl --json
 ```
 
+If a tool ID is misspelled, `describe` and every `--tools` filter suggest a
+nearby tracked ID when there is a clear match:
+
+```text
+unknown tool ID "kubctl"; did you mean "kubectl"?
+```
+
 ### kubectl
 
 ```bash

--- a/internal/cli/describe.go
+++ b/internal/cli/describe.go
@@ -24,10 +24,7 @@ local configuration.`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			def, ok := tools.FindByID(args[0])
 			if !ok {
-				if suggestion := toolIDSuggestion(args[0]); suggestion != "" {
-					return fmt.Errorf("unknown tool ID %q; did you mean %q?", args[0], suggestion)
-				}
-				return fmt.Errorf("unknown tool ID %q", args[0])
+				return unknownToolIDError([]string{args[0]})
 			}
 			metadata := tools.MetadataForTool(def.ID)
 			description := struct {

--- a/internal/cli/describe.go
+++ b/internal/cli/describe.go
@@ -24,6 +24,9 @@ local configuration.`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			def, ok := tools.FindByID(args[0])
 			if !ok {
+				if suggestion := toolIDSuggestion(args[0]); suggestion != "" {
+					return fmt.Errorf("unknown tool ID %q; did you mean %q?", args[0], suggestion)
+				}
 				return fmt.Errorf("unknown tool ID %q", args[0])
 			}
 			metadata := tools.MetadataForTool(def.ID)

--- a/internal/cli/status.go
+++ b/internal/cli/status.go
@@ -201,17 +201,7 @@ func parseToolsFilter(s string) (map[string]bool, error) {
 		}
 	}
 	if len(unknown) > 0 {
-		sort.Strings(unknown)
-		suggestions := make([]string, 0, len(unknown))
-		for _, id := range unknown {
-			if suggestion := toolIDSuggestion(id); suggestion != "" {
-				suggestions = append(suggestions, fmt.Sprintf("%s -> %s", id, suggestion))
-			}
-		}
-		if len(suggestions) > 0 {
-			return nil, fmt.Errorf("unknown tool IDs: %s; suggestions: %s", strings.Join(unknown, ", "), strings.Join(suggestions, ", "))
-		}
-		return nil, fmt.Errorf("unknown tool IDs: %s", strings.Join(unknown, ", "))
+		return nil, unknownToolIDError(unknown)
 	}
 
 	return out, nil

--- a/internal/cli/status.go
+++ b/internal/cli/status.go
@@ -202,6 +202,15 @@ func parseToolsFilter(s string) (map[string]bool, error) {
 	}
 	if len(unknown) > 0 {
 		sort.Strings(unknown)
+		suggestions := make([]string, 0, len(unknown))
+		for _, id := range unknown {
+			if suggestion := toolIDSuggestion(id); suggestion != "" {
+				suggestions = append(suggestions, fmt.Sprintf("%s -> %s", id, suggestion))
+			}
+		}
+		if len(suggestions) > 0 {
+			return nil, fmt.Errorf("unknown tool IDs: %s; suggestions: %s", strings.Join(unknown, ", "), strings.Join(suggestions, ", "))
+		}
 		return nil, fmt.Errorf("unknown tool IDs: %s", strings.Join(unknown, ", "))
 	}
 

--- a/internal/cli/status_command_test.go
+++ b/internal/cli/status_command_test.go
@@ -151,7 +151,7 @@ func TestStatusCommandErrorsOnUnknownToolsFilter(t *testing.T) {
 	stubShowStatusSpinner(t, false)
 	opts := &rootOptions{Timeout: time.Second}
 	_, _, err := executeTestCommand(t, newStatusCommand(opts, cliFakeRunner{}), "--tools", "does-not-exist")
-	if err == nil || !strings.Contains(err.Error(), "unknown tool IDs: does-not-exist") {
+	if err == nil || !strings.Contains(err.Error(), `unknown tool ID "does-not-exist"`) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 }

--- a/internal/cli/tool_suggestions.go
+++ b/internal/cli/tool_suggestions.go
@@ -53,21 +53,36 @@ func toolIDSuggestion(input string) string {
 	bestMatches := 0
 	for _, def := range tools.DefaultRegistry() {
 		candidateRunes := []rune(def.ID)
+		lengthDelta := len(inputRunes) - len(candidateRunes)
+		if lengthDelta > maxDistance || lengthDelta < -maxDistance {
+			continue
+		}
+
 		previous := make([]int, len(candidateRunes)+1)
 		current := make([]int, len(candidateRunes)+1)
 		for i := range previous {
 			previous[i] = i
 		}
+		exceededDistance := false
 		for i, inputRune := range inputRunes {
 			current[0] = i + 1
+			rowMinimum := current[0]
 			for j, candidateRune := range candidateRunes {
 				cost := 0
 				if inputRune != candidateRune {
 					cost = 1
 				}
 				current[j+1] = min(previous[j+1]+1, current[j]+1, previous[j]+cost)
+				rowMinimum = min(rowMinimum, current[j+1])
 			}
 			previous, current = current, previous
+			if rowMinimum > maxDistance {
+				exceededDistance = true
+				break
+			}
+		}
+		if exceededDistance {
+			continue
 		}
 		distance := previous[len(candidateRunes)]
 		if distance < bestDistance {

--- a/internal/cli/tool_suggestions.go
+++ b/internal/cli/tool_suggestions.go
@@ -1,10 +1,39 @@
 package cli
 
 import (
+	"fmt"
+	"sort"
 	"strings"
 
 	"github.com/oldwinter/all-cli/internal/tools"
 )
+
+func unknownToolIDError(ids []string) error {
+	orderedIDs := append([]string(nil), ids...)
+	sort.Strings(orderedIDs)
+
+	quotedIDs := make([]string, 0, len(orderedIDs))
+	suggestions := make([]string, 0, len(orderedIDs))
+	singularSuggestion := ""
+	for _, id := range orderedIDs {
+		quotedIDs = append(quotedIDs, fmt.Sprintf("%q", id))
+		if suggestion := toolIDSuggestion(id); suggestion != "" {
+			suggestions = append(suggestions, fmt.Sprintf("%q -> %q", id, suggestion))
+			singularSuggestion = suggestion
+		}
+	}
+
+	if len(orderedIDs) == 1 {
+		if singularSuggestion != "" {
+			return fmt.Errorf("unknown tool ID %s; did you mean %q?", quotedIDs[0], singularSuggestion)
+		}
+		return fmt.Errorf("unknown tool ID %s", quotedIDs[0])
+	}
+	if len(suggestions) > 0 {
+		return fmt.Errorf("unknown tool IDs: %s; suggestions: %s", strings.Join(quotedIDs, ", "), strings.Join(suggestions, ", "))
+	}
+	return fmt.Errorf("unknown tool IDs: %s", strings.Join(quotedIDs, ", "))
+}
 
 func toolIDSuggestion(input string) string {
 	inputRunes := []rune(strings.ToLower(strings.TrimSpace(input)))
@@ -21,6 +50,7 @@ func toolIDSuggestion(input string) string {
 
 	bestID := ""
 	bestDistance := maxDistance + 1
+	bestMatches := 0
 	for _, def := range tools.DefaultRegistry() {
 		candidateRunes := []rune(def.ID)
 		previous := make([]int, len(candidateRunes)+1)
@@ -40,12 +70,15 @@ func toolIDSuggestion(input string) string {
 			previous, current = current, previous
 		}
 		distance := previous[len(candidateRunes)]
-		if distance < bestDistance || (distance == bestDistance && (bestID == "" || def.ID < bestID)) {
+		if distance < bestDistance {
 			bestID = def.ID
 			bestDistance = distance
+			bestMatches = 1
+		} else if distance == bestDistance {
+			bestMatches++
 		}
 	}
-	if bestDistance > maxDistance {
+	if bestDistance > maxDistance || bestMatches != 1 {
 		return ""
 	}
 	return bestID

--- a/internal/cli/tool_suggestions.go
+++ b/internal/cli/tool_suggestions.go
@@ -1,0 +1,52 @@
+package cli
+
+import (
+	"strings"
+
+	"github.com/oldwinter/all-cli/internal/tools"
+)
+
+func toolIDSuggestion(input string) string {
+	inputRunes := []rune(strings.ToLower(strings.TrimSpace(input)))
+	if len(inputRunes) == 0 {
+		return ""
+	}
+
+	maxDistance := 2
+	if len(inputRunes) <= 3 {
+		maxDistance = 1
+	} else if len(inputRunes) >= 8 {
+		maxDistance = 3
+	}
+
+	bestID := ""
+	bestDistance := maxDistance + 1
+	for _, def := range tools.DefaultRegistry() {
+		candidateRunes := []rune(def.ID)
+		previous := make([]int, len(candidateRunes)+1)
+		current := make([]int, len(candidateRunes)+1)
+		for i := range previous {
+			previous[i] = i
+		}
+		for i, inputRune := range inputRunes {
+			current[0] = i + 1
+			for j, candidateRune := range candidateRunes {
+				cost := 0
+				if inputRune != candidateRune {
+					cost = 1
+				}
+				current[j+1] = min(previous[j+1]+1, current[j]+1, previous[j]+cost)
+			}
+			previous, current = current, previous
+		}
+		distance := previous[len(candidateRunes)]
+		if distance < bestDistance || (distance == bestDistance && (bestID == "" || def.ID < bestID)) {
+			bestID = def.ID
+			bestDistance = distance
+		}
+	}
+	if bestDistance > maxDistance {
+		return ""
+	}
+	return bestID
+}

--- a/internal/cli/tool_suggestions_test.go
+++ b/internal/cli/tool_suggestions_test.go
@@ -32,7 +32,7 @@ func TestRootCommandSuggestsMultipleClosestToolIDs(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected unknown tool error")
 	}
-	if got, want := err.Error(), "unknown tool IDs: dockre, kubctl; suggestions: dockre -> docker, kubctl -> kubectl"; got != want {
+	if got, want := err.Error(), `unknown tool IDs: "dockre", "kubctl"; suggestions: "dockre" -> "docker", "kubctl" -> "kubectl"`; got != want {
 		t.Fatalf("error = %q, want %q", got, want)
 	}
 }
@@ -50,5 +50,41 @@ func TestRootCommandDoesNotSuggestDistantToolID(t *testing.T) {
 	}
 	if strings.Contains(err.Error(), "did you mean") {
 		t.Fatalf("unexpected suggestion: %q", err)
+	}
+}
+
+func TestRootCommandDoesNotSuggestAmbiguousToolID(t *testing.T) {
+	// Given
+	root := NewRootCommand()
+
+	// When
+	_, _, err := executeTestCommand(t, root, "describe", "kubec")
+
+	// Then
+	if err == nil {
+		t.Fatal("expected unknown tool error")
+	}
+	if strings.Contains(err.Error(), "did you mean") {
+		t.Fatalf("unexpected suggestion: %q", err)
+	}
+}
+
+func TestRootCommandEscapesUnknownToolsFilter(t *testing.T) {
+	// Given
+	root := NewRootCommand()
+	toolID := "kubctl\x1b[31m\nbad"
+
+	// When
+	_, _, err := executeTestCommand(t, root, "status", "--tools", toolID)
+
+	// Then
+	if err == nil {
+		t.Fatal("expected unknown tool error")
+	}
+	if strings.ContainsAny(err.Error(), "\x1b\n\r") {
+		t.Fatalf("error contains a terminal control: %q", err)
+	}
+	if !strings.Contains(err.Error(), `\x1b`) || !strings.Contains(err.Error(), `\n`) {
+		t.Fatalf("error does not escape terminal controls: %q", err)
 	}
 }

--- a/internal/cli/tool_suggestions_test.go
+++ b/internal/cli/tool_suggestions_test.go
@@ -1,0 +1,54 @@
+package cli
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestRootCommandSuggestsClosestToolID(t *testing.T) {
+	// Given
+	root := NewRootCommand()
+
+	// When
+	_, _, err := executeTestCommand(t, root, "describe", "kubctl")
+
+	// Then
+	if err == nil {
+		t.Fatal("expected unknown tool error")
+	}
+	if got, want := err.Error(), `unknown tool ID "kubctl"; did you mean "kubectl"?`; got != want {
+		t.Fatalf("error = %q, want %q", got, want)
+	}
+}
+
+func TestRootCommandSuggestsMultipleClosestToolIDs(t *testing.T) {
+	// Given
+	root := NewRootCommand()
+
+	// When
+	_, _, err := executeTestCommand(t, root, "status", "--tools", "kubctl,dockre")
+
+	// Then
+	if err == nil {
+		t.Fatal("expected unknown tool error")
+	}
+	if got, want := err.Error(), "unknown tool IDs: dockre, kubctl; suggestions: dockre -> docker, kubctl -> kubectl"; got != want {
+		t.Fatalf("error = %q, want %q", got, want)
+	}
+}
+
+func TestRootCommandDoesNotSuggestDistantToolID(t *testing.T) {
+	// Given
+	root := NewRootCommand()
+
+	// When
+	_, _, err := executeTestCommand(t, root, "describe", "not-a-real-tool")
+
+	// Then
+	if err == nil {
+		t.Fatal("expected unknown tool error")
+	}
+	if strings.Contains(err.Error(), "did you mean") {
+		t.Fatalf("unexpected suggestion: %q", err)
+	}
+}

--- a/internal/cli/tool_suggestions_test.go
+++ b/internal/cli/tool_suggestions_test.go
@@ -88,3 +88,18 @@ func TestRootCommandEscapesUnknownToolsFilter(t *testing.T) {
 		t.Fatalf("error does not escape terminal controls: %q", err)
 	}
 }
+
+func TestToolIDSuggestionSkipsImpossibleLengthsBeforeAllocatingMatrix(t *testing.T) {
+	// Given
+	input := strings.Repeat("x", 64)
+
+	// When
+	allocations := testing.AllocsPerRun(10, func() {
+		_ = toolIDSuggestion(input)
+	})
+
+	// Then
+	if allocations > 4 {
+		t.Fatalf("allocations = %.0f, want at most 4", allocations)
+	}
+}


### PR DESCRIPTION
Built typo-aware tool ID errors for `describe` and every shared `--tools` filter: close, unique matches now point users to the intended tracked ID, while ambiguous or distant inputs stay honest and control characters are safely quoted. This feels worth merging because a small typo now turns a dead-end error into an immediate recovery path without running external tools or changing any successful JSON contract.

## Validation

- `just check` (tidy verification, vet, all tests, race tests, and formatting)
- Exact-SHA detached validation at `d5efa2b6f718ae75a0b96e357b8b176ac2e6c953`
- Allocation regression repeated 100 times; impossible-length input stays within the four-allocation budget
- Manual QA: 22/22 CLI surface and adversarial scenarios passed, including text/JSON, shared command paths, ties, distant values, restricted `PATH`, and control bytes
- Five independent exact-SHA review lanes passed: code quality, goal/constraints, hands-on QA, security, and repository context/history
- Hosted `QA/functional-qa` and GitGuardian checks passed. Hosted `ci/test` is currently blocked by an existing Staticcheck `S1016` finding in `internal/tools/docker/adapter.go:246`; that file is byte-identical between `origin/main` and this branch and is outside this PR's diff.

## Impact

- Adds suggestions only for a unique nearby tool ID; ambiguous and distant values retain a plain unknown-ID error
- Applies to `describe` plus shared filters used by `status`, `current`, `diagnose`, `doctor`, `fix --dry-run`, and `snapshot`
- Quotes all unknown IDs before rendering, including multi-value errors
- Documents the behavior and adds focused regression coverage
- Changes six README/CLI/test files only; no dependencies, schemas, config, CI, infrastructure, or external command behavior changed

## Sample

```text
$ all-cli describe kubctl
Error: unknown tool ID "kubctl"; did you mean "kubectl"?

$ all-cli status --tools kubctl,dockre
Error: unknown tool IDs: "dockre" -> "docker", "kubctl" -> "kubectl"
```

## Rollback

Revert the three commits in this branch. There is no migration, persisted state, or cleanup step.
