### PR TITLE
feat(cli): complete category filter values

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,8 @@ all-cli status --timeout 10s
 
 Use `--categories` to check one or more registry categories at once. When combined with
 `--tools`, both filters apply, so the result contains only tools matching both selections.
+With shell completion loaded, comma-separated category values complete in place: for
+example, `--categories cloud,k<TAB>` keeps `cloud` and offers `k8s`.
 
 ### Current contexts at a glance
 

--- a/internal/cli/completion.go
+++ b/internal/cli/completion.go
@@ -22,6 +22,17 @@ func registerToolFilterCompletions(root *cobra.Command) {
 	}
 }
 
+func registerCategoryFilterCompletions(root *cobra.Command) {
+	for _, cmd := range root.Commands() {
+		if cmd.Flags().Lookup("categories") == nil {
+			continue
+		}
+		if err := cmd.RegisterFlagCompletionFunc("categories", completeCategoryFilter); err != nil {
+			panic(fmt.Sprintf("register --categories completion for %s: %v", cmd.CommandPath(), err))
+		}
+	}
+}
+
 func completeToolFilter(_ *cobra.Command, _ []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 	prefix := ""
 	fragment := toComplete
@@ -41,6 +52,35 @@ func completeToolFilter(_ *cobra.Command, _ []string, toComplete string) ([]stri
 		if !selected[def.ID] && strings.HasPrefix(def.ID, fragment) {
 			candidates = append(candidates, prefix+def.ID)
 		}
+	}
+	sort.Strings(candidates)
+	return candidates, cobra.ShellCompDirectiveNoFileComp | cobra.ShellCompDirectiveNoSpace
+}
+
+func completeCategoryFilter(_ *cobra.Command, _ []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+	prefix := ""
+	fragment := toComplete
+	selected := map[string]bool{}
+	if comma := strings.LastIndex(toComplete, ","); comma >= 0 {
+		suffix := toComplete[comma+1:]
+		fragment = strings.TrimLeftFunc(suffix, unicode.IsSpace)
+		prefix = toComplete[:len(toComplete)-len(fragment)]
+		for _, category := range strings.Split(toComplete[:comma], ",") {
+			selected[strings.ToLower(strings.TrimSpace(category))] = true
+		}
+	}
+	fragment = strings.ToLower(strings.TrimSpace(fragment))
+
+	categories := map[string]bool{}
+	for _, def := range tools.DefaultRegistry() {
+		category := strings.ToLower(def.Category)
+		if !selected[category] && strings.HasPrefix(category, fragment) {
+			categories[category] = true
+		}
+	}
+	candidates := make([]string, 0, len(categories))
+	for category := range categories {
+		candidates = append(candidates, prefix+category)
 	}
 	sort.Strings(candidates)
 	return candidates, cobra.ShellCompDirectiveNoFileComp | cobra.ShellCompDirectiveNoSpace

--- a/internal/cli/completion_test.go
+++ b/internal/cli/completion_test.go
@@ -212,3 +212,54 @@ func TestToolFilterCompletionCandidatesAndDirective(t *testing.T) {
 		})
 	}
 }
+
+func TestCategoryFilterFlagCompletesCategories(t *testing.T) {
+	root := NewRootCommand()
+
+	stdout, _, err := executeTestCommand(t, root, "__complete", "status", "--categories", "cl")
+	if err != nil {
+		t.Fatalf("complete status --categories: %v", err)
+	}
+	if !strings.Contains(stdout, "cloud") {
+		t.Fatalf("cloud completion missing: %q", stdout)
+	}
+}
+
+func TestCategoryFilterCompletionOmitsAlreadySelectedCategories(t *testing.T) {
+	root := NewRootCommand()
+
+	stdout, _, err := executeTestCommand(t, root, "__complete", "status", "--categories", "cloud,")
+	if err != nil {
+		t.Fatalf("complete comma-separated --categories: %v", err)
+	}
+	if !strings.Contains(stdout, "cloud,k8s") {
+		t.Fatalf("remaining category completion missing: %q", stdout)
+	}
+	if strings.Contains(stdout, "cloud,cloud") {
+		t.Fatalf("duplicate category completion offered: %q", stdout)
+	}
+}
+
+func TestCategoryFilterCompletionCandidatesAndDirective(t *testing.T) {
+	tests := []struct {
+		name       string
+		toComplete string
+		want       string
+	}{
+		{name: "single item", toComplete: "cl", want: "cloud"},
+		{name: "case insensitive", toComplete: "CL", want: "cloud"},
+		{name: "whitespace after comma", toComplete: "cloud, k", want: "cloud, k8s"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, directive := completeCategoryFilter(nil, nil, tt.toComplete)
+			if len(got) != 1 || got[0] != tt.want {
+				t.Fatalf("completion = %#v, want %q", got, tt.want)
+			}
+			wantDirective := cobra.ShellCompDirectiveNoFileComp | cobra.ShellCompDirectiveNoSpace
+			if directive != wantDirective {
+				t.Fatalf("directive = %v, want NoFileComp|NoSpace", directive)
+			}
+		})
+	}
+}

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -104,6 +104,7 @@ Environment:
 
 	setSubcommandGroups(cmd)
 	registerToolFilterCompletions(cmd)
+	registerCategoryFilterCompletions(cmd)
 
 	return cmd
 }


### PR DESCRIPTION
Built dynamic shell completion for `all-cli status --categories`: partial category names now complete from the live registry, comma-separated selections stay intact, duplicate categories are omitted, and matching follows the existing case-insensitive flag validation. It is worth merging because category filtering now feels as fluid as the existing `--tools` workflow, while remaining entirely local and never invoking a tracked CLI.

## Validation

- `just check` (tidy verification, vet, all tests, race tests, and formatting)
- `just build`
- `go test ./internal/cli -run TestCategoryFilter -count=1`
- Generated Bash and zsh scripts passed syntax checks; fish and PowerShell generation succeeded
- Exact-SHA protocol QA under `PATH=/nonexistent` returned `cloud` and `cloud, k8s` with Cobra directive `:6`
- Generated Bash consumed `cloud, k` as `cloud\\,\\ k8s`; generated zsh consumed it as `cloud, k8s`

## Hosted checks

- `functional-qa`: pass
- GitGuardian Security Checks: pass
- `test`: blocked by the existing Staticcheck `S1016` at `internal/tools/docker/adapter.go:246`; the base and PR head both contain blob `ccff9b46559fdf7310bceed3fe3a093e4a0a7bbd`, and this PR does not change that file

## Impact

The change only registers completion for the existing `status --categories` flag, derives candidates from the existing in-memory registry, and documents the behavior. Status execution, external tool calls, JSON contracts, dependencies, configuration, and machine state are unchanged.

## Rollback

Revert commit `2e1deced332909d0d66b0f582f328a5a26ee20e6` to remove category completion and its documentation.

## Issue relationship

No open repository issue matches this completion-only improvement.