### PR TITLE
ci: Linux jobs → self-hosted all-cli runner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ env:
 
 jobs:
   test:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, Linux, X64, all-cli]
     timeout-minutes: 20
     steps:
       - name: Checkout


### PR DESCRIPTION
## 现象
ci/qa/release 仍 `ubuntu-latest`，自托管 runner `all-cli-185` 已 online 未用上。

## 想改成啥
Linux jobs → `runs-on: [self-hosted, Linux, X64, all-cli]`。不改产品代码。

## 验收
- checks 在 all-cli runner 上跑
- diff 仅 workflow `runs-on`