### PR TITLE
feat(cli): add JSON version output

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,16 @@ Note about Go toolchain mismatch:
 
 ## Usage
 
+### Version metadata
+
+`all-cli version` keeps its compact human-readable output. Add `--json` when a
+script needs the version and build metadata as separate fields:
+
+```bash
+all-cli version
+all-cli version --json
+```
+
 ### Global overview
 
 `all-cli status` defaults to grouping by `category` and sorting tools by `tool` (A-Z).

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -85,7 +85,7 @@ Environment:
 	cmd.AddCommand(newFixCommand(opts, runner))
 	cmd.AddCommand(newSnapshotCommand(opts, runner))
 	cmd.AddCommand(newDiffCommand(opts))
-	cmd.AddCommand(newVersionCommand())
+	cmd.AddCommand(newVersionCommand(opts))
 	cmd.AddCommand(newOptionsCommand(opts))
 	cmd.AddCommand(newSurpriseCommand())
 	cmd.AddCommand(newCompletionCommand())

--- a/internal/cli/version.go
+++ b/internal/cli/version.go
@@ -3,15 +3,30 @@ package cli
 import (
 	"fmt"
 
+	"github.com/oldwinter/all-cli/internal/output"
 	"github.com/spf13/cobra"
 )
 
-func newVersionCommand() *cobra.Command {
+type versionReport struct {
+	Version string `json:"version"`
+	Commit  string `json:"commit"`
+	Date    string `json:"date"`
+}
+
+func newVersionCommand(opts *rootOptions) *cobra.Command {
 	return &cobra.Command{
 		Use:   "version",
 		Short: "Print version information",
-		Run: func(cmd *cobra.Command, _ []string) {
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			if opts.JSON {
+				return output.PrintJSON(cmd.OutOrStdout(), versionReport{
+					Version: version,
+					Commit:  commit,
+					Date:    date,
+				})
+			}
 			fmt.Fprintln(cmd.OutOrStdout(), VersionString())
+			return nil
 		},
 	}
 }

--- a/internal/cli/version_test.go
+++ b/internal/cli/version_test.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"bytes"
+	"encoding/json"
 	"strings"
 	"testing"
 )
@@ -22,7 +23,7 @@ func TestVersionStringDev(t *testing.T) {
 
 func TestVersionCommandDevOutput(t *testing.T) {
 	buf := &bytes.Buffer{}
-	cmd := newVersionCommand()
+	cmd := newVersionCommand(&rootOptions{})
 	cmd.SetOut(buf)
 	cmd.SetArgs([]string{})
 	if err := cmd.Execute(); err != nil {
@@ -44,7 +45,7 @@ func TestVersionCommandIncludesCommitAndDate(t *testing.T) {
 	}()
 
 	buf := &bytes.Buffer{}
-	cmd := newVersionCommand()
+	cmd := newVersionCommand(&rootOptions{})
 	cmd.SetOut(buf)
 	cmd.SetArgs([]string{})
 	if err := cmd.Execute(); err != nil {
@@ -53,5 +54,35 @@ func TestVersionCommandIncludesCommitAndDate(t *testing.T) {
 	out := strings.TrimSpace(buf.String())
 	if out != "v1.2.3 (commit=abc123 date=2026-03-15)" {
 		t.Fatalf("unexpected output: %q", out)
+	}
+}
+
+func TestVersionCommandJSONIncludesBuildMetadata(t *testing.T) {
+	oldVersion, oldCommit, oldDate := version, commit, date
+	version = "v1.2.3"
+	commit = "abc123"
+	date = "2026-03-15"
+	defer func() {
+		version, commit, date = oldVersion, oldCommit, oldDate
+	}()
+
+	stdout, stderr, err := executeTestCommand(t, NewRootCommand(), "version", "--json")
+	if err != nil {
+		t.Fatalf("version --json: %v", err)
+	}
+	if stderr != "" {
+		t.Fatalf("stderr = %q, want empty", stderr)
+	}
+
+	var got struct {
+		Version string `json:"version"`
+		Commit  string `json:"commit"`
+		Date    string `json:"date"`
+	}
+	if err := json.Unmarshal([]byte(stdout), &got); err != nil {
+		t.Fatalf("decode version JSON: %v\noutput: %s", err, stdout)
+	}
+	if got.Version != version || got.Commit != commit || got.Date != date {
+		t.Fatalf("unexpected version JSON: %#v", got)
 	}
 }


### PR DESCRIPTION
This PR adds structured JSON output to `all-cli version`, exposing `version`, `commit`, and `date` as separate fields while preserving the existing human-readable output. It is worth merging because scripts and agents can inspect build metadata without parsing a presentation string, and the root-level `--json` flag now behaves consistently on this everyday command.

## Validation

- `just check`
- `just build-release`
- Exact-SHA binary QA for `all-cli version`, `all-cli version --json`, `all-cli --json version`, and `all-cli --version`
- `jq` assertion for the exact JSON key set, types, and embedded commit SHA
- `git diff --check`
- Hosted `QA / functional-qa` and GitGuardian checks passed

## Impact

- Adds an opt-in JSON representation for `all-cli version`.
- Keeps existing text output and the root `--version` flag unchanged.
- Changes only CLI wiring, the version command/tests, and README documentation.
- Adds no dependencies, schema migrations, configuration, or external tool execution.

## Rollback

Revert commit `43b99d65499e1841029781608e11a64475b0400f`. There is no data or configuration migration.

## Blockers

No local blocker. Hosted `ci / test` is red only on the pre-existing Staticcheck
`S1016` at `internal/tools/docker/adapter.go:246`; that file is outside this PR and
has the same blob (`ccff9b46559fdf7310bceed3fe3a093e4a0a7bbd`) on `origin/main` and
this branch.
