### PR TITLE
feat: harden agent readiness controls

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,35 @@
+FROM mcr.microsoft.com/devcontainers/go:1.26-bookworm
+
+ARG TARGETARCH
+ARG JUST_VERSION=1.58.0
+
+USER root
+
+RUN apt-get update \
+    && apt-get install --yes --no-install-recommends ca-certificates curl pipx \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN set -eux; \
+    case "${TARGETARCH}" in \
+      amd64) \
+        just_arch="x86_64"; \
+        just_sha256="4a5cc2f53e6f0f8c59092a6cc38291eb729d46a7dd95d3ae582008881b84931d" ;; \
+      arm64) \
+        just_arch="aarch64"; \
+        just_sha256="748237128c4c40cbdabc65e841d05ceba13cc23a91eaba395495894c1d9764df" ;; \
+      *) echo "unsupported TARGETARCH: ${TARGETARCH}" >&2; exit 1 ;; \
+    esac; \
+    archive="/tmp/just.tar.gz"; \
+    curl --fail --location --retry 3 --show-error \
+      "https://github.com/casey/just/releases/download/${JUST_VERSION}/just-${JUST_VERSION}-${just_arch}-unknown-linux-musl.tar.gz" \
+      --output "${archive}"; \
+    echo "${just_sha256}  ${archive}" | sha256sum --check --strict; \
+    tar --extract --gzip --file "${archive}" --directory /usr/local/bin just; \
+    chmod 0755 /usr/local/bin/just; \
+    rm "${archive}"
+
+USER vscode
+
+ENV PATH="/home/vscode/.local/bin:${PATH}"
+
+RUN pipx install pre-commit==4.6.2

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,27 @@
+{
+  "name": "all-cli Go 1.26",
+  "build": {
+    "dockerfile": "Dockerfile",
+    "context": ".."
+  },
+  "features": {
+    "ghcr.io/devcontainers/features/github-cli:1": {}
+  },
+  "containerEnv": {
+    "GOTOOLCHAIN": "auto"
+  },
+  "postCreateCommand": "go mod download && pre-commit install",
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "golang.go",
+        "redhat.vscode-yaml"
+      ],
+      "settings": {
+        "go.toolsManagement.autoUpdate": false,
+        "go.useLanguageServer": true
+      }
+    }
+  },
+  "remoteUser": "vscode"
+}

--- a/.factory/skills/qa/config.yaml
+++ b/.factory/skills/qa/config.yaml
@@ -47,9 +47,9 @@ apps:
     smoke_command: 'just smoke'
 
 feature_flags:
-  provider: none
-  dashboard_url: null
-  how_to_override: 'No feature flag system detected. Use CLI flags and environment variables for runtime behavior toggles.'
+  provider: internal_typed_registry
+  dashboard_url: docs/feature-flags.md
+  how_to_override: 'Set ALL_CLI_FEATURES to a comma-separated list of registered flags; telemetry-v1 is disabled by default and is the current production flag.'
 
 integrations:
   external_cli_registry:

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# Default review owner for source, automation, documentation, and releases.
+* @oldwinter

--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -1,0 +1,76 @@
+name: Bug report
+description: Report reproducible incorrect behavior in all-cli.
+title: "bug: "
+labels:
+  - type:bug
+  - priority:P2
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Do not include tokens, credentials, or the contents of private tool configuration.
+  - type: input
+    id: version
+    attributes:
+      label: all-cli version
+      description: Paste the output of `all-cli version`.
+      placeholder: v0.0.0 (commit=abc1234 date=2026-08-23)
+    validations:
+      required: true
+  - type: dropdown
+    id: area
+    attributes:
+      label: Affected area
+      options:
+        - CLI command behavior
+        - Tool detection or context
+        - Installation or doctor fix
+        - JSON schema or output
+        - CI, release, or documentation
+    validations:
+      required: true
+  - type: textarea
+    id: description
+    attributes:
+      label: What happened?
+      description: Describe the observed behavior and why it is incorrect.
+    validations:
+      required: true
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: Reproduction
+      description: Provide the shortest safe command sequence that reproduces the problem.
+      placeholder: |
+        1. Run `all-cli ...`
+        2. Observe ...
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+      description: State the output or behavior you expected.
+    validations:
+      required: true
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment
+      description: Include OS, architecture, shell, and relevant external CLI versions. Remove private paths and identity.
+    validations:
+      required: true
+  - type: textarea
+    id: diagnostics
+    attributes:
+      label: Safe diagnostics
+      description: Add redacted `all-cli diagnose --json` details if useful.
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Submission checks
+      options:
+        - label: I removed credentials, tokens, private paths, account IDs, and confidential output.
+          required: true
+        - label: I searched existing issues for the same behavior.
+          required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Security vulnerability
+    url: https://github.com/oldwinter/all-cli/security/advisories/new
+    about: Privately report vulnerabilities instead of opening a public issue.

--- a/.github/ISSUE_TEMPLATE/feature.yml
+++ b/.github/ISSUE_TEMPLATE/feature.yml
@@ -1,0 +1,63 @@
+name: Feature request
+description: Propose a scoped improvement to all-cli.
+title: "feat: "
+labels:
+  - type:feature
+  - priority:P3
+body:
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem
+      description: Describe the workflow limitation or unmet need without prescribing implementation.
+    validations:
+      required: true
+  - type: textarea
+    id: outcome
+    attributes:
+      label: Desired outcome
+      description: Explain the observable behavior that would solve the problem.
+    validations:
+      required: true
+  - type: dropdown
+    id: area
+    attributes:
+      label: Primary area
+      options:
+        - CLI command behavior
+        - Tool detection or context
+        - Installation or doctor fix
+        - JSON schema or output
+        - CI, release, or documentation
+    validations:
+      required: true
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: List current workarounds or simpler alternatives.
+    validations:
+      required: true
+  - type: textarea
+    id: compatibility
+    attributes:
+      label: Compatibility and risk
+      description: Note output/schema compatibility, platform impact, security, privacy, or rollback concerns.
+    validations:
+      required: true
+  - type: textarea
+    id: validation
+    attributes:
+      label: Acceptance checks
+      description: List commands or assertions that would prove the feature works.
+    validations:
+      required: true
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Submission checks
+      options:
+        - label: This request describes one independently deliverable outcome.
+          required: true
+        - label: I searched existing issues and documentation for an existing solution.
+          required: true

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,52 @@
+version: 2
+updates:
+  - package-ecosystem: gomod
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+      time: "09:00"
+      timezone: UTC
+    open-pull-requests-limit: 5
+    labels:
+      - dependencies
+      - type:chore
+      - area:dependencies
+    groups:
+      go-modules:
+        patterns:
+          - "*"
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+      time: "09:30"
+      timezone: UTC
+    open-pull-requests-limit: 5
+    labels:
+      - dependencies
+      - type:chore
+      - area:ci
+    groups:
+      github-actions:
+        patterns:
+          - "*"
+
+  - package-ecosystem: devcontainers
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+      time: "10:00"
+      timezone: UTC
+    open-pull-requests-limit: 3
+    labels:
+      - dependencies
+      - type:chore
+      - area:dependencies
+    groups:
+      dev-container:
+        patterns:
+          - "*"

--- a/.github/labels.json
+++ b/.github/labels.json
@@ -1,0 +1,82 @@
+[
+  {
+    "name": "priority:P0",
+    "color": "B60205",
+    "description": "Critical incident requiring immediate response."
+  },
+  {
+    "name": "priority:P1",
+    "color": "D93F0B",
+    "description": "High-impact work requiring response within one hour."
+  },
+  {
+    "name": "priority:P2",
+    "color": "FBCA04",
+    "description": "Normal defect or degradation requiring prompt backlog review."
+  },
+  {
+    "name": "priority:P3",
+    "color": "0E8A16",
+    "description": "Low-impact improvement handled through normal prioritization."
+  },
+  {
+    "name": "type:bug",
+    "color": "D73A4A",
+    "description": "Incorrect or regressed behavior."
+  },
+  {
+    "name": "type:feature",
+    "color": "A2EEEF",
+    "description": "New user-visible capability."
+  },
+  {
+    "name": "type:chore",
+    "color": "D4C5F9",
+    "description": "Maintenance, tooling, or dependency work."
+  },
+  {
+    "name": "type:security",
+    "color": "5319E7",
+    "description": "Security hardening or vulnerability remediation."
+  },
+  {
+    "name": "area:cli",
+    "color": "1D76DB",
+    "description": "CLI command wiring, output, options, or schemas."
+  },
+  {
+    "name": "area:tools",
+    "color": "0052CC",
+    "description": "Tool registry, adapter, detection, or context behavior."
+  },
+  {
+    "name": "area:ci",
+    "color": "006B75",
+    "description": "Continuous integration, QA, or release automation."
+  },
+  {
+    "name": "area:docs",
+    "color": "0075CA",
+    "description": "Documentation, runbooks, or contributor guidance."
+  },
+  {
+    "name": "area:dependencies",
+    "color": "0366D6",
+    "description": "Go modules, actions, images, and supply-chain policy."
+  },
+  {
+    "name": "area:observability",
+    "color": "C2E0C6",
+    "description": "Logging, traces, metrics, errors, analytics, or alerts."
+  },
+  {
+    "name": "area:security",
+    "color": "7057FF",
+    "description": "Security automation, findings, controls, or privacy."
+  },
+  {
+    "name": "dependencies",
+    "color": "0366D6",
+    "description": "Automated dependency update."
+  }
+]

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,28 @@
+## Context
+
+<!-- Link the issue/spec and explain why this change is needed. -->
+
+Closes #
+
+## Changes
+
+<!-- Describe user-visible behavior and important implementation decisions. -->
+
+## Validation
+
+<!-- List exact commands and results. Include sample CLI output when UX changes. -->
+
+- [ ] `just ci`
+- [ ] `just check` (or explain why it was not run)
+
+## Risk and rollback
+
+<!-- Identify compatibility, release, security, and operational risks. State how to revert or disable the change. -->
+
+## Telemetry and privacy
+
+<!-- State whether data collection, logging, errors, identifiers, or external requests changed. -->
+
+- [ ] No secrets, tokens, private paths, account IDs, or user-generated output are added to code, logs, tests, or artifacts.
+- [ ] New behavior is covered by meaningful tests.
+- [ ] Documentation and schemas are updated when applicable.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,7 @@ on:
 
 permissions:
   contents: read
+  security-events: write
 
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
@@ -15,6 +16,7 @@ env:
 jobs:
   test:
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     steps:
       - name: Checkout
         uses: actions/checkout@v6.0.2
@@ -28,7 +30,7 @@ jobs:
       - name: Verify go.mod tidy
         run: |
           go mod tidy
-          git diff --exit-code
+          git diff --exit-code -- go.mod go.sum
 
       - name: Format check
         run: |
@@ -42,13 +44,85 @@ jobs:
       - name: Vet
         run: go vet ./...
 
-      - name: Test
-        run: go test ./...
+      - name: Repository policy
+        run: go test ./internal/repopolicy -run TestRepositoryPolicy -count=1
+
+      - name: Build performance
+        shell: bash
+        run: |
+          mkdir -p quality-metrics
+          SECONDS=0
+          go build -o /tmp/all-cli ./cmd/all-cli
+          elapsed="$SECONDS"
+          printf '%s\n' "$elapsed" > quality-metrics/build-seconds.txt
+          {
+            echo "### Build performance"
+            echo
+            echo "- Elapsed: ${elapsed}s"
+            echo "- Regression ceiling: 120s"
+          } >> "$GITHUB_STEP_SUMMARY"
+          if (( elapsed > 120 )); then
+            echo "build exceeded the 120-second regression ceiling" >&2
+            exit 1
+          fi
+
+      - name: Test with timing events
+        shell: bash
+        run: |
+          set -o pipefail
+          go test -json ./... | tee quality-metrics/test-events.json
 
       - name: Test (race detector)
         run: go test -race ./...
+
+      - name: Test stability (three passes)
+        shell: bash
+        run: |
+          set -o pipefail
+          go test -count=3 -json ./... | tee quality-metrics/stability-events.json
+          {
+            echo "### Test stability"
+            echo
+            echo "Every package passed three consecutive executions."
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Enforce coverage threshold
+        env:
+          COVERAGE_FILE: quality-metrics/coverage.out
+          COVERAGE_MIN: "80.0"
+        run: bash scripts/check-coverage.sh
 
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v9.2.0
         with:
           version: v2.11.3
+          args: --output.sarif.path=quality-metrics/golangci-lint.sarif
+
+      - name: Upload lint SARIF
+        if: always() && hashFiles('quality-metrics/golangci-lint.sarif') != ''
+        uses: github/codeql-action/upload-sarif@v4
+        with:
+          sarif_file: quality-metrics/golangci-lint.sarif
+          category: golangci-lint
+
+      - name: Summarize quality controls
+        if: always()
+        run: |
+          {
+            echo "### Enforced quality controls"
+            echo
+            echo "- Coverage floor: 80.0%"
+            echo "- Cyclomatic complexity: less than 20"
+            echo "- Duplicate block threshold: 200 tokens"
+            echo "- Source limits: 1 MiB and 1,500 lines"
+            echo "- Stability: three consecutive test passes"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload quality metrics
+        if: always()
+        uses: actions/upload-artifact@v4.6.2
+        with:
+          name: quality-metrics
+          path: quality-metrics/
+          if-no-files-found: error
+          retention-days: 30

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,60 @@
+name: security-review
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+  schedule:
+    - cron: "31 5 * * 2"
+
+permissions:
+  contents: read
+  security-events: write
+
+jobs:
+  codeql:
+    name: CodeQL (Go)
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6.0.2
+
+      - name: Setup Go
+        uses: actions/setup-go@v6.3.0
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v4
+        with:
+          languages: go
+          queries: security-and-quality
+
+      - name: Build
+        run: go build ./cmd/all-cli
+
+      - name: Analyze
+        uses: github/codeql-action/analyze@v4
+        with:
+          category: /language:go
+          upload: always
+
+  dependency-review:
+    name: Dependency review
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6.0.2
+
+      - name: Review dependency changes
+        uses: actions/dependency-review-action@v4.8.0
+        with:
+          fail-on-severity: high
+          deny-licenses: GPL-2.0, GPL-3.0, AGPL-1.0, AGPL-3.0
+          show-openssf-scorecard: true

--- a/.github/workflows/labels.yml
+++ b/.github/workflows/labels.yml
@@ -1,0 +1,68 @@
+name: labels
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - .github/labels.json
+      - .github/workflows/labels.yml
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6.0.2
+
+      - name: Synchronize versioned labels
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require("fs");
+            const desired = JSON.parse(fs.readFileSync(".github/labels.json", "utf8"));
+            const current = await github.paginate(github.rest.issues.listLabelsForRepo, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              per_page: 100,
+            });
+            const byName = new Map(current.map((label) => [label.name, label]));
+
+            for (const label of desired) {
+              if (!/^[0-9A-Fa-f]{6}$/.test(label.color)) {
+                core.setFailed(`Invalid color for ${label.name}: ${label.color}`);
+                return;
+              }
+              const existing = byName.get(label.name);
+              if (existing) {
+                if (
+                  existing.color.toLowerCase() !== label.color.toLowerCase() ||
+                  existing.description !== label.description
+                ) {
+                  await github.rest.issues.updateLabel({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    name: label.name,
+                    new_name: label.name,
+                    color: label.color,
+                    description: label.description,
+                  });
+                }
+              } else {
+                await github.rest.issues.createLabel({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  name: label.name,
+                  color: label.color,
+                  description: label.description,
+                });
+              }
+            }
+            await core.summary.addHeading("Label taxonomy").addRaw(
+              `Synchronized ${desired.length} versioned labels without deleting unrelated labels.`
+            ).write();

--- a/.github/workflows/qa.yml
+++ b/.github/workflows/qa.yml
@@ -27,11 +27,14 @@ jobs:
 
       - name: Resolve PR metadata
         id: pr
+        env:
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_HEAD_REF: ${{ github.head_ref }}
         shell: bash
         run: |
           if [ "${{ github.event_name }}" = "pull_request" ]; then
-            echo "number=${{ github.event.pull_request.number }}" >> "$GITHUB_OUTPUT"
-            echo "ref=${{ github.head_ref }}" >> "$GITHUB_OUTPUT"
+            echo "number=$PR_NUMBER" >> "$GITHUB_OUTPUT"
+            echo "ref=$PR_HEAD_REF" >> "$GITHUB_OUTPUT"
           else
             echo "number=" >> "$GITHUB_OUTPUT"
             echo "ref=${GITHUB_REF_NAME}" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,7 @@ on:
 
 permissions:
   contents: write
+  deployments: write
 
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
@@ -17,6 +18,9 @@ concurrency:
 jobs:
   release:
     runs-on: ubuntu-latest
+    environment:
+      name: production
+      url: ${{ steps.release-info.outputs.url }}
     steps:
       - name: Checkout
         uses: actions/checkout@v6.0.2
@@ -52,6 +56,7 @@ jobs:
           git push origin "$tag"
 
       - name: GoReleaser
+        id: goreleaser
         uses: goreleaser/goreleaser-action@v7.0.0
         with:
           version: v2.14.3
@@ -59,3 +64,48 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           HOMEBREW_TAP_GITHUB_TOKEN: ${{ secrets.HOMEBREW_TAP_GITHUB_TOKEN }}
+
+      - name: Verify published release assets
+        id: release-info
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ steps.tag.outputs.tag }}
+        shell: bash
+        run: |
+          gh release view "$TAG" --json url,assets > /tmp/release.json
+          url="$(jq -r '.url' /tmp/release.json)"
+          mapfile -t assets < <(jq -r '.assets[].name' /tmp/release.json)
+          printf 'url=%s\n' "$url" >> "$GITHUB_OUTPUT"
+          printf '%s\n' "${assets[@]}" | grep -qx 'checksums.txt'
+          archive_count="$(printf '%s\n' "${assets[@]}" | grep -Ec '^all-cli_.*_(darwin|linux)_(amd64|arm64)\.tar\.gz$')"
+          if [[ "$archive_count" -ne 4 ]]; then
+            printf 'expected four platform archives, found %s\n' "$archive_count" >&2
+            printf '%s\n' "${assets[@]}" >&2
+            exit 1
+          fi
+          {
+            echo "### Published release"
+            echo
+            echo "- Tag: \`$TAG\`"
+            echo "- Release: $url"
+            echo "- Verified: checksums plus four Darwin/Linux amd64/arm64 archives"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Deployment impact links
+        if: always()
+        env:
+          SENTRY_DASHBOARD_URL: ${{ vars.SENTRY_DASHBOARD_URL }}
+          PROMETHEUS_DASHBOARD_URL: ${{ vars.PROMETHEUS_DASHBOARD_URL }}
+          POSTHOG_DASHBOARD_URL: ${{ vars.POSTHOG_DASHBOARD_URL }}
+        shell: bash
+        run: |
+          {
+            echo "### Deployment impact"
+            echo
+            echo "- [Production deployment history]($GITHUB_SERVER_URL/$GITHUB_REPOSITORY/deployments)"
+            echo "- [Release runbook]($GITHUB_SERVER_URL/$GITHUB_REPOSITORY/blob/main/docs/runbooks/release.md)"
+            echo "- [Telemetry alert workflow]($GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/workflows/telemetry-alerts.yml)"
+            if [[ -n "$SENTRY_DASHBOARD_URL" ]]; then echo "- [Sentry errors]($SENTRY_DASHBOARD_URL)"; fi
+            if [[ -n "$PROMETHEUS_DASHBOARD_URL" ]]; then echo "- [Prometheus performance]($PROMETHEUS_DASHBOARD_URL)"; fi
+            if [[ -n "$POSTHOG_DASHBOARD_URL" ]]; then echo "- [PostHog adoption]($POSTHOG_DASHBOARD_URL)"; fi
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/telemetry-alerts.yml
+++ b/.github/workflows/telemetry-alerts.yml
@@ -1,0 +1,134 @@
+name: telemetry-alerts
+
+on:
+  schedule:
+    - cron: "17 * * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: write
+
+concurrency:
+  group: telemetry-alerts
+  cancel-in-progress: false
+
+jobs:
+  sentry-to-issues:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Check Sentry configuration
+        id: config
+        env:
+          SENTRY_ORG: ${{ vars.SENTRY_ORG }}
+          SENTRY_PROJECT: ${{ vars.SENTRY_PROJECT }}
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+        shell: bash
+        run: |
+          if [[ -n "$SENTRY_ORG" && -n "$SENTRY_PROJECT" && -n "$SENTRY_AUTH_TOKEN" ]]; then
+            echo "enabled=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "enabled=false" >> "$GITHUB_OUTPUT"
+            echo "Sentry issue ingestion skipped: configure SENTRY_ORG, SENTRY_PROJECT, and SENTRY_AUTH_TOKEN." >> "$GITHUB_STEP_SUMMARY"
+          fi
+
+      - name: Fetch recent unresolved Sentry issues
+        if: steps.config.outputs.enabled == 'true'
+        env:
+          SENTRY_ORG: ${{ vars.SENTRY_ORG }}
+          SENTRY_PROJECT: ${{ vars.SENTRY_PROJECT }}
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+        shell: bash
+        run: |
+          curl --fail-with-body --silent --show-error \
+            --retry 2 --retry-all-errors --max-time 20 \
+            --get "https://sentry.io/api/0/projects/${SENTRY_ORG}/${SENTRY_PROJECT}/issues/" \
+            --header "Authorization: Bearer ${SENTRY_AUTH_TOKEN}" \
+            --data-urlencode "query=is:unresolved lastSeen:-1h" \
+            --data-urlencode "limit=50" \
+            --output /tmp/sentry-issues.json
+          jq -e 'type == "array"' /tmp/sentry-issues.json >/dev/null
+
+      - name: Create or update actionable issues
+        if: steps.config.outputs.enabled == 'true'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require("fs");
+            const sentryIssues = JSON.parse(fs.readFileSync("/tmp/sentry-issues.json", "utf8"));
+            const cleanText = (value, max = 160) =>
+              String(value || "unknown").replace(/[\r\n\t`<>{}]/g, " ").replace(/\s+/g, " ").trim().slice(0, max);
+            const safeURL = (value) => {
+              try {
+                const url = new URL(String(value));
+                return url.protocol === "https:" ? url.toString() : "";
+              } catch {
+                return "";
+              }
+            };
+            const runbookURL = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/blob/main/docs/runbooks/telemetry-alert.md`;
+            const openIssues = await github.paginate(github.rest.issues.listForRepo, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: "open",
+              labels: "area:observability",
+              per_page: 100,
+            });
+
+            for (const issue of sentryIssues.slice(0, 50)) {
+              const id = cleanText(issue.id, 40);
+              if (!/^\d+$/.test(id)) continue;
+              const marker = `<!-- sentry:${id} -->`;
+              const level = cleanText(issue.level, 20).toLowerCase();
+              const priority = ["fatal", "error"].includes(level) ? "priority:P1" : "priority:P2";
+              const title = `[Sentry] ${cleanText(issue.title || issue.culprit)}`;
+              const link = safeURL(issue.permalink);
+              const release = cleanText(issue.firstRelease?.version || "unknown", 100);
+              const body = [
+                marker,
+                "## Contextual production error",
+                "",
+                `- Sentry: ${link || "link unavailable"}`,
+                `- Level: \`${cleanText(issue.level, 20)}\``,
+                `- First seen: \`${cleanText(issue.firstSeen, 40)}\``,
+                `- Last seen: \`${cleanText(issue.lastSeen, 40)}\``,
+                `- Event count: \`${cleanText(issue.count, 20)}\``,
+                `- First release: \`${release}\``,
+                "",
+                "## Triage",
+                "",
+                "- [ ] Confirm release, environment, command tag, trace ID, breadcrumb, and stack frames in Sentry",
+                "- [ ] Classify user impact and adjust priority",
+                "- [ ] Reproduce without copying user arguments, private configuration, or tokens",
+                "- [ ] Link a tested fix or record mitigation",
+                "",
+                `Runbook: [telemetry alert response](${runbookURL})`,
+              ].join("\n");
+
+              const match = openIssues.find((candidate) => candidate.body?.includes(marker));
+              if (match) {
+                await github.rest.issues.update({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: match.number,
+                  title,
+                  body,
+                  labels: [priority, "type:bug", "area:observability"],
+                  assignees: ["oldwinter"],
+                });
+              } else {
+                const created = await github.rest.issues.create({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  title,
+                  body,
+                  labels: [priority, "type:bug", "area:observability"],
+                  assignees: ["oldwinter"],
+                });
+                openIssues.push(created.data);
+              }
+            }
+            await core.summary.addHeading("Sentry error-to-insight").addRaw(
+              `Processed ${Math.min(sentryIssues.length, 50)} recent unresolved issue(s).`
+            ).write();

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,19 @@
 .DS_Store
 .idea/
 .vscode/
+.worktrees/
+
+# Local secrets and environment configuration
+.env
+.env.*
+!.env.example
+.secrets/
+*.key
+*.pem
+*.p12
+*.pfx
+credentials.local.*
+secrets.local.*
 
 # Go
 bin/
@@ -9,6 +22,13 @@ dist/
 *.test
 *.out
 coverage.out
+coverage.html
+quality-metrics/
+qa-results/
 
 # Local builds
 /all-cli
+
+# Opt-in local telemetry state and textfile metrics
+.all-cli-telemetry/
+all-cli.prom

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,6 +1,11 @@
 version: "2"
 linters:
+  enable:
+    - dupl
+    - gocyclo
   settings:
+    dupl:
+      threshold: 200
     errcheck:
       exclude-functions:
         - fmt.Fprintf
@@ -8,6 +13,8 @@ linters:
         - fmt.Fprint
         - (io.Writer).Write
         - (*text/tabwriter.Writer).Flush
+    gocyclo:
+      min-complexity: 20
   exclusions:
     generated: lax
     presets:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,35 @@
+minimum_pre_commit_version: "3.7.0"
+
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v6.0.0
+    hooks:
+      - id: check-added-large-files
+        args: [--maxkb=1024]
+      - id: check-merge-conflict
+      - id: check-yaml
+      - id: end-of-file-fixer
+      - id: trailing-whitespace
+
+  - repo: local
+    hooks:
+      - id: gofmt
+        name: gofmt
+        entry: gofmt -w
+        language: system
+        types: [go]
+      - id: repository-policy
+        name: repository policy
+        entry: env -u GOROOT -u GOTOOLDIR go test ./internal/repopolicy -run TestRepositoryPolicy -count=1
+        language: system
+        pass_filenames: false
+      - id: go-vet
+        name: go vet
+        entry: env -u GOROOT -u GOTOOLDIR go vet ./...
+        language: system
+        pass_filenames: false
+      - id: go-test
+        name: go test
+        entry: env -u GOROOT -u GOTOOLDIR go test ./...
+        language: system
+        pass_filenames: false

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,8 +13,12 @@
 - Tests are colocated with code as `*_test.go`.
 
 ## Build, Test, and Development Commands
-- `just ci`: CI-equivalent checks (`verify-tidy`, `vet`, `test`).
-- `just check`: stricter local gate (`ci` + `test-race` + `fmt-check`).
+- `just ci`: CI-equivalent quality gate (`verify-tidy`, formatting, repository policy, vet, tests, coverage threshold, complexity, and duplication checks).
+- `just check`: stricter local gate (`ci` + race tests + three-pass stability tests).
+- `just policy`: validate file-size/line limits, issue-linked debt markers, and AGENTS.md command/link freshness.
+- `just coverage-check`: enforce the 80% total statement coverage floor.
+- `just lint`: run golangci-lint, including a maximum cyclomatic complexity of 19 and duplicate-block detection at 200 tokens.
+- `just pre-commit`: run every configured commit-time hook against all files.
 - `just build`: build local binary at `./all-cli`.
 - `just run status --json`: run from source without building manually.
 - `just smoke`: quick sanity check (`version` + `status --group-by none`).
@@ -47,7 +51,14 @@
 - Use Go’s standard `testing` package.
 - Add or update `*_test.go` for any behavior change.
 - Prefer table-driven tests for parsing/validation branches and adapter edge cases.
+- Keep total statement coverage at or above 80%; `just coverage-check` enforces the floor.
+- Treat `just test-stability` failures as flaky-test defects, not as retryable noise.
 - Run `just check` before opening a PR; at minimum ensure `go test ./...` passes.
+
+## Local Commit Hooks
+- Install pre-commit with `pipx install pre-commit`, then run `pre-commit install`.
+- Hooks format staged Go files, reject files over 1 MiB, validate repository policy, run `go vet`, and run the Go test suite.
+- Run `just pre-commit` before a pull request to exercise every hook against the full repository.
 
 ## Commit & Pull Request Guidelines
 - Commit subjects are short and imperative; many commits use Conventional Commit prefixes (`feat:`, `fix:`). Prefer `<type>: <summary>`.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,6 +6,8 @@ Thanks for your interest in contributing! This document covers the development w
 
 - **Go 1.26.1+** (auto-downloads if your Go toolchain supports it; see `go.mod`)
 - **just** (optional but recommended — install via `brew install just` or [just.systems](https://just.systems/))
+- **golangci-lint v2.11.3+** for complexity, duplication, and static analysis
+- **pre-commit 3.7+** for commit-time validation
 
 ## Quick Start
 
@@ -16,15 +18,17 @@ go mod tidy
 go test ./...
 go build ./cmd/all-cli
 ./all-cli status
+pipx install pre-commit
+pre-commit install
 ```
 
 ## Development Workflow
 
 ```bash
-# CI-equivalent checks (tidy + vet + test)
+# CI-equivalent checks, including policy, coverage, and lint thresholds
 just ci
 
-# Stricter local gate (ci + race + format check)
+# Stricter local gate (CI + race and stability tests)
 just check
 
 # Build and run a quick smoke test
@@ -56,6 +60,9 @@ See `just help` for all available recipes.
 - Prefer table-driven tests.
 - Colocate tests as `*_test.go` next to the code.
 - Run `just check` before opening a PR; at minimum ensure `go test ./...` passes.
+- Maintain at least 80% total statement coverage (`just coverage-check`).
+- Link technical-debt markers to a GitHub issue, for example `TODO(#123): remove the compatibility path`.
+- Keep source and documentation files below the repository policy limits of 1 MiB and 1,500 lines.
 
 ## Pull Requests
 

--- a/README.md
+++ b/README.md
@@ -40,6 +40,21 @@ all-cli version
 
 ## Local development
 
+### Dev container
+
+The repository includes a pinned Go development container with GitHub CLI,
+`just`, and `pre-commit`. In VS Code or another Dev Container client, choose
+**Reopen in Container**. The container downloads Go modules and installs the
+repository hooks automatically.
+
+For a host-based setup:
+
+```bash
+brew install just golangci-lint pipx
+pipx install pre-commit
+pre-commit install
+```
+
 ### Local test (without just)
 
 ```bash
@@ -70,12 +85,18 @@ just check
 
 # build and run quick smoke checks
 just smoke
+
+# exercise every commit-time hook
+just pre-commit
 ```
 
 High-frequency recipes:
 
-- `just ci`: same checks as GitHub CI (`verify-tidy + vet + test`)
-- `just check`: stronger local gate (`ci + test-race + fmt-check`)
+- `just ci`: CI policy (`tidy + format + repository policy + vet + tests + 80% coverage + lint`)
+- `just check`: stronger local gate (`ci + race tests + three-pass stability tests`)
+- `just policy`: check source size, issue-linked debt markers, and AGENTS.md freshness
+- `just lint`: enforce cyclomatic-complexity and duplicate-code thresholds
+- `just pre-commit`: run every configured commit hook against all files
 - `just fmt` / `just fmt-check`: format code or enforce formatting
 - `just test-cover`: run coverage and print per-package function coverage
 - `just coverage-html`: write `coverage.html` for detailed coverage browsing
@@ -336,3 +357,24 @@ all-cli kargo use --unset
 
 - `all-cli` does **not** print or read plaintext tokens/secrets.
 - It avoids `--show-token` flags and only uses official CLI outputs to determine “configured” state.
+
+## Feature flags and observability
+
+Risky or operational behavior can be rolled out through the typed feature-flag
+registry documented in [docs/feature-flags.md](docs/feature-flags.md).
+
+CLI observability is disabled by default. Explicitly enabling
+`ALL_CLI_FEATURES=telemetry-v1` activates only the sinks configured by
+environment variables:
+
+- `ALL_CLI_LOG_PATH` for structured JSON `slog` events,
+- `ALL_CLI_METRICS_PATH` for atomic Prometheus textfile metrics,
+- `ALL_CLI_TRACEPARENT` for W3C trace correlation,
+- `SENTRY_DSN` for contextualized failed-command events,
+- `POSTHOG_API_KEY` for privacy-minimized command-use analytics.
+
+Telemetry omits arguments, environment contents, external command output,
+identity, and configuration values. See
+[docs/observability.md](docs/observability.md) for the data contract,
+dashboards, setup, and opt-out, and [docs/runbooks](docs/runbooks/README.md)
+for alert, release, rollback, and privacy procedures.

--- a/cmd/all-cli/main.go
+++ b/cmd/all-cli/main.go
@@ -1,14 +1,14 @@
 package main
 
 import (
+	"context"
 	"os"
 
 	"github.com/oldwinter/all-cli/internal/cli"
 )
 
 func main() {
-	cmd := cli.NewRootCommand()
-	if err := cmd.Execute(); err != nil {
+	if err := cli.Execute(context.Background(), os.Args[1:], os.Stdout, os.Stderr, os.Getenv); err != nil {
 		os.Exit(1)
 	}
 }

--- a/docs/dependency-policy.md
+++ b/docs/dependency-policy.md
@@ -1,0 +1,39 @@
+# Dependency update policy
+
+Dependabot opens grouped weekly pull requests for Go modules, GitHub Actions,
+and the development container.
+
+## Minimum release age
+
+Normal dependency releases must be at least **seven full days old** before a
+version-update pull request is merged. The waiting period begins at the
+upstream registry or release timestamp, not when Dependabot opens the pull
+request.
+
+The reviewer records the upstream release timestamp and earliest eligible
+merge time in the pull request. If the release is younger than seven days,
+leave the pull request open and allow CI and community reports to accumulate.
+
+## Required review
+
+Before merge:
+
+1. Read upstream release notes and linked migration/security notes.
+2. Verify source repository, module path, checksum, and maintainer identity.
+3. Run `go mod verify`, `just check`, CodeQL, and dependency review.
+4. Inspect transitive changes with `go mod graph` and `go mod why`.
+5. Confirm the pull request includes a rollback plan.
+
+## Security exception
+
+The seven-day wait may be waived only when a linked security advisory shows
+that delaying is riskier than updating. The pull request must:
+
+- link the advisory or CVE,
+- explain exploitability in `all-cli`,
+- receive explicit maintainer approval,
+- pass all required security and quality checks,
+- document the previous known-good version and rollback command.
+
+The exception changes timing only; it never bypasses tests, review, or branch
+protection.

--- a/docs/feature-flags.md
+++ b/docs/feature-flags.md
@@ -1,0 +1,31 @@
+# Feature flags
+
+`all-cli` uses a closed, typed feature-flag registry in `internal/featureflags`.
+Flags are explicitly enabled with a comma-separated environment variable:
+
+```bash
+ALL_CLI_FEATURES=telemetry-v1 all-cli status
+```
+
+Unknown flag names stop startup with an actionable error. This prevents typos
+from silently selecting an unexpected rollout state.
+
+## Active flags
+
+| Flag | Default | Owner | Purpose | Disable or rollback |
+|---|---|---|---|---|
+| `telemetry-v1` | Disabled | `@oldwinter` | Enables privacy-minimized structured events, metrics, contextual error capture, and command-use analytics when their sinks are configured. | Remove the value from `ALL_CLI_FEATURES`; no telemetry sink is initialized. |
+
+## Adding a flag
+
+1. Add a typed constant and register it in `internal/featureflags/flags.go`.
+2. Add parser, default, unknown-value, and context-propagation tests.
+3. Gate real production behavior with `featureflags.Enabled`; unused flag
+   declarations are not accepted.
+4. Document the owner, default, purpose, rollout population, success signal,
+   failure signal, and rollback here.
+5. Remove the flag after the rollout decision so permanent branches do not
+   accumulate.
+
+Flags must default to the safer behavior. A flag may not disable security,
+privacy, schema compatibility, or validation controls.

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -1,0 +1,89 @@
+# CLI observability
+
+Runtime telemetry is **disabled by default**. Set
+`ALL_CLI_FEATURES=telemetry-v1` to initialize configured sinks. Telemetry
+delivery failures never change the command's output or exit status.
+
+## Data contract
+
+Every enabled command lifecycle records:
+
+- normalized command path without flags or arguments,
+- `success` or `error`,
+- duration,
+- release version,
+- a random or W3C-propagated trace ID.
+
+The implementation intentionally excludes command arguments, environment
+contents, external command output, usernames, account IDs, configuration
+values, and paths. PostHog receives no error text or trace ID. Sentry receives
+a scrubbed error, release/environment context, trace context, a command
+breadcrumb, and an in-process stack trace.
+
+## Structured logs
+
+Set `ALL_CLI_LOG_PATH` to append one `log/slog` JSON event per command:
+
+```bash
+ALL_CLI_FEATURES=telemetry-v1 \
+ALL_CLI_LOG_PATH="$HOME/.local/state/all-cli/events.jsonl" \
+all-cli status
+```
+
+The file is created with mode `0600` inside directories created with mode
+`0700`.
+
+## Traces
+
+Set `ALL_CLI_TRACEPARENT` to a valid W3C traceparent. `all-cli` reuses its
+32-hex trace ID across structured logs and contextual errors. Invalid or absent
+values produce a new random trace ID.
+
+## Prometheus metrics
+
+Set `ALL_CLI_METRICS_PATH` to a Prometheus node-exporter textfile location:
+
+```bash
+ALL_CLI_FEATURES=telemetry-v1 \
+ALL_CLI_METRICS_PATH=/var/lib/node_exporter/textfile_collector/all-cli.prom \
+all-cli doctor
+```
+
+The atomic textfile exposes command/result counters plus duration sum/count.
+It never uses trace IDs or error text as labels.
+
+## Sentry contextual errors
+
+Set `SENTRY_DSN` and optionally `SENTRY_ENVIRONMENT`. Failed commands submit a
+Sentry envelope with a two-second deadline. To enable the repository's
+error-to-insight pipeline, configure:
+
+- repository variables `SENTRY_ORG` and `SENTRY_PROJECT`,
+- repository secret `SENTRY_AUTH_TOKEN` with read-only project issue access,
+- repository variable `SENTRY_DASHBOARD_URL` pointing to the operator dashboard.
+
+The hourly `telemetry-alerts` workflow creates or updates deduplicated GitHub
+issues and assigns the code owner. See
+[`docs/runbooks/telemetry-alert.md`](runbooks/telemetry-alert.md).
+
+## PostHog product analytics
+
+Set `POSTHOG_API_KEY` and optionally `POSTHOG_HOST` (default:
+`https://us.i.posthog.com`). Capture events include only anonymous installation
+ID, command, result, release, and library name. Set repository variable
+`POSTHOG_DASHBOARD_URL` to the maintained usage dashboard.
+
+The anonymous ID is generated only when PostHog is configured and is stored in
+the user config directory with mode `0600`. Removing that file resets it.
+
+## Dashboards and ownership
+
+Operators find current links in GitHub repository **Settings → Secrets and
+variables → Actions → Variables**:
+
+- `SENTRY_DASHBOARD_URL`: failures by release, command, and environment,
+- `POSTHOG_DASHBOARD_URL`: command adoption and release usage,
+- `PROMETHEUS_DASHBOARD_URL`: command count, error ratio, and duration.
+
+`@oldwinter` owns dashboard access and retention policy. Do not place access
+tokens in repository variables or documentation.

--- a/docs/plans/2026-02-24-all-cli-design.md
+++ b/docs/plans/2026-02-24-all-cli-design.md
@@ -4,8 +4,8 @@
 
 Build a CLI tool `all-cli` that:
 
-1) Inspects whether common CLI tools are installed/configured  
-2) Provides context read/list/switch for `kubectl`, `docker`, `gh`, `glab`  
+1) Inspects whether common CLI tools are installed/configured
+2) Provides context read/list/switch for `kubectl`, `docker`, `gh`, `glab`
 3) Outputs human-friendly tables by default and stable JSON with `--json`, to enable a future SwiftUI macOS app.
 
 ## Scope (v0.1)

--- a/docs/runbooks/README.md
+++ b/docs/runbooks/README.md
@@ -1,0 +1,23 @@
+# Incident runbooks
+
+These playbooks define the response surface for the released CLI and its
+opt-in telemetry.
+
+| Trigger | Runbook | Primary owner |
+|---|---|---|
+| Release workflow failure or bad artifact | [Release and rollback](release.md) | `@oldwinter` |
+| Sentry issue, metric alert, or telemetry-created GitHub issue | [Telemetry alert](telemetry-alert.md) | `@oldwinter` |
+| Suspected sensitive telemetry or unauthorized collection | [Telemetry privacy incident](privacy.md) | `@oldwinter` |
+
+## Severity and response
+
+| Severity | Meaning | Initial response |
+|---|---|---|
+| P0 | Active credential/private-data exposure or broadly destructive release | Stop distribution immediately; begin response within 15 minutes |
+| P1 | Release unusable for most users, repeated fatal errors, or confirmed privacy defect | Triage within one hour |
+| P2 | Degraded command or elevated error rate with a workaround | Triage within one business day |
+| P3 | Low-impact defect or operational improvement | Prioritize through normal backlog review |
+
+Record evidence and decisions in the linked GitHub issue. Never paste tokens,
+private configuration, full environment dumps, or unredacted external command
+output into an incident record.

--- a/docs/runbooks/privacy.md
+++ b/docs/runbooks/privacy.md
@@ -1,0 +1,43 @@
+# Telemetry privacy incident runbook
+
+## Trigger
+
+Use this runbook for suspected secrets, account identifiers, private paths,
+user-generated output, or telemetry sent without explicit `telemetry-v1`
+enablement.
+
+## Contain
+
+1. Disable `telemetry-v1` for managed environments.
+2. Remove `SENTRY_DSN` and `POSTHOG_API_KEY` from affected runtime
+   environments to stop network delivery.
+3. Restrict dashboard access and pause the `telemetry-alerts` workflow if issue
+   bodies could repeat the sensitive value.
+4. Open a private GitHub security advisory. Do not copy the sensitive payload
+   into a public issue.
+
+## Investigate
+
+1. Identify sink, event schema, release, first/last seen, and affected event
+   count.
+2. Verify whether the value exists in structured logs, Prometheus labels,
+   Sentry envelopes, PostHog properties, or GitHub issues.
+3. Use event IDs and timestamps, not raw sensitive values, to correlate
+   records.
+4. Review retention and deletion capabilities with the telemetry provider.
+
+## Eradicate and recover
+
+1. Add a failing privacy regression test that reproduces the leaked field.
+2. Fix redaction or remove the field, then run telemetry race tests and the
+   security review.
+3. Request provider-side deletion and record confirmation in the private
+   advisory.
+4. Rotate any exposed credential at its source.
+5. Re-enable telemetry only after maintainer review and a verified release.
+
+## Follow-up
+
+Document root cause, affected data classes, retention/deletion outcome,
+detection gap, and a preventive test. Notify affected users according to
+applicable policy and legal requirements.

--- a/docs/runbooks/release.md
+++ b/docs/runbooks/release.md
@@ -1,0 +1,45 @@
+# Release and rollback runbook
+
+## Observe deployment impact
+
+Every push to `main` creates a GitHub production deployment and a checksummed
+release. Use:
+
+- **Actions → release** for build/test/publish status,
+- **Environments → production** for deployment history,
+- the release summary for tag and asset verification,
+- `SENTRY_DASHBOARD_URL` for errors by release,
+- `PROMETHEUS_DASHBOARD_URL` for error ratio and duration,
+- `POSTHOG_DASHBOARD_URL` for adoption of the new release.
+
+Dashboard URLs are maintained as repository Actions variables, not committed
+credentials.
+
+## Failed release
+
+1. Preserve the failed workflow link and step logs in a `type:bug`,
+   `area:ci` issue.
+2. Determine whether tagging, GitHub release publication, or Homebrew formula
+   update occurred.
+3. If nothing published, fix forward through a reviewed pull request.
+4. If a partial release published, mark the GitHub release as a prerelease,
+   explain the incomplete state, and stop Homebrew promotion.
+5. Rerun only after `just check` and `goreleaser check` pass at the intended
+   commit.
+
+## Bad published release
+
+1. Classify user impact and open a P0/P1 incident issue.
+2. Do not rewrite or delete the existing tag; released checksums are immutable
+   evidence.
+3. Revert the faulty change through a protected pull request.
+4. Publish the next release and verify all four platform archives plus
+   `checksums.txt`.
+5. Confirm error rate and command success recover on the dashboards.
+6. Add release notes identifying the superseded version.
+
+## Completion
+
+Close the incident only after release assets, Homebrew installation, `all-cli
+version`, and one representative `all-cli status --group-by none` smoke test
+are verified.

--- a/docs/runbooks/telemetry-alert.md
+++ b/docs/runbooks/telemetry-alert.md
@@ -1,0 +1,43 @@
+# Telemetry alert runbook
+
+## Detection
+
+Alerts enter through the scheduled
+[`telemetry-alerts`](../../.github/workflows/telemetry-alerts.yml) workflow.
+It queries unresolved Sentry issues updated in the last hour and creates or
+updates one GitHub issue per Sentry issue. GitHub assignment notifies the
+repository owner.
+
+Operators can also inspect:
+
+- the Sentry dashboard in repository variable `SENTRY_DASHBOARD_URL`,
+- the Prometheus dashboard in `PROMETHEUS_DASHBOARD_URL`,
+- the PostHog usage dashboard in `POSTHOG_DASHBOARD_URL`,
+- workflow history under **Actions → telemetry-alerts**.
+
+## Triage
+
+1. Confirm the GitHub issue marker matches the linked Sentry issue.
+2. Check first/last seen, event count, release, environment, command tag, trace
+   ID, breadcrumb, and stack frames.
+3. Compare the error rate and duration with the previous release.
+4. Reproduce with the same released binary and command path without copying
+   user arguments or private configuration.
+5. Assign severity using the runbook index and update labels if necessary.
+
+## Mitigation
+
+- If the error exists only in telemetry delivery, disable `telemetry-v1` or the
+  affected sink while preserving CLI behavior.
+- If a released command is broken, follow the
+  [release rollback runbook](release.md).
+- If any event may contain sensitive data, stop ingestion and switch to the
+  [privacy runbook](privacy.md).
+
+## Resolution
+
+1. Link the fixing pull request and its tests.
+2. Verify the error no longer appears in the affected release/environment.
+3. Record the root cause, detection gap, and preventive action.
+4. Resolve the Sentry issue, then close the GitHub issue with verification
+   evidence.

--- a/docs/superpowers/plans/2026-08-23-agent-readiness.md
+++ b/docs/superpowers/plans/2026-08-23-agent-readiness.md
@@ -1,0 +1,524 @@
+# Agent Readiness Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add enforceable quality, testing, development, delivery, observability, security, and governance controls that address all 31 failing Agent Readiness signals.
+
+**Architecture:** Repository-owned controls run identically through Go tests, `just`, pre-commit, and GitHub Actions. Runtime observability is centralized at the CLI execution boundary, gated by a typed feature flag, privacy-minimized, and connected to standard opt-in sinks. GitHub-native workflows and settings provide security reporting, alert-to-issue routing, labels, deployments, and protected review flow.
+
+**Tech Stack:** Go 1.26.1, Cobra, `log/slog`, GitHub Actions, CodeQL, Dependabot, pre-commit, golangci-lint, Dev Containers, GitHub REST API
+
+**Spec:** `docs/superpowers/specs/2026-08-23-agent-readiness-design.md`
+
+## Global Constraints
+
+- Preserve the pre-existing changes in `AGENTS.md`, `internal/cli/agent_commands.go`, `internal/cli/agent_commands_test.go`, `CONTEXT.md`, `internal/cli/doctor_fix.go`, and `qa-bin/`.
+- Runtime telemetry is disabled unless `ALL_CLI_FEATURES` contains `telemetry-v1`.
+- Never record command arguments, environment contents, external command output, usernames, file paths, tokens, or configuration values.
+- Telemetry delivery errors never alter a CLI command's result.
+- The initial total statement coverage floor is exactly 80.0%.
+- Normal dependency releases wait at least seven full days before merge.
+- Do not commit or push local changes unless the user separately requests it.
+
+---
+
+## File structure
+
+### Repository quality
+
+- `internal/repopolicy/policy.go`: reusable repository file, debt-marker, and AGENTS.md policy checks.
+- `internal/repopolicy/policy_test.go`: unit tests plus the live repository-policy test.
+- `scripts/check-coverage.sh`: run tests and enforce the 80.0% floor.
+- `.golangci.yml`: complexity and duplication thresholds.
+- `.pre-commit-config.yaml`: commit-time formatting, policy, vet, and test hooks.
+- `justfile`: local entrypoints matching CI.
+- `.github/workflows/ci.yml`: timing, stability, coverage, reports, summaries, and artifacts.
+
+### Agent environment and contribution metadata
+
+- `.devcontainer/devcontainer.json`: pinned Go container and tools.
+- `.github/CODEOWNERS`: default ownership.
+- `.github/ISSUE_TEMPLATE/bug.yml`: actionable defect intake.
+- `.github/ISSUE_TEMPLATE/feature.yml`: scoped feature intake.
+- `.github/ISSUE_TEMPLATE/config.yml`: template policy.
+- `.github/pull_request_template.md`: context, testing, risk, and rollback.
+- `.gitignore`: local secrets and generated telemetry.
+- `AGENTS.md`, `CONTRIBUTING.md`, `README.md`: accurate operator and contributor commands.
+
+### Safe runtime controls
+
+- `internal/featureflags/flags.go`: typed parsing and context propagation.
+- `internal/featureflags/flags_test.go`: known/unknown/default flag behavior.
+- `internal/telemetry/recorder.go`: lifecycle, structured logging, trace correlation, and sink coordination.
+- `internal/telemetry/recorder_test.go`: command lifecycle and privacy tests.
+- `internal/telemetry/prometheus.go`: atomic Prometheus textfile output.
+- `internal/telemetry/prometheus_test.go`: metric format and aggregation tests.
+- `internal/telemetry/sentry.go`: bounded Sentry envelope delivery.
+- `internal/telemetry/sentry_test.go`: payload, context, and failure isolation tests.
+- `internal/telemetry/posthog.go`: bounded PostHog capture delivery.
+- `internal/telemetry/posthog_test.go`: minimized analytics payload tests.
+- `internal/cli/execute.go`: one execution boundary for feature flags and telemetry.
+- `internal/cli/execute_test.go`: success/error command recording tests.
+- `cmd/all-cli/main.go`: delegate to `cli.Execute`.
+
+### Security, operations, and governance
+
+- `.github/workflows/codeql.yml`: CodeQL analysis and readable security findings.
+- `.github/dependabot.yml`: grouped Go, action, and dev-container updates.
+- `docs/dependency-policy.md`: seven-day release-age policy and security exception.
+- `.github/workflows/telemetry-alerts.yml`: Sentry issue ingestion and deduplicated GitHub issue creation.
+- `.github/workflows/labels.yml`, `.github/labels.json`: versioned priority/type/area taxonomy.
+- `docs/runbooks/README.md`: runbook index and escalation policy.
+- `docs/runbooks/release.md`: failed release, impact check, and rollback.
+- `docs/runbooks/telemetry-alert.md`: alert triage and error-to-insight flow.
+- `docs/runbooks/privacy.md`: telemetry privacy incident response.
+- `.github/workflows/release.yml`: deployment record, verification, and impact summary.
+
+---
+
+### Task 1: Repository policy checks
+
+**Files:**
+- Create: `internal/repopolicy/policy.go`
+- Create: `internal/repopolicy/policy_test.go`
+
+**Interfaces:**
+- Produces: `func Audit(root string, limits Limits) ([]Violation, error)`
+- Produces: `func CheckAgentGuide(root string) ([]Violation, error)`
+- Produces: `type Limits struct { MaxBytes int64; MaxLines int }`
+- Produces: `type Violation struct { Rule, Path string; Line int; Message string }`
+
+- [ ] **Step 1: Write failing table-driven tests**
+
+Cover a 1 MiB file, a 1,500-line file, `TODO` without an issue, `TODO(#123)`, missing `just` recipes referenced by AGENTS.md, and broken local Markdown links. Use temporary repositories so fixtures do not weaken the live policy.
+
+- [ ] **Step 2: Confirm the tests fail**
+
+Run: `go test ./internal/repopolicy -run 'Test(Audit|CheckAgentGuide)' -count=1`
+
+Expected: package or symbols do not exist.
+
+- [ ] **Step 3: Implement deterministic policy traversal**
+
+Use `git -C <root> ls-files -z` to inspect tracked files only. Reject files larger than 1,048,576 bytes or 1,500 lines, excluding generated schemas and vendored/build paths by explicit allowlist. Match debt markers with `\b(TODO|FIXME|HACK|XXX)\b` and require an adjacent `#123`, `GH-123`, or full GitHub issue URL. Parse `just <recipe>` references from AGENTS.md and compare them with recipe declarations in `justfile`; resolve relative Markdown links against the guide location.
+
+- [ ] **Step 4: Add the live repository-policy test**
+
+`TestRepositoryPolicy` locates the repository root, runs `Audit` with the exact limits, runs `CheckAgentGuide`, sorts violations, and reports every actionable violation in one failure.
+
+- [ ] **Step 5: Verify**
+
+Run: `go test ./internal/repopolicy -count=1`
+
+Expected: PASS against unit fixtures and the current repository.
+
+### Task 2: Local quality gates and coverage threshold
+
+**Files:**
+- Create: `scripts/check-coverage.sh`
+- Create: `.pre-commit-config.yaml`
+- Modify: `.golangci.yml`
+- Modify: `justfile`
+- Modify: `AGENTS.md`
+- Modify: `CONTRIBUTING.md`
+
+**Interfaces:**
+- Consumes: `go test ./internal/repopolicy`
+- Produces: `just policy`, `just lint`, `just coverage-check`, `just pre-commit`
+
+- [ ] **Step 1: Write the coverage gate**
+
+Run `go test -coverprofile=coverage.out ./...`, extract the `total:` percentage from `go tool cover -func`, compare it numerically against `${COVERAGE_MIN:-80.0}`, write the actual and threshold to stdout and `$GITHUB_STEP_SUMMARY` when present, and exit nonzero below the floor.
+
+- [ ] **Step 2: Enable complexity and duplication enforcement**
+
+Enable `gocyclo` with `min-complexity: 20` and `dupl` with `threshold: 200` under golangci-lint v2. Keep all existing errcheck exclusions. The 200-token threshold remains sensitive to substantial production copy/paste blocks while avoiding noisy reports for structurally similar table-driven CLI tests.
+
+- [ ] **Step 3: Configure pre-commit**
+
+Use local hooks for `gofmt -w` on staged Go files, `go test ./internal/repopolicy`, `go vet ./...`, `go test ./...`, and the standard `check-added-large-files` hook with `--maxkb=1024`. Do not use hook-level excludes that bypass source or documentation.
+
+- [ ] **Step 4: Add matching `just` recipes and docs**
+
+Make `just ci` run tidy, format, policy, vet, tests, coverage, and lint. Make `just check` add race/stability checks. Document `pre-commit install` and exact recipes while preserving the user's existing AGENTS.md changes.
+
+- [ ] **Step 5: Verify local gates**
+
+Run:
+
+```bash
+go test ./internal/repopolicy -count=1
+bash scripts/check-coverage.sh
+golangci-lint run
+pre-commit run --all-files
+```
+
+Expected: all commands pass; coverage is at least 80.0%.
+
+### Task 3: Build, test performance, and flake evidence
+
+**Files:**
+- Modify: `.github/workflows/ci.yml`
+
+**Interfaces:**
+- Produces artifacts: `quality-metrics/coverage.out`, `quality-metrics/test-events.json`, `quality-metrics/stability-events.json`, `quality-metrics/build-seconds.txt`
+
+- [ ] **Step 1: Add deliberate build timing**
+
+Wrap `go build ./cmd/all-cli` with Bash `SECONDS`, fail above 120 seconds, and record the elapsed value in the artifact directory and job summary.
+
+- [ ] **Step 2: Add test timing reports**
+
+Run `go test -json ./...` through `tee quality-metrics/test-events.json`; JSON events include package/test elapsed values. Preserve pipeline failures with `set -o pipefail`.
+
+- [ ] **Step 3: Add proactive stability execution**
+
+Run `go test -count=3 -json ./...` through `tee quality-metrics/stability-events.json`. A pass requires every test to succeed in all three executions, not a masked retry.
+
+- [ ] **Step 4: Add coverage and lint metrics**
+
+Call `scripts/check-coverage.sh`, retain `coverage.out`, run golangci-lint with complexity and duplication enabled, and summarize the thresholds.
+
+- [ ] **Step 5: Retain metrics**
+
+Upload the complete `quality-metrics/` directory for 30 days with `if: always()` and `if-no-files-found: error`.
+
+- [ ] **Step 6: Validate workflow syntax and local equivalents**
+
+Run `just ci` and, if available, `actionlint .github/workflows/ci.yml`.
+
+Expected: local checks pass and workflow syntax is valid.
+
+### Task 4: Agent environment and contribution workflow
+
+**Files:**
+- Create: `.devcontainer/devcontainer.json`
+- Create: `.github/CODEOWNERS`
+- Create: `.github/ISSUE_TEMPLATE/bug.yml`
+- Create: `.github/ISSUE_TEMPLATE/feature.yml`
+- Create: `.github/ISSUE_TEMPLATE/config.yml`
+- Create: `.github/pull_request_template.md`
+- Modify: `.gitignore`
+- Modify: `README.md`
+
+**Interfaces:**
+- Produces: a container where `just ci` and `pre-commit run --all-files` are available.
+
+- [ ] **Step 1: Add the pinned dev container**
+
+Use `mcr.microsoft.com/devcontainers/go:1-1.26-bookworm`, official GitHub CLI and community `just`/`pre-commit` features pinned to major versions, `go mod download` as `postCreateCommand`, and Go/repository YAML extensions.
+
+- [ ] **Step 2: Add ownership and structured intake**
+
+Assign `* @oldwinter`, then add bug and feature forms requiring expected behavior, reproduction or motivation, scope, risks, and validation. Disable blank issues.
+
+- [ ] **Step 3: Add the PR template**
+
+Require summary/context, linked issue, testing commands and results, user-visible impact, risks, rollback, telemetry/privacy impact, and checklist confirmation.
+
+- [ ] **Step 4: Harden ignores**
+
+Ignore `.env`, `.env.*` except `.env.example`, credential/key/certificate files, generated coverage HTML, local telemetry state, and quality artifacts without ignoring tracked example configuration.
+
+- [ ] **Step 5: Document container and agent workflow**
+
+Add dev-container startup, hook installation, quality gates, and troubleshooting to README.
+
+- [ ] **Step 6: Verify**
+
+Run `go test ./internal/repopolicy -run TestRepositoryPolicy -count=1`, parse the dev-container JSON, and validate issue-form YAML with a YAML parser if installed.
+
+### Task 5: Typed feature flags
+
+**Files:**
+- Create: `internal/featureflags/flags.go`
+- Create: `internal/featureflags/flags_test.go`
+
+**Interfaces:**
+- Produces: `type Flag string`
+- Produces: `const TelemetryV1 Flag = "telemetry-v1"`
+- Produces: `func Parse(raw string) (Set, error)`
+- Produces: `func WithContext(context.Context, Set) context.Context`
+- Produces: `func Enabled(context.Context, Flag) bool`
+
+- [ ] **Step 1: Write failing tests**
+
+Cover blank input, comma-separated known flags, whitespace, duplicate flags, an unknown flag with a useful error, and immutable context retrieval. Follow Go's context contract by never passing a nil context.
+
+- [ ] **Step 2: Confirm failure**
+
+Run: `go test ./internal/featureflags -count=1`
+
+Expected: package or symbols do not exist.
+
+- [ ] **Step 3: Implement the registry**
+
+Keep a closed map of supported flags. Parsing returns an error naming every unknown flag. Context propagation copies the set so callers cannot mutate it.
+
+- [ ] **Step 4: Verify**
+
+Run: `go test ./internal/featureflags -count=1`
+
+Expected: PASS.
+
+### Task 6: Privacy-preserving telemetry module
+
+**Files:**
+- Create: `internal/telemetry/recorder.go`
+- Create: `internal/telemetry/recorder_test.go`
+- Create: `internal/telemetry/prometheus.go`
+- Create: `internal/telemetry/prometheus_test.go`
+- Create: `internal/telemetry/sentry.go`
+- Create: `internal/telemetry/sentry_test.go`
+- Create: `internal/telemetry/posthog.go`
+- Create: `internal/telemetry/posthog_test.go`
+
+**Interfaces:**
+- Produces: `type Config struct { LogPath, MetricsPath, SentryDSN, SentryEnvironment, PostHogKey, PostHogHost, Release string; HTTPClient *http.Client }`
+- Produces: `func New(Config) (*Recorder, error)`
+- Produces: `func (r *Recorder) Start(context.Context) (context.Context, Span)`
+- Produces: `func (r *Recorder) Finish(context.Context, Span, string, error)`
+- Produces: `type Span struct { TraceID string; StartedAt time.Time }`
+
+- [ ] **Step 1: Write recorder and privacy tests**
+
+Verify 32-hex trace IDs, accepted valid W3C `traceparent`, JSON log keys, success/error result, command name, duration, release context, and the absence of arguments, paths, environment, and error details from analytics.
+
+- [ ] **Step 2: Write sink tests with local HTTP servers**
+
+Assert Sentry envelopes contain exception type, scrubbed error message, command tag, release, environment, and trace ID. Assert PostHog capture contains only event name, command, result, release, and anonymous installation ID. Verify 500 responses and timeouts do not panic.
+
+- [ ] **Step 3: Write Prometheus tests**
+
+Record multiple command/results, assert monotonic counters and duration sum/count, stable label escaping, atomic file replacement, and no high-cardinality trace/error labels.
+
+- [ ] **Step 4: Implement recorder lifecycle**
+
+Use `log/slog` JSON handlers, context trace propagation, a two-second default HTTP timeout, bounded 8 KiB scrubbed error messages for Sentry only, and sink isolation. `Finish` invokes every configured sink even if a preceding sink fails.
+
+- [ ] **Step 5: Implement standard-compatible sinks**
+
+Write Prometheus 0.0.4 text format. Send Sentry envelope requests derived from the DSN. Send PostHog `/capture/` JSON requests. Generate and persist an anonymous random installation ID only when PostHog is configured.
+
+- [ ] **Step 6: Verify**
+
+Run: `go test -race ./internal/telemetry -count=1`
+
+Expected: PASS with no races.
+
+### Task 7: Instrument the CLI execution boundary
+
+**Files:**
+- Create: `internal/cli/execute.go`
+- Create: `internal/cli/execute_test.go`
+- Modify: `cmd/all-cli/main.go`
+- Modify: `internal/cli/root.go`
+
+**Interfaces:**
+- Consumes: `featureflags.Parse`, `telemetry.New`, `Recorder.Start`, `Recorder.Finish`
+- Produces: `func Execute(context.Context, []string, io.Writer, io.Writer, func(string) string) error`
+
+- [ ] **Step 1: Write failing boundary tests**
+
+Run `version` with telemetry disabled and assert no artifacts. Enable `telemetry-v1` with a temporary log/metrics path and assert one successful command record. Run an invalid command and assert one error record. Supply an unknown feature and assert a clear startup error.
+
+- [ ] **Step 2: Confirm failure**
+
+Run: `go test ./internal/cli -run TestExecute -count=1`
+
+Expected: `Execute` is undefined.
+
+- [ ] **Step 3: Implement environment-to-config mapping**
+
+Read only named variables: `ALL_CLI_FEATURES`, `ALL_CLI_LOG_PATH`, `ALL_CLI_METRICS_PATH`, `ALL_CLI_TRACEPARENT`, `SENTRY_DSN`, `SENTRY_ENVIRONMENT`, `POSTHOG_API_KEY`, and `POSTHOG_HOST`. Do not enumerate the environment.
+
+- [ ] **Step 4: Implement one command lifecycle**
+
+Construct the root command, set args/writers/context, start telemetry only when the feature flag is enabled, execute, derive a normalized command path without arguments, finish telemetry, and return the original command error.
+
+- [ ] **Step 5: Delegate main**
+
+Call `cli.Execute(context.Background(), os.Args[1:], os.Stdout, os.Stderr, os.Getenv)` and preserve exit code 1 on error.
+
+- [ ] **Step 6: Verify**
+
+Run:
+
+```bash
+go test ./internal/cli -run TestExecute -count=1
+go test -race ./internal/featureflags ./internal/telemetry ./internal/cli
+```
+
+Expected: PASS and existing CLI output tests remain unchanged.
+
+### Task 8: Security and dependency governance
+
+**Files:**
+- Create: `.github/workflows/codeql.yml`
+- Create: `.github/dependabot.yml`
+- Create: `docs/dependency-policy.md`
+
+**Interfaces:**
+- Produces: GitHub CodeQL SARIF and dependency-review summaries.
+
+- [ ] **Step 1: Add CodeQL**
+
+Run on pull requests, pushes to `main`, and weekly schedule with `security-events: write`, Go autobuild, and `github/codeql-action/analyze`. Pin action releases.
+
+- [ ] **Step 2: Add dependency review**
+
+On pull requests, run `actions/dependency-review-action` with high-severity failure, denied GPL-only licenses inappropriate for this project, and a readable job summary.
+
+- [ ] **Step 3: Configure Dependabot**
+
+Create weekly grouped updates for Go modules, GitHub Actions, and dev containers. Limit open PRs and assign `dependencies`, `type:chore`, and the matching area label.
+
+- [ ] **Step 4: Document minimum release age**
+
+Require seven full days between an upstream release timestamp and merge for ordinary updates. Permit an explicit linked security advisory exception with maintainer review and rollback notes.
+
+- [ ] **Step 5: Verify**
+
+Parse YAML, run `go mod verify`, and inspect workflow permissions for least privilege.
+
+### Task 9: Alerting, runbooks, and error-to-insight
+
+**Files:**
+- Create: `.github/workflows/telemetry-alerts.yml`
+- Create: `docs/runbooks/README.md`
+- Create: `docs/runbooks/telemetry-alert.md`
+- Create: `docs/runbooks/release.md`
+- Create: `docs/runbooks/privacy.md`
+- Modify: `README.md`
+
+**Interfaces:**
+- Consumes repository variables `SENTRY_ORG`, `SENTRY_PROJECT` and secret `SENTRY_AUTH_TOKEN`.
+- Produces deduplicated issues labeled with priority, type, and area.
+
+- [ ] **Step 1: Add scheduled Sentry ingestion**
+
+Run hourly and by manual dispatch. If configuration is absent, produce a clear skipped summary. Otherwise fetch unresolved `is:unresolved` issues updated in the last hour from the Sentry API using a bounded query and timeout.
+
+- [ ] **Step 2: Create deduplicated actionable issues**
+
+Use `actions/github-script` to search for marker `<!-- sentry:<id> -->`. Create or update an issue containing the Sentry link, first/last seen, event count, release, environment, owner checklist, and runbook link. Map fatal/error to `priority:P1`, warning to `priority:P2`, and always apply `type:bug` and `area:observability`.
+
+- [ ] **Step 3: Add operator runbooks**
+
+Document detection, severity, evidence gathering, mitigation, rollback, escalation, resolution, and follow-up for release failures, telemetry alerts, and privacy incidents. Include exact GitHub Actions and Sentry locations.
+
+- [ ] **Step 4: Document telemetry setup**
+
+Explain explicit feature enablement, sink variables, data schema, opt-out, retention ownership, dashboard links/placeholders as repository variables rather than fake URLs, and alert workflow setup.
+
+- [ ] **Step 5: Verify**
+
+Parse workflow YAML and run the JavaScript data-mapping logic against a local representative payload.
+
+### Task 10: Deployment observability
+
+**Files:**
+- Modify: `.github/workflows/release.yml`
+
+**Interfaces:**
+- Produces: GitHub `production` deployment records and release verification summaries.
+
+- [ ] **Step 1: Declare deployment permissions and environment**
+
+Add `deployments: write`, set the release job environment to `production` with the repository URL, and keep the existing release concurrency guard.
+
+- [ ] **Step 2: Verify the published release**
+
+After GoReleaser, query the created tag with `gh release view`, require expected checksums and four platform archives, and write the release URL plus asset inventory to the job summary.
+
+- [ ] **Step 3: Publish impact-check guidance**
+
+Add links to the telemetry alert workflow, production deployment history, release runbook, and configured dashboard repository variables. Make the final step run with `if: always()` so failure impact is visible.
+
+- [ ] **Step 4: Verify**
+
+Run `goreleaser check` if installed and validate all expression references against existing step IDs.
+
+### Task 11: Label taxonomy and synchronization
+
+**Files:**
+- Create: `.github/labels.json`
+- Create: `.github/workflows/labels.yml`
+
+**Interfaces:**
+- Produces labels: `priority:P0` through `priority:P3`; `type:bug`, `type:feature`, `type:chore`, `type:security`; `area:cli`, `area:tools`, `area:ci`, `area:docs`, `area:dependencies`, `area:observability`, `area:security`.
+
+- [ ] **Step 1: Define descriptions and colors**
+
+Every label has a unique name, six-digit color, and operational description. Priorities describe response urgency; types describe work class; areas map to repository ownership.
+
+- [ ] **Step 2: Add a least-privilege sync workflow**
+
+Run on changes to the taxonomy and manual dispatch with `issues: write`. Use `actions/github-script` to read JSON, create absent labels, and update color/description for existing labels without deleting unrelated labels.
+
+- [ ] **Step 3: Apply the taxonomy remotely**
+
+Call the authenticated GitHub label API for each versioned label. Do not delete or rename existing user labels.
+
+- [ ] **Step 4: Verify**
+
+Read back all repository labels and assert every versioned name/color/description matches.
+
+### Task 12: Branch protection
+
+**Files:**
+- No repository files; apply authenticated GitHub settings.
+
+**Interfaces:**
+- Consumes required CI check names discovered from the latest successful run.
+- Produces protected `main` branch settings.
+
+- [ ] **Step 1: Discover exact check contexts**
+
+Read the most recent successful `main` CI run and record exact check names. Do not guess contexts that would make merging impossible.
+
+- [ ] **Step 2: Apply protection**
+
+Require up-to-date branches, the verified CI checks, one approving review, stale-review dismissal, code-owner review, conversation resolution, and linear history. Block force pushes and deletion. Enforce the rule for administrators so direct pushes do not bypass it.
+
+- [ ] **Step 3: Verify**
+
+Read back branch protection/rulesets and confirm the `main` target, PR requirement, required checks, code-owner review, direct-push prevention, force-push block, deletion block, and active enforcement.
+
+### Task 13: Full validation and readiness evidence
+
+**Files:**
+- Modify: `task_plan.md`
+- Modify: `findings.md`
+- Modify: `progress.md`
+
+**Interfaces:**
+- Produces: a verified mapping from all 31 signals to repository or GitHub evidence.
+
+- [ ] **Step 1: Run narrow checks**
+
+Run package tests for `repopolicy`, `featureflags`, `telemetry`, and CLI execution, then pre-commit and configuration parsers.
+
+- [ ] **Step 2: Run full gates**
+
+Run:
+
+```bash
+just check
+go test -count=3 ./...
+go mod verify
+```
+
+Expected: all pass.
+
+- [ ] **Step 3: Inspect the final diff**
+
+Confirm no pre-existing user change was overwritten, no secret or generated artifact is included, no TODO without an issue was added, and no workflow has excessive permissions.
+
+- [ ] **Step 4: Re-evaluate signal evidence**
+
+For each of the 31 signal names, point to the exact file, check, workflow, or verified GitHub setting. Record any platform-side prerequisite such as repository secrets without presenting it as already configured.
+
+- [ ] **Step 5: Update persistent progress**
+
+Mark phases complete only after validation. Record every command and result, including skipped checks and external limitations.

--- a/docs/superpowers/specs/2026-08-23-agent-readiness-design.md
+++ b/docs/superpowers/specs/2026-08-23-agent-readiness-design.md
@@ -1,0 +1,145 @@
+# Agent Readiness Remediation Design
+
+Date: 2026-08-23
+
+## Purpose
+
+Raise `all-cli` from its current Agent Readiness score by genuinely addressing all 31 reported failures. The result should make autonomous changes safer, easier to validate, easier to review, and easier to diagnose without turning a local CLI into a mandatory hosted service.
+
+## Constraints
+
+- Preserve the user's existing uncommitted CLI and documentation work.
+- Keep checks reproducible locally and in CI.
+- Do not silently collect or transmit CLI usage.
+- Avoid placeholder configuration that has no enforcement or operating path.
+- Keep runtime additions bounded behind stable interfaces and feature flags.
+- Apply repository-host settings only through authenticated GitHub APIs.
+
+## Considered approaches
+
+### 1. Configuration-only remediation
+
+Add expected filenames and minimal workflows for each metric. This is fast but does not provide durable enforcement, operating guidance, or useful runtime evidence. Rejected because it would optimize for the score rather than the repository.
+
+### 2. Hosted-platform-first remediation
+
+Adopt hosted quality, feature flag, telemetry, incident, and analytics products for every signal. This provides rich dashboards but forces credentials, network access, and operational overhead onto a small local CLI. Rejected as the default because it is disproportionate and could violate user expectations.
+
+### 3. Hybrid, repository-owned controls with opt-in integrations
+
+Use repository-owned policy tools, CI summaries/artifacts, GitHub-native security and governance, a small custom feature-flag registry, and an opt-in telemetry boundary that integrates with standard external systems when configured. Selected because every control has local value while hosted integrations remain available without silent collection.
+
+## Architecture
+
+### Quality policy
+
+A repository-owned `cmd/quality-gate` command will enforce policies that ordinary Go linters do not cover:
+
+- tracked file byte and line limits,
+- technical-debt markers linked to issue identifiers,
+- AGENTS.md `just` recipe references and local links,
+- an explicit total coverage threshold.
+
+The same command will run from `just`, pre-commit, and CI so agents receive identical feedback everywhere. `golangci-lint` will enforce cyclomatic complexity and duplicate-code thresholds.
+
+### Test and build evidence
+
+CI will:
+
+- time builds and enforce a generous regression ceiling,
+- produce Go JSON and JUnit test reports with per-test durations,
+- run repeated tests to expose unstable tests,
+- enforce the coverage floor,
+- upload quality artifacts and write a readable job summary,
+- upload SARIF for GitHub code scanning.
+
+Local `just` recipes will expose the same gates.
+
+### Agent development environment
+
+A dev container will pin the Go toolchain and install the local tools needed to run hooks and checks. Contributor documentation, AGENTS.md validation, CODEOWNERS, issue forms, and a pull-request template will make agent-authored work reproducible and reviewable.
+
+### Safe delivery and dependencies
+
+A typed feature-flag registry will support explicit opt-in flags through `ALL_CLI_FEATURES`. New telemetry will be the first feature behind a flag, proving the mechanism works on production code rather than existing as an unused abstraction.
+
+Dependabot will create grouped Go, GitHub Actions, and dev-container updates. A dependency policy will require a seven-day waiting period for normal releases, with a documented security exception process.
+
+CodeQL and dependency review will generate readable security results in GitHub.
+
+### Runtime observability
+
+An `internal/telemetry` module will instrument command execution at one boundary:
+
+- `log/slog` JSON records provide structured logging,
+- generated or accepted W3C trace IDs correlate a complete command,
+- Prometheus textfile output provides command counts, result, and duration,
+- Sentry-compatible event delivery captures contextual command failures,
+- PostHog capture records privacy-minimized command-use events.
+
+Telemetry will be disabled by default and enabled only with the `telemetry-v1` feature flag. Individual sinks require their own environment variables. Events will never include command arguments, environment contents, external command output, usernames, paths, tokens, or configuration data.
+
+### Incident and deployment operations
+
+Runbooks will describe release failures, telemetry alerts, privacy response, and rollback. A GitHub alert workflow will accept authenticated dispatches from Sentry or monitoring and create deduplicated, labeled issues. This supplies both active alert routing and an error-to-insight path.
+
+The release workflow will create GitHub deployment records, verify the released artifact, and publish a deployment summary with links to the release, workflow, and follow-up runbook.
+
+### GitHub governance
+
+The repository will define and synchronize a label taxonomy covering priority, type, and area. The active `main` branch will receive protection requiring pull requests, required CI checks, conversation resolution, and protection against force pushes and deletions.
+
+## Signal mapping
+
+| Signal | Substantive evidence |
+|---|---|
+| Pre-commit hooks | `.pre-commit-config.yaml` runs formatting and repository checks |
+| Cyclomatic complexity | enforced `gocyclo` threshold |
+| Large-file detection | tracked-file byte and line limits |
+| Duplicate code detection | enforced 200-token `dupl` threshold |
+| Technical debt tracking | TODO/FIXME issue-link policy |
+| Build performance tracking | timed build metric, ceiling, summary, artifact |
+| Feature flag infrastructure | typed registry used to gate telemetry |
+| Test performance tracking | test JSON/JUnit timings and artifacts |
+| Flaky test detection | repeated test job and retained stability results |
+| Coverage thresholds | blocking 80% total coverage floor |
+| AGENTS.md validation | command and local-link validation in policy gate |
+| Dev container | pinned Go development container and setup |
+| Structured logging | dedicated JSON `slog` telemetry module |
+| Distributed tracing | W3C trace correlation through command context |
+| Metrics collection | Prometheus textfile metrics |
+| Code quality metrics | SARIF, coverage, complexity, duplication, and CI summaries |
+| Contextual error tracking | opt-in Sentry-compatible events with release/trace/command context |
+| Alerting | dispatch-driven severity routing to labeled GitHub issues |
+| Runbooks | operator procedures under `docs/runbooks/` |
+| Deployment observability | GitHub deployment states, release verification, impact links |
+| Branch protection | active GitHub ruleset/protection on `main` |
+| CODEOWNERS | valid owner assignment |
+| Automated security review | CodeQL and dependency-review reports |
+| Dependency updates | grouped Dependabot updates |
+| Comprehensive gitignore | secret-bearing local config and generated telemetry excluded |
+| Minimum release age | explicit seven-day dependency policy |
+| Issue templates | structured bug and feature forms |
+| Issue labeling | synchronized priority/type/area taxonomy |
+| PR template | context, change, testing, risk, and rollback sections |
+| Product analytics | opt-in PostHog command-use capture |
+| Error-to-insight | alert/error dispatch creates deduplicated actionable issues |
+
+## Error handling and privacy
+
+- Quality checks fail with precise file, line, policy, and remediation output.
+- Telemetry failures never change a CLI command's exit status.
+- Network telemetry uses short timeouts and is skipped when unconfigured.
+- Sentry DSNs and PostHog keys are read at runtime and never logged.
+- Telemetry arguments and arbitrary user data are intentionally absent from event schemas.
+- Alert workflows cap and sanitize external text before adding it to issues.
+
+## Testing and validation
+
+- Unit-test the policy gate's parsers and each failure branch.
+- Unit-test feature parsing, unknown flags, defaults, and telemetry gating.
+- Unit-test trace generation/propagation, structured event shape, Prometheus output, redaction, and HTTP payloads with local test servers.
+- Validate YAML and JSON configuration where local tools are available.
+- Run pre-commit against all files.
+- Run `just check`, the coverage gate, repeated tests, CodeQL workflow syntax checks where available, and GoReleaser validation.
+- Query GitHub after applying labels and branch protection to verify remote state.

--- a/findings.md
+++ b/findings.md
@@ -61,7 +61,7 @@
 ## Quality-gate implementation findings
 
 - The live repository policy passes with limits of 1 MiB and 1,500 lines and requires issue links for debt markers in code-bearing comments.
-- The coverage gate passes at 80.4% after adding repository-policy tests, above the enforced 80.0% floor.
+- The coverage gate passes at 80.3% on the declared Go 1.26.1 toolchain after adding repository-policy and registry-contract tests, above the enforced 80.0% floor.
 - A 120-token duplication threshold found 34 mostly structural CLI test-fixture matches. A calibrated 200-token threshold still found a real 43-line Vercel/Netlify production duplicate.
 - The cloud registry now uses one typed constructor for Vercel, Railway, and Netlify whoami/current behavior.
 - Simple tool metadata moved from a 47-complexity switch into a lookup table; the glab parser was split into a detail parser.
@@ -85,3 +85,10 @@
 - The exact successful required CI context is `test`.
 - Sixteen versioned priority/type/area/dependency labels were created and read back with matching colors and descriptions; default labels were preserved.
 - `main` protection is active and strict: `test` required, one approval, stale review dismissal, code-owner review, conversation resolution, linear history, admin enforcement, no force pushes, and no deletion.
+
+## Pull-request validation findings
+
+- PR [#26](https://github.com/oldwinter/all-cli/pull/26) passed the required `test` job, functional QA, CodeQL, dependency review, golangci-lint SARIF, and GitGuardian.
+- The first CI run exposed compiler-sensitive coverage accounting: Go 1.27.0 reported 81.4%, while the repository-declared Go 1.26.1 reported 78.1%.
+- Public `ToolDefinition` contract tests now cover installed-state handling, adapter reuse, diagnostic propagation, cloud identity caching, file-backed configuration, and default-registry dispatch.
+- The exact Go 1.26.1 gate now passes at 80.3% without weakening the threshold.

--- a/findings.md
+++ b/findings.md
@@ -1,0 +1,87 @@
+# Agent Readiness Findings
+
+## Initial repository state
+
+- The repository is a Go 1.26.1 CLI with a small dependency set.
+- `just ci` currently runs tidy verification, vet, and tests.
+- `just check` adds race tests and formatting checks.
+- Coverage can be generated locally, but there is no enforced threshold.
+- Existing repository automation includes CI, QA, and release workflows.
+- CI already uses pinned major/minor action versions, Go caching, formatting, vet, tests, race tests, and golangci-lint.
+- The QA workflow produces readable PR reports and retained artifacts, but does not track unit-test timing or flakiness.
+- The release workflow tags and publishes every successful push to `main`; it has no post-release verification or observability handoff.
+- `.golangci.yml` is minimal and does not enable complexity or duplicate-code checks.
+- `.gitignore` covers Go build output, IDE state, and macOS metadata but not environment/secret-bearing files.
+- The README documents development, diagnostics, release, and security basics, but not quality thresholds, feature flags, telemetry, runbooks, or deploy-impact checks.
+- GoReleaser produces checksummed Darwin/Linux archives and a Homebrew formula.
+- No planning files, dev container, pre-commit configuration, CODEOWNERS, issue templates, or pull-request template were found by the initial inventory.
+
+## Existing user work to preserve
+
+- Modified: `AGENTS.md`
+- Modified: `internal/cli/agent_commands.go`
+- Modified: `internal/cli/agent_commands_test.go`
+- Untracked: `CONTEXT.md`
+- Untracked: `internal/cli/doctor_fix.go`
+- Untracked: `qa-bin/`
+
+## Design direction
+
+- Consolidate local and CI quality policy into reproducible Go-based tools and `just` recipes instead of scattering non-portable shell snippets.
+- Use CI artifacts and step summaries for persistent build, test, coverage, complexity, duplication, and security evidence.
+- Add a dedicated internal telemetry boundary for structured events, trace correlation, metrics, product-use counts, and contextual failures.
+- Route actionable telemetry failures into a GitHub issue workflow while preserving explicit opt-in and secret scrubbing.
+- Use Renovate for delayed dependency adoption and automated update PRs.
+
+## Cohesive implementation candidates
+
+- `cmd/quality-gate`: repository-owned policy checker for staged file size, TODO issue linkage, AGENTS.md command drift, and coverage thresholds.
+- golangci-lint additions: `gocyclo` for enforced complexity and `dupl` for copy/paste detection.
+- `.pre-commit-config.yaml`: local commit-time execution of formatting, vet, policy, and targeted tests.
+- CI metrics job: timed build/tests, JSON test events, retry comparison for flake detection, coverage gate, and retained metrics artifacts.
+- GitHub CodeQL workflow plus dependency review for readable automated security results.
+- `.devcontainer`: pinned Go development image and reproducible editor/tool setup.
+
+## Runtime integration findings
+
+- `cmd/all-cli/main.go` has a single `cmd.Execute()` boundary, so telemetry can be added without instrumenting every command handler.
+- `internal/cli/root.go` already propagates `context.Context` into command handlers and external runners.
+- Existing command tests generally construct commands directly; a separate execution-boundary test can cover telemetry without changing command behavior.
+- Current total statement coverage is 80.2%, which supports an enforceable 80% initial floor.
+- No tracked Go TODO/FIXME/HACK/XXX markers currently need migration.
+- Go command errors are returned from Cobra to `main`; contextual error capture can occur before the final exit code without changing user-facing output.
+
+## Selected design
+
+- Use the hybrid approach documented in `docs/superpowers/specs/2026-08-23-agent-readiness-design.md`.
+- Keep quality and governance controls always on.
+- Gate all new runtime telemetry behind `ALL_CLI_FEATURES=telemetry-v1`.
+- Use privacy-minimized schemas that omit arguments, paths, environment contents, tool output, and identity.
+
+## Quality-gate implementation findings
+
+- The live repository policy passes with limits of 1 MiB and 1,500 lines and requires issue links for debt markers in code-bearing comments.
+- The coverage gate passes at 80.4% after adding repository-policy tests, above the enforced 80.0% floor.
+- A 120-token duplication threshold found 34 mostly structural CLI test-fixture matches. A calibrated 200-token threshold still found a real 43-line Vercel/Netlify production duplicate.
+- The cloud registry now uses one typed constructor for Vercel, Railway, and Netlify whoami/current behavior.
+- Simple tool metadata moved from a 47-complexity switch into a lookup table; the glab parser was split into a detail parser.
+- golangci-lint now passes with zero complexity, duplication, or standard-linter findings.
+- A complete pre-commit run passes after fixing two pre-existing trailing-whitespace findings.
+
+## Runtime and operations implementation findings
+
+- `telemetry-v1` is a typed, disabled-by-default flag; unknown flags fail startup rather than silently drifting.
+- One CLI execution boundary now correlates each enabled command with a W3C-compatible trace ID.
+- Structured JSON logs and atomic Prometheus metrics are local-only sinks with restrictive file modes.
+- Sentry envelopes include release, environment, trace, command breadcrumb, scrubbed error, and stack frames.
+- PostHog captures only anonymous installation ID, normalized command, result, release, and library name.
+- All network sinks have two-second deadlines and cannot alter command output or exit status.
+- The scheduled Sentry workflow sanitizes input, deduplicates by Sentry issue ID, routes by severity, labels and assigns GitHub issues, and links a response runbook.
+- Release automation now records a production deployment, verifies checksums and four platform archives, and publishes impact links.
+
+## GitHub governance findings
+
+- Admin access was verified for `oldwinter/all-cli`.
+- The exact successful required CI context is `test`.
+- Sixteen versioned priority/type/area/dependency labels were created and read back with matching colors and descriptions; default labels were preserved.
+- `main` protection is active and strict: `test` required, one approval, stale review dismissal, code-owner review, conversation resolution, linear history, admin enforcement, no force pushes, and no deletion.

--- a/internal/cli/execute.go
+++ b/internal/cli/execute.go
@@ -1,0 +1,86 @@
+package cli
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/oldwinter/all-cli/internal/featureflags"
+	"github.com/oldwinter/all-cli/internal/telemetry"
+	"github.com/spf13/cobra"
+)
+
+func Execute(
+	ctx context.Context,
+	args []string,
+	stdout io.Writer,
+	stderr io.Writer,
+	getenv func(string) string,
+) error {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if getenv == nil {
+		getenv = func(string) string { return "" }
+	}
+
+	flags, err := featureflags.Parse(getenv("ALL_CLI_FEATURES"))
+	if err != nil {
+		printStartupError(stderr, err)
+		return err
+	}
+	ctx = featureflags.WithContext(ctx, flags)
+
+	root := NewRootCommand()
+	root.SetContext(ctx)
+	root.SetArgs(args)
+	root.SetOut(stdout)
+	root.SetErr(stderr)
+
+	if !featureflags.Enabled(ctx, featureflags.TelemetryV1) {
+		return root.Execute()
+	}
+
+	recorder, err := telemetry.New(telemetry.Config{
+		LogPath:            getenv("ALL_CLI_LOG_PATH"),
+		MetricsPath:        getenv("ALL_CLI_METRICS_PATH"),
+		SentryDSN:          getenv("SENTRY_DSN"),
+		SentryEnvironment:  getenv("SENTRY_ENVIRONMENT"),
+		PostHogKey:         getenv("POSTHOG_API_KEY"),
+		PostHogHost:        getenv("POSTHOG_HOST"),
+		InstallationIDPath: getenv("ALL_CLI_INSTALLATION_ID_PATH"),
+		Release:            VersionString(),
+		TraceParent:        getenv("ALL_CLI_TRACEPARENT"),
+	})
+	if err != nil {
+		startupErr := fmt.Errorf("initialize telemetry: %w", err)
+		printStartupError(stderr, startupErr)
+		return startupErr
+	}
+	ctx, span := recorder.Start(ctx)
+	root.SetContext(ctx)
+	command := telemetryCommand(root, args)
+	commandErr := root.Execute()
+	recorder.Finish(ctx, span, command, commandErr)
+	return commandErr
+}
+
+func printStartupError(stderr io.Writer, err error) {
+	if stderr != nil {
+		fmt.Fprintf(stderr, "Error: %v\n", err)
+	}
+}
+
+func telemetryCommand(root *cobra.Command, args []string) string {
+	for _, arg := range args {
+		if arg == "--version" || arg == "-v" {
+			return "version"
+		}
+	}
+	command, _, err := root.Find(args)
+	if err != nil || command == root {
+		return "unknown"
+	}
+	return strings.TrimPrefix(command.CommandPath(), root.Name()+" ")
+}

--- a/internal/cli/execute_test.go
+++ b/internal/cli/execute_test.go
@@ -1,0 +1,120 @@
+package cli
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestExecuteLeavesTelemetryDisabledByDefault(t *testing.T) {
+	root := t.TempDir()
+	logPath := filepath.Join(root, "events.jsonl")
+	env := map[string]string{
+		"ALL_CLI_LOG_PATH": logPath,
+	}
+	var stdout, stderr bytes.Buffer
+
+	err := Execute(context.Background(), []string{"version"}, &stdout, &stderr, mapGetenv(env))
+
+	if err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+	if stdout.Len() == 0 {
+		t.Fatal("Execute(version) produced no stdout")
+	}
+	if _, err := os.Stat(logPath); !os.IsNotExist(err) {
+		t.Fatalf("telemetry artifact exists without feature flag: %v", err)
+	}
+}
+
+func TestExecuteRecordsEnabledCommandLifecycle(t *testing.T) {
+	root := t.TempDir()
+	logPath := filepath.Join(root, "events.jsonl")
+	metricsPath := filepath.Join(root, "all-cli.prom")
+	env := map[string]string{
+		"ALL_CLI_FEATURES":     "telemetry-v1",
+		"ALL_CLI_LOG_PATH":     logPath,
+		"ALL_CLI_METRICS_PATH": metricsPath,
+	}
+	var stdout, stderr bytes.Buffer
+
+	err := Execute(context.Background(), []string{"version"}, &stdout, &stderr, mapGetenv(env))
+
+	if err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+	event := readExecuteEvent(t, logPath)
+	if event["command"] != "version" || event["result"] != "success" {
+		t.Fatalf("telemetry event = %#v", event)
+	}
+	if _, err := os.Stat(metricsPath); err != nil {
+		t.Fatalf("metrics file missing: %v", err)
+	}
+}
+
+func TestExecuteRecordsInvalidInputAsUnknownCommand(t *testing.T) {
+	logPath := filepath.Join(t.TempDir(), "events.jsonl")
+	privateInput := "token=do-not-record"
+	env := map[string]string{
+		"ALL_CLI_FEATURES": "telemetry-v1",
+		"ALL_CLI_LOG_PATH": logPath,
+	}
+	var stdout, stderr bytes.Buffer
+
+	err := Execute(context.Background(), []string{privateInput}, &stdout, &stderr, mapGetenv(env))
+
+	if err == nil {
+		t.Fatal("Execute(invalid command) error = nil")
+	}
+	event := readExecuteEvent(t, logPath)
+	if event["command"] != "unknown" || event["result"] != "error" {
+		t.Fatalf("telemetry event = %#v", event)
+	}
+	encoded, _ := json.Marshal(event)
+	if strings.Contains(string(encoded), privateInput) {
+		t.Fatalf("telemetry leaked invalid user input: %s", encoded)
+	}
+}
+
+func TestExecuteRejectsUnknownFeatureFlags(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+
+	err := Execute(context.Background(), []string{"version"}, &stdout, &stderr, mapGetenv(map[string]string{
+		"ALL_CLI_FEATURES": "future-mode",
+	}))
+
+	if err == nil || !strings.Contains(err.Error(), "unknown ALL_CLI_FEATURES") {
+		t.Fatalf("Execute() error = %v, want unknown feature error", err)
+	}
+	if stdout.Len() != 0 {
+		t.Fatalf("stdout = %q, want empty", stdout.String())
+	}
+	if !strings.Contains(stderr.String(), "Error: unknown ALL_CLI_FEATURES values: future-mode") {
+		t.Fatalf("stderr = %q, want actionable unknown feature error", stderr.String())
+	}
+}
+
+func mapGetenv(values map[string]string) func(string) string {
+	return func(key string) string {
+		return values[key]
+	}
+}
+
+func readExecuteEvent(t *testing.T, path string) map[string]any {
+	t.Helper()
+
+	content, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("ReadFile(%q) error = %v", path, err)
+	}
+	line := strings.SplitN(string(content), "\n", 2)[0]
+	var event map[string]any
+	if err := json.Unmarshal([]byte(line), &event); err != nil {
+		t.Fatalf("Unmarshal(event) error = %v\n%s", err, line)
+	}
+	return event
+}

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -40,7 +40,15 @@ Environment:
   NO_COLOR            If set (any value), disable ANSI colors and escape sequences.
   TERM                If "dumb", ANSI output is disabled.
   CI                  If set, the status command skips the stderr progress spinner.
-  ALL_CLI_NO_PROGRESS If 1, true, yes, or on, disable the status spinner (any environment).`,
+  ALL_CLI_NO_PROGRESS If 1, true, yes, or on, disable the status spinner (any environment).
+  ALL_CLI_FEATURES    Comma-separated opt-in feature flags; telemetry-v1 enables telemetry.
+  ALL_CLI_LOG_PATH    JSON structured event log path when telemetry-v1 is enabled.
+  ALL_CLI_METRICS_PATH Prometheus textfile path when telemetry-v1 is enabled.
+  ALL_CLI_TRACEPARENT W3C traceparent used to correlate this command.
+  SENTRY_DSN          Optional Sentry error-tracking DSN.
+  SENTRY_ENVIRONMENT  Optional Sentry environment name.
+  POSTHOG_API_KEY     Optional PostHog project key for minimized command-use analytics.
+  POSTHOG_HOST        Optional PostHog ingestion host.`,
 		Example: `  # Full overview as JSON (stable schema)
   all-cli status --json
 

--- a/internal/featureflags/flags.go
+++ b/internal/featureflags/flags.go
@@ -1,0 +1,67 @@
+package featureflags
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strings"
+)
+
+type Flag string
+
+const TelemetryV1 Flag = "telemetry-v1"
+
+type Set struct {
+	enabled map[Flag]struct{}
+}
+
+var supported = map[Flag]struct{}{
+	TelemetryV1: {},
+}
+
+type contextKey struct{}
+
+func Parse(raw string) (Set, error) {
+	set := Set{enabled: make(map[Flag]struct{})}
+	var unknown []string
+	for _, part := range strings.Split(raw, ",") {
+		name := strings.TrimSpace(part)
+		if name == "" {
+			continue
+		}
+		flag := Flag(name)
+		if _, ok := supported[flag]; !ok {
+			unknown = append(unknown, name)
+			continue
+		}
+		set.enabled[flag] = struct{}{}
+	}
+	if len(unknown) > 0 {
+		sort.Strings(unknown)
+		return Set{}, fmt.Errorf("unknown ALL_CLI_FEATURES values: %s", strings.Join(unknown, ", "))
+	}
+	return set, nil
+}
+
+func WithContext(ctx context.Context, set Set) context.Context {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	copySet := Set{enabled: make(map[Flag]struct{}, len(set.enabled))}
+	for flag := range set.enabled {
+		copySet.enabled[flag] = struct{}{}
+	}
+	return context.WithValue(ctx, contextKey{}, copySet)
+}
+
+func Enabled(ctx context.Context, flag Flag) bool {
+	if ctx == nil {
+		return false
+	}
+	set, ok := ctx.Value(contextKey{}).(Set)
+	if !ok {
+		return false
+	}
+	_, ok = set.enabled[flag]
+	return ok
+}

--- a/internal/featureflags/flags_test.go
+++ b/internal/featureflags/flags_test.go
@@ -1,0 +1,54 @@
+package featureflags
+
+import (
+	"context"
+	"strings"
+	"testing"
+)
+
+func TestParseFeatureFlags(t *testing.T) {
+	tests := []struct {
+		name    string
+		raw     string
+		enabled bool
+		wantErr string
+	}{
+		{name: "blank", raw: ""},
+		{name: "known", raw: "telemetry-v1", enabled: true},
+		{name: "whitespace and duplicate", raw: " telemetry-v1, telemetry-v1 ", enabled: true},
+		{name: "unknown", raw: "future-z,future-a", wantErr: "future-a, future-z"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			set, err := Parse(tt.raw)
+			if tt.wantErr != "" {
+				if err == nil || !strings.Contains(err.Error(), tt.wantErr) {
+					t.Fatalf("Parse(%q) error = %v, want containing %q", tt.raw, err, tt.wantErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("Parse(%q) error = %v", tt.raw, err)
+			}
+			ctx := WithContext(context.Background(), set)
+			if got := Enabled(ctx, TelemetryV1); got != tt.enabled {
+				t.Fatalf("Enabled(TelemetryV1) = %t, want %t", got, tt.enabled)
+			}
+		})
+	}
+}
+
+func TestWithContextCopiesSet(t *testing.T) {
+	set, err := Parse("telemetry-v1")
+	if err != nil {
+		t.Fatalf("Parse() error = %v", err)
+	}
+	ctx := WithContext(context.Background(), set)
+
+	delete(set.enabled, TelemetryV1)
+
+	if !Enabled(ctx, TelemetryV1) {
+		t.Fatal("mutating the caller's set changed the context feature flags")
+	}
+}

--- a/internal/repopolicy/policy.go
+++ b/internal/repopolicy/policy.go
@@ -1,0 +1,268 @@
+package repopolicy
+
+import (
+	"bytes"
+	"fmt"
+	"go/parser"
+	"go/token"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+)
+
+type Limits struct {
+	MaxBytes int64
+	MaxLines int
+}
+
+type Violation struct {
+	Rule    string
+	Path    string
+	Line    int
+	Message string
+}
+
+var (
+	debtMarkerPattern  = regexp.MustCompile(`\b(TODO|FIXME|HACK|XXX)\b`)
+	issueLinkPattern   = regexp.MustCompile(`(?i)(#\d+|GH-\d+|https://github\.com/[^/\s]+/[^/\s]+/issues/\d+)`)
+	justCommandPattern = regexp.MustCompile(
+		"`just[ \t]+([A-Za-z_][A-Za-z0-9_-]*)",
+	)
+	justRecipePattern = regexp.MustCompile(
+		`(?m)^([A-Za-z_][A-Za-z0-9_-]*)(?:[ \t]+[^:=\n]+)?[ \t]*:`,
+	)
+	markdownLinkPattern = regexp.MustCompile(`\[[^]]+\]\(([^)]+)\)`)
+)
+
+func Audit(root string, limits Limits) ([]Violation, error) {
+	paths, err := repositoryFiles(root)
+	if err != nil {
+		return nil, err
+	}
+
+	var violations []Violation
+	for _, path := range paths {
+		fullPath := filepath.Join(root, filepath.FromSlash(path))
+		info, err := os.Stat(fullPath)
+		if err != nil {
+			return nil, fmt.Errorf("stat %s: %w", path, err)
+		}
+		if !info.Mode().IsRegular() {
+			continue
+		}
+
+		content, err := os.ReadFile(fullPath)
+		if err != nil {
+			return nil, fmt.Errorf("read %s: %w", path, err)
+		}
+		if limits.MaxBytes > 0 && info.Size() > limits.MaxBytes {
+			violations = append(violations, Violation{
+				Rule:    "file-size",
+				Path:    path,
+				Message: fmt.Sprintf("%d bytes exceeds the %d-byte limit", info.Size(), limits.MaxBytes),
+			})
+		}
+		if lines := lineCount(content); limits.MaxLines > 0 && lines > limits.MaxLines {
+			violations = append(violations, Violation{
+				Rule:    "file-lines",
+				Path:    path,
+				Message: fmt.Sprintf("%d lines exceeds the %d-line limit", lines, limits.MaxLines),
+			})
+		}
+
+		debtViolations, err := auditDebtMarkers(path, content)
+		if err != nil {
+			return nil, err
+		}
+		violations = append(violations, debtViolations...)
+	}
+
+	sortViolations(violations)
+	return violations, nil
+}
+
+func CheckAgentGuide(root string) ([]Violation, error) {
+	guidePath := filepath.Join(root, "AGENTS.md")
+	guide, err := os.ReadFile(guidePath)
+	if err != nil {
+		return nil, fmt.Errorf("read AGENTS.md: %w", err)
+	}
+	justfile, err := os.ReadFile(filepath.Join(root, "justfile"))
+	if err != nil {
+		return nil, fmt.Errorf("read justfile: %w", err)
+	}
+
+	recipes := make(map[string]struct{})
+	for _, match := range justRecipePattern.FindAllSubmatch(justfile, -1) {
+		recipes[string(match[1])] = struct{}{}
+	}
+
+	var violations []Violation
+	for _, match := range justCommandPattern.FindAllSubmatchIndex(guide, -1) {
+		recipe := string(guide[match[2]:match[3]])
+		if _, ok := recipes[recipe]; ok {
+			continue
+		}
+		violations = append(violations, Violation{
+			Rule:    "agent-command",
+			Path:    "AGENTS.md",
+			Line:    lineAt(guide, match[0]),
+			Message: fmt.Sprintf("references undefined just recipe %q", recipe),
+		})
+	}
+
+	for _, match := range markdownLinkPattern.FindAllSubmatchIndex(guide, -1) {
+		target := strings.TrimSpace(string(guide[match[2]:match[3]]))
+		if !isLocalLink(target) {
+			continue
+		}
+		target = strings.TrimPrefix(target, "<")
+		target = strings.TrimSuffix(target, ">")
+		target = strings.SplitN(target, "#", 2)[0]
+		target = strings.SplitN(target, "?", 2)[0]
+		if target == "" {
+			continue
+		}
+		if _, err := os.Stat(filepath.Join(filepath.Dir(guidePath), filepath.FromSlash(target))); err == nil {
+			continue
+		} else if !os.IsNotExist(err) {
+			return nil, fmt.Errorf("check AGENTS.md link %q: %w", target, err)
+		}
+		violations = append(violations, Violation{
+			Rule:    "agent-link",
+			Path:    "AGENTS.md",
+			Line:    lineAt(guide, match[0]),
+			Message: fmt.Sprintf("references missing local path %q", target),
+		})
+	}
+
+	sortViolations(violations)
+	return violations, nil
+}
+
+func repositoryFiles(root string) ([]string, error) {
+	cmd := exec.Command("git", "-C", root, "ls-files", "-z", "--cached", "--others", "--exclude-standard")
+	out, err := cmd.Output()
+	if err != nil {
+		return nil, fmt.Errorf("list repository files: %w", err)
+	}
+
+	rawPaths := bytes.Split(out, []byte{0})
+	paths := make([]string, 0, len(rawPaths))
+	for _, rawPath := range rawPaths {
+		if len(rawPath) == 0 {
+			continue
+		}
+		path := filepath.ToSlash(string(rawPath))
+		if excludedPath(path) {
+			continue
+		}
+		paths = append(paths, path)
+	}
+	sort.Strings(paths)
+	return paths, nil
+}
+
+func excludedPath(path string) bool {
+	for _, prefix := range []string{"dist/", "qa-bin/", "vendor/", ".git/"} {
+		if strings.HasPrefix(path, prefix) {
+			return true
+		}
+	}
+	return false
+}
+
+func lineCount(content []byte) int {
+	if len(content) == 0 {
+		return 0
+	}
+	lines := bytes.Count(content, []byte{'\n'})
+	if content[len(content)-1] != '\n' {
+		lines++
+	}
+	return lines
+}
+
+func auditDebtMarkers(path string, content []byte) ([]Violation, error) {
+	if filepath.Ext(path) == ".go" {
+		return auditGoDebtMarkers(path, content)
+	}
+	if !isCommentBearingText(path) {
+		return nil, nil
+	}
+	return debtViolationsForText(path, content, 1), nil
+}
+
+func auditGoDebtMarkers(path string, content []byte) ([]Violation, error) {
+	fset := token.NewFileSet()
+	file, err := parser.ParseFile(fset, path, content, parser.ParseComments)
+	if err != nil {
+		return nil, fmt.Errorf("parse %s for debt markers: %w", path, err)
+	}
+	if bytes.Contains(content, []byte("Code generated")) {
+		return nil, nil
+	}
+
+	var violations []Violation
+	for _, group := range file.Comments {
+		for _, comment := range group.List {
+			startLine := fset.Position(comment.Pos()).Line
+			violations = append(violations, debtViolationsForText(path, []byte(comment.Text), startLine)...)
+		}
+	}
+	return violations, nil
+}
+
+func debtViolationsForText(path string, content []byte, startLine int) []Violation {
+	var violations []Violation
+	for offset, line := range strings.Split(string(content), "\n") {
+		if !debtMarkerPattern.MatchString(line) || issueLinkPattern.MatchString(line) {
+			continue
+		}
+		marker := debtMarkerPattern.FindString(line)
+		violations = append(violations, Violation{
+			Rule:    "debt-marker",
+			Path:    path,
+			Line:    startLine + offset,
+			Message: fmt.Sprintf("%s must reference a GitHub issue", marker),
+		})
+	}
+	return violations
+}
+
+func isCommentBearingText(path string) bool {
+	switch filepath.Ext(path) {
+	case ".bash", ".mk", ".sh", ".toml", ".yaml", ".yml":
+		return true
+	}
+	base := filepath.Base(path)
+	return base == "Dockerfile" || base == "justfile"
+}
+
+func lineAt(content []byte, index int) int {
+	return bytes.Count(content[:index], []byte{'\n'}) + 1
+}
+
+func isLocalLink(target string) bool {
+	lower := strings.ToLower(target)
+	return target != "" &&
+		!strings.HasPrefix(target, "#") &&
+		!strings.HasPrefix(lower, "http://") &&
+		!strings.HasPrefix(lower, "https://") &&
+		!strings.HasPrefix(lower, "mailto:")
+}
+
+func sortViolations(violations []Violation) {
+	sort.Slice(violations, func(i, j int) bool {
+		if violations[i].Path != violations[j].Path {
+			return violations[i].Path < violations[j].Path
+		}
+		if violations[i].Rule != violations[j].Rule {
+			return violations[i].Rule < violations[j].Rule
+		}
+		return violations[i].Line < violations[j].Line
+	})
+}

--- a/internal/repopolicy/policy_test.go
+++ b/internal/repopolicy/policy_test.go
@@ -1,0 +1,192 @@
+package repopolicy
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+func TestAuditRejectsOversizedFiles(t *testing.T) {
+	tests := []struct {
+		name    string
+		content string
+		limits  Limits
+		rule    string
+	}{
+		{
+			name:    "bytes",
+			content: strings.Repeat("x", 33),
+			limits:  Limits{MaxBytes: 32, MaxLines: 100},
+			rule:    "file-size",
+		},
+		{
+			name:    "lines",
+			content: strings.Repeat("line\n", 4),
+			limits:  Limits{MaxBytes: 1_024, MaxLines: 3},
+			rule:    "file-lines",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			root := newTestRepository(t, map[string]string{
+				"internal/example.txt": tt.content,
+			})
+
+			violations, err := Audit(root, tt.limits)
+			if err != nil {
+				t.Fatalf("Audit() error = %v", err)
+			}
+			if len(violations) != 1 {
+				t.Fatalf("Audit() violations = %#v, want one", violations)
+			}
+			if violations[0].Rule != tt.rule || violations[0].Path != "internal/example.txt" {
+				t.Fatalf("Audit() violation = %#v, want rule %q for internal/example.txt", violations[0], tt.rule)
+			}
+		})
+	}
+}
+
+func TestAuditRequiresIssueLinkedDebtMarkers(t *testing.T) {
+	marker := "TO" + "DO"
+	root := newTestRepository(t, map[string]string{
+		"internal/bad.go":  "package internal\n// " + marker + ": remove fallback\n",
+		"internal/good.go": "package internal\n// " + marker + "(#123): remove fallback\n",
+		"script.sh":        "#!/bin/sh\n# FIXME GH-456: simplify after migration\n",
+	})
+
+	violations, err := Audit(root, Limits{MaxBytes: 1_024, MaxLines: 100})
+	if err != nil {
+		t.Fatalf("Audit() error = %v", err)
+	}
+	if len(violations) != 1 {
+		t.Fatalf("Audit() violations = %#v, want one", violations)
+	}
+	got := violations[0]
+	if got.Rule != "debt-marker" || got.Path != "internal/bad.go" || got.Line != 2 {
+		t.Fatalf("Audit() violation = %#v, want unlinked marker at internal/bad.go:2", got)
+	}
+}
+
+func TestAuditReportsAllViolationsInStableOrder(t *testing.T) {
+	root := newTestRepository(t, map[string]string{
+		"z.go":  "package z\n// FIXME: issue missing\n",
+		"a.txt": strings.Repeat("x", 12),
+	})
+
+	violations, err := Audit(root, Limits{MaxBytes: 8, MaxLines: 100})
+	if err != nil {
+		t.Fatalf("Audit() error = %v", err)
+	}
+	if len(violations) != 3 {
+		t.Fatalf("Audit() violations = %#v, want three", violations)
+	}
+	got := fmt.Sprintf("%s:%s|%s:%s|%s:%s",
+		violations[0].Path, violations[0].Rule,
+		violations[1].Path, violations[1].Rule,
+		violations[2].Path, violations[2].Rule,
+	)
+	if got != "a.txt:file-size|z.go:debt-marker|z.go:file-size" {
+		t.Fatalf("Audit() order = %q", got)
+	}
+}
+
+func TestCheckAgentGuideRejectsUnknownRecipesAndBrokenLinks(t *testing.T) {
+	root := newTestRepository(t, map[string]string{
+		"AGENTS.md": "# Agent guide\nRun `just ci` and `just missing`.\nSee [operations](docs/missing.md).\n",
+		"justfile":  "ci:\n    go test ./...\n",
+	})
+
+	violations, err := CheckAgentGuide(root)
+	if err != nil {
+		t.Fatalf("CheckAgentGuide() error = %v", err)
+	}
+	if len(violations) != 2 {
+		t.Fatalf("CheckAgentGuide() violations = %#v, want two", violations)
+	}
+	if violations[0].Rule != "agent-command" || !strings.Contains(violations[0].Message, "missing") {
+		t.Fatalf("first violation = %#v, want missing recipe", violations[0])
+	}
+	if violations[1].Rule != "agent-link" || !strings.Contains(violations[1].Message, "docs/missing.md") {
+		t.Fatalf("second violation = %#v, want broken local link", violations[1])
+	}
+}
+
+func TestCheckAgentGuideAcceptsExistingRecipesAndLinks(t *testing.T) {
+	root := newTestRepository(t, map[string]string{
+		"AGENTS.md":         "# Agent guide\nRun `just ci`.\nSee [operations](docs/runbook.md#recovery).\n",
+		"justfile":          "ci:\n    go test ./...\n",
+		"docs/runbook.md":   "# Recovery\n",
+		"docs/external.url": "not referenced\n",
+	})
+
+	violations, err := CheckAgentGuide(root)
+	if err != nil {
+		t.Fatalf("CheckAgentGuide() error = %v", err)
+	}
+	if len(violations) != 0 {
+		t.Fatalf("CheckAgentGuide() violations = %#v, want none", violations)
+	}
+}
+
+func TestRepositoryPolicy(t *testing.T) {
+	_, currentFile, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("runtime.Caller() could not locate the repository")
+	}
+	root := filepath.Clean(filepath.Join(filepath.Dir(currentFile), "..", ".."))
+
+	violations, err := Audit(root, Limits{MaxBytes: 1_048_576, MaxLines: 1_500})
+	if err != nil {
+		t.Fatalf("Audit() error = %v", err)
+	}
+	agentViolations, err := CheckAgentGuide(root)
+	if err != nil {
+		t.Fatalf("CheckAgentGuide() error = %v", err)
+	}
+	violations = append(violations, agentViolations...)
+	if len(violations) == 0 {
+		return
+	}
+
+	var messages []string
+	for _, violation := range violations {
+		location := violation.Path
+		if violation.Line > 0 {
+			location = fmt.Sprintf("%s:%d", location, violation.Line)
+		}
+		messages = append(messages, fmt.Sprintf("%s: %s: %s", location, violation.Rule, violation.Message))
+	}
+	t.Fatalf("repository policy violations:\n%s", strings.Join(messages, "\n"))
+}
+
+func newTestRepository(t *testing.T, files map[string]string) string {
+	t.Helper()
+
+	root := t.TempDir()
+	runGit(t, root, "init", "-q")
+	for name, content := range files {
+		path := filepath.Join(root, filepath.FromSlash(name))
+		if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+			t.Fatalf("MkdirAll(%q): %v", path, err)
+		}
+		if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+			t.Fatalf("WriteFile(%q): %v", path, err)
+		}
+	}
+	runGit(t, root, "add", ".")
+	return root
+}
+
+func runGit(t *testing.T, root string, args ...string) {
+	t.Helper()
+
+	cmd := exec.Command("git", append([]string{"-C", root}, args...)...)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("git %s: %v\n%s", strings.Join(args, " "), err, out)
+	}
+}

--- a/internal/telemetry/posthog.go
+++ b/internal/telemetry/posthog.go
@@ -1,0 +1,122 @@
+package telemetry
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+type posthogSink struct {
+	apiKey         string
+	endpoint       string
+	release        string
+	installationID string
+	client         *http.Client
+}
+
+func newPosthogSink(config Config, client *http.Client) (*posthogSink, error) {
+	host := strings.TrimSpace(config.PostHogHost)
+	if host == "" {
+		host = "https://us.i.posthog.com"
+	}
+	parsed, err := url.Parse(host)
+	if err != nil || parsed.Scheme == "" || parsed.Host == "" {
+		return nil, fmt.Errorf("parse POSTHOG_HOST %q", host)
+	}
+	installationIDPath := config.InstallationIDPath
+	if installationIDPath == "" {
+		configDir, err := os.UserConfigDir()
+		if err != nil {
+			return nil, fmt.Errorf("resolve config directory for analytics ID: %w", err)
+		}
+		installationIDPath = filepath.Join(configDir, "all-cli", "telemetry", "installation-id")
+	}
+	installationID, err := loadOrCreateInstallationID(installationIDPath)
+	if err != nil {
+		return nil, err
+	}
+	return &posthogSink{
+		apiKey:         config.PostHogKey,
+		endpoint:       strings.TrimSuffix(host, "/") + "/capture/",
+		release:        config.Release,
+		installationID: installationID,
+		client:         client,
+	}, nil
+}
+
+func (p *posthogSink) capture(ctx context.Context, command, result string) {
+	payload := map[string]any{
+		"api_key": p.apiKey,
+		"event":   "all_cli command",
+		"properties": map[string]string{
+			"distinct_id": p.installationID,
+			"command":     command,
+			"result":      result,
+			"release":     p.release,
+			"$lib":        "all-cli",
+		},
+	}
+	body, err := json.Marshal(payload)
+	if err != nil {
+		return
+	}
+	requestContext := ctx
+	if requestContext == nil {
+		requestContext = context.Background()
+	}
+	requestContext, cancel := context.WithTimeout(requestContext, 2*time.Second)
+	defer cancel()
+	req, err := http.NewRequestWithContext(requestContext, http.MethodPost, p.endpoint, bytes.NewReader(body))
+	if err != nil {
+		return
+	}
+	req.Header.Set("Content-Type", "application/json")
+	response, err := p.client.Do(req)
+	if err == nil {
+		response.Body.Close()
+	}
+}
+
+func loadOrCreateInstallationID(path string) (string, error) {
+	content, err := os.ReadFile(path)
+	if err == nil {
+		if id := strings.TrimSpace(string(content)); id != "" {
+			return id, nil
+		}
+	} else if !os.IsNotExist(err) {
+		return "", fmt.Errorf("read analytics installation ID: %w", err)
+	}
+
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		return "", fmt.Errorf("create analytics installation ID directory: %w", err)
+	}
+	id := randomHex(16)
+	temp, err := os.CreateTemp(filepath.Dir(path), ".installation-id-*")
+	if err != nil {
+		return "", fmt.Errorf("create analytics installation ID: %w", err)
+	}
+	tempPath := temp.Name()
+	defer os.Remove(tempPath)
+	if err := temp.Chmod(0o600); err != nil {
+		temp.Close()
+		return "", fmt.Errorf("secure analytics installation ID: %w", err)
+	}
+	if _, err := temp.WriteString(id + "\n"); err != nil {
+		temp.Close()
+		return "", fmt.Errorf("write analytics installation ID: %w", err)
+	}
+	if err := temp.Close(); err != nil {
+		return "", fmt.Errorf("close analytics installation ID: %w", err)
+	}
+	if err := os.Rename(tempPath, path); err != nil {
+		return "", fmt.Errorf("persist analytics installation ID: %w", err)
+	}
+	return id, nil
+}

--- a/internal/telemetry/prometheus.go
+++ b/internal/telemetry/prometheus.go
@@ -1,0 +1,154 @@
+package telemetry
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+)
+
+type metricKey struct {
+	Command string
+	Result  string
+}
+
+type metricValue struct {
+	Count       uint64
+	DurationSum float64
+}
+
+var prometheusMu sync.Mutex
+
+func recordPrometheus(path, command, result string, duration time.Duration) error {
+	prometheusMu.Lock()
+	defer prometheusMu.Unlock()
+
+	metrics, err := readPrometheus(path)
+	if err != nil {
+		return err
+	}
+	key := metricKey{Command: command, Result: result}
+	value := metrics[key]
+	value.Count++
+	value.DurationSum += duration.Seconds()
+	metrics[key] = value
+	return writePrometheus(path, metrics)
+}
+
+func readPrometheus(path string) (map[metricKey]metricValue, error) {
+	metrics := make(map[metricKey]metricValue)
+	file, err := os.Open(path)
+	if os.IsNotExist(err) {
+		return metrics, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	defer file.Close()
+
+	scanner := bufio.NewScanner(file)
+	for scanner.Scan() {
+		line := scanner.Text()
+		name, key, value, ok := parseMetricLine(line)
+		if !ok {
+			continue
+		}
+		current := metrics[key]
+		switch name {
+		case "all_cli_command_total":
+			current.Count = uint64(value)
+		case "all_cli_command_duration_seconds_sum":
+			current.DurationSum = value
+		}
+		metrics[key] = current
+	}
+	return metrics, scanner.Err()
+}
+
+func parseMetricLine(line string) (string, metricKey, float64, bool) {
+	open := strings.IndexByte(line, '{')
+	close := strings.Index(line, `"} `)
+	if open <= 0 || close <= open {
+		return "", metricKey{}, 0, false
+	}
+	name := line[:open]
+	labels := line[open+1 : close+2]
+	var command, result string
+	if _, err := fmt.Sscanf(labels, `command=%q,result=%q`, &command, &result); err != nil {
+		return "", metricKey{}, 0, false
+	}
+	value, err := strconv.ParseFloat(strings.TrimSpace(line[close+3:]), 64)
+	if err != nil {
+		return "", metricKey{}, 0, false
+	}
+	return name, metricKey{Command: command, Result: result}, value, true
+}
+
+func writePrometheus(path string, metrics map[metricKey]metricValue) error {
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		return err
+	}
+	keys := make([]metricKey, 0, len(metrics))
+	for key := range metrics {
+		keys = append(keys, key)
+	}
+	sort.Slice(keys, func(i, j int) bool {
+		if keys[i].Command != keys[j].Command {
+			return keys[i].Command < keys[j].Command
+		}
+		return keys[i].Result < keys[j].Result
+	})
+
+	var output strings.Builder
+	output.WriteString("# HELP all_cli_command_total Completed all-cli commands.\n")
+	output.WriteString("# TYPE all_cli_command_total counter\n")
+	for _, key := range keys {
+		value := metrics[key]
+		fmt.Fprintf(&output, "all_cli_command_total%s %d\n", prometheusLabels(key), value.Count)
+	}
+	output.WriteString("# HELP all_cli_command_duration_seconds Command duration in seconds.\n")
+	output.WriteString("# TYPE all_cli_command_duration_seconds summary\n")
+	for _, key := range keys {
+		value := metrics[key]
+		fmt.Fprintf(&output, "all_cli_command_duration_seconds_sum%s %.6f\n", prometheusLabels(key), value.DurationSum)
+		fmt.Fprintf(&output, "all_cli_command_duration_seconds_count%s %d\n", prometheusLabels(key), value.Count)
+	}
+
+	temp, err := os.CreateTemp(filepath.Dir(path), ".all-cli-prom-*")
+	if err != nil {
+		return err
+	}
+	tempPath := temp.Name()
+	defer os.Remove(tempPath)
+	if err := temp.Chmod(0o600); err != nil {
+		temp.Close()
+		return err
+	}
+	if _, err := temp.WriteString(output.String()); err != nil {
+		temp.Close()
+		return err
+	}
+	if err := temp.Close(); err != nil {
+		return err
+	}
+	return os.Rename(tempPath, path)
+}
+
+func prometheusLabels(key metricKey) string {
+	return fmt.Sprintf(
+		`{command="%s",result="%s"}`,
+		escapePrometheusLabel(key.Command),
+		escapePrometheusLabel(key.Result),
+	)
+}
+
+func escapePrometheusLabel(value string) string {
+	value = strings.ReplaceAll(value, `\`, `\\`)
+	value = strings.ReplaceAll(value, "\n", `\n`)
+	return strings.ReplaceAll(value, `"`, `\"`)
+}

--- a/internal/telemetry/recorder.go
+++ b/internal/telemetry/recorder.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/rand"
 	"encoding/hex"
+	"fmt"
 	"log/slog"
 	"net/http"
 	"os"
@@ -94,7 +95,7 @@ func (r *Recorder) Finish(ctx context.Context, span Span, command string, comman
 	}
 	command = normalizeCommand(command)
 
-	r.writeStructuredLog(ctx, span, command, result, duration)
+	_ = r.writeStructuredLog(ctx, span, command, result, duration)
 	if r.config.MetricsPath != "" {
 		_ = recordPrometheus(r.config.MetricsPath, command, result, duration)
 	}
@@ -114,18 +115,17 @@ func TraceID(ctx context.Context) string {
 	return traceID
 }
 
-func (r *Recorder) writeStructuredLog(ctx context.Context, span Span, command, result string, duration time.Duration) {
+func (r *Recorder) writeStructuredLog(ctx context.Context, span Span, command, result string, duration time.Duration) error {
 	if strings.TrimSpace(r.config.LogPath) == "" {
-		return
+		return nil
 	}
 	if err := os.MkdirAll(filepath.Dir(r.config.LogPath), 0o700); err != nil {
-		return
+		return fmt.Errorf("create structured log directory: %w", err)
 	}
 	file, err := os.OpenFile(r.config.LogPath, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o600)
 	if err != nil {
-		return
+		return fmt.Errorf("open structured log: %w", err)
 	}
-	defer file.Close()
 
 	logger := slog.New(slog.NewJSONHandler(file, &slog.HandlerOptions{Level: slog.LevelInfo}))
 	logger.InfoContext(
@@ -138,6 +138,10 @@ func (r *Recorder) writeStructuredLog(ctx context.Context, span Span, command, r
 		slog.String("release", r.config.Release),
 		slog.String("trace_id", span.TraceID),
 	)
+	if err := file.Close(); err != nil {
+		return fmt.Errorf("close structured log: %w", err)
+	}
+	return nil
 }
 
 func traceIDFromParent(traceParent string) string {

--- a/internal/telemetry/recorder.go
+++ b/internal/telemetry/recorder.go
@@ -1,0 +1,166 @@
+package telemetry
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"log/slog"
+	"net/http"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"time"
+)
+
+type Config struct {
+	LogPath            string
+	MetricsPath        string
+	SentryDSN          string
+	SentryEnvironment  string
+	PostHogKey         string
+	PostHogHost        string
+	InstallationIDPath string
+	Release            string
+	TraceParent        string
+	HTTPClient         *http.Client
+}
+
+type Span struct {
+	TraceID   string
+	StartedAt time.Time
+}
+
+type Recorder struct {
+	config     Config
+	httpClient *http.Client
+	sentry     *sentrySink
+	posthog    *posthogSink
+}
+
+type traceContextKey struct{}
+
+var traceParentPattern = regexp.MustCompile(`(?i)^[0-9a-f]{2}-([0-9a-f]{32})-[0-9a-f]{16}-[0-9a-f]{2}$`)
+
+func New(config Config) (*Recorder, error) {
+	client := config.HTTPClient
+	if client == nil {
+		client = &http.Client{Timeout: 2 * time.Second}
+	}
+	recorder := &Recorder{
+		config:     config,
+		httpClient: client,
+	}
+
+	var err error
+	if strings.TrimSpace(config.SentryDSN) != "" {
+		recorder.sentry, err = newSentrySink(config, client)
+		if err != nil {
+			return nil, err
+		}
+	}
+	if strings.TrimSpace(config.PostHogKey) != "" {
+		recorder.posthog, err = newPosthogSink(config, client)
+		if err != nil {
+			return nil, err
+		}
+	}
+	return recorder, nil
+}
+
+func (r *Recorder) Start(ctx context.Context) (context.Context, Span) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	traceID := traceIDFromParent(r.config.TraceParent)
+	if traceID == "" {
+		traceID = randomHex(16)
+	}
+	span := Span{
+		TraceID:   traceID,
+		StartedAt: time.Now(),
+	}
+	return context.WithValue(ctx, traceContextKey{}, traceID), span
+}
+
+func (r *Recorder) Finish(ctx context.Context, span Span, command string, commandErr error) {
+	result := "success"
+	if commandErr != nil {
+		result = "error"
+	}
+	duration := time.Since(span.StartedAt)
+	if duration < 0 {
+		duration = 0
+	}
+	command = normalizeCommand(command)
+
+	r.writeStructuredLog(ctx, span, command, result, duration)
+	if r.config.MetricsPath != "" {
+		_ = recordPrometheus(r.config.MetricsPath, command, result, duration)
+	}
+	if r.sentry != nil && commandErr != nil {
+		r.sentry.capture(ctx, span, command, commandErr)
+	}
+	if r.posthog != nil {
+		r.posthog.capture(ctx, command, result)
+	}
+}
+
+func TraceID(ctx context.Context) string {
+	if ctx == nil {
+		return ""
+	}
+	traceID, _ := ctx.Value(traceContextKey{}).(string)
+	return traceID
+}
+
+func (r *Recorder) writeStructuredLog(ctx context.Context, span Span, command, result string, duration time.Duration) {
+	if strings.TrimSpace(r.config.LogPath) == "" {
+		return
+	}
+	if err := os.MkdirAll(filepath.Dir(r.config.LogPath), 0o700); err != nil {
+		return
+	}
+	file, err := os.OpenFile(r.config.LogPath, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o600)
+	if err != nil {
+		return
+	}
+	defer file.Close()
+
+	logger := slog.New(slog.NewJSONHandler(file, &slog.HandlerOptions{Level: slog.LevelInfo}))
+	logger.InfoContext(
+		ctx,
+		"command finished",
+		slog.String("event", "command_finished"),
+		slog.String("command", command),
+		slog.String("result", result),
+		slog.Int64("duration_ms", duration.Milliseconds()),
+		slog.String("release", r.config.Release),
+		slog.String("trace_id", span.TraceID),
+	)
+}
+
+func traceIDFromParent(traceParent string) string {
+	match := traceParentPattern.FindStringSubmatch(strings.TrimSpace(traceParent))
+	if len(match) != 2 || match[1] == strings.Repeat("0", 32) {
+		return ""
+	}
+	return strings.ToLower(match[1])
+}
+
+func randomHex(bytesCount int) string {
+	data := make([]byte, bytesCount)
+	if _, err := rand.Read(data); err != nil {
+		now := time.Now().UTC().Format(time.RFC3339Nano)
+		return hex.EncodeToString([]byte(now))[:bytesCount*2]
+	}
+	return hex.EncodeToString(data)
+}
+
+func normalizeCommand(command string) string {
+	fields := strings.Fields(command)
+	if len(fields) == 0 {
+		return "unknown"
+	}
+	return strings.Join(fields, " ")
+}

--- a/internal/telemetry/recorder_test.go
+++ b/internal/telemetry/recorder_test.go
@@ -1,0 +1,153 @@
+package telemetry
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestRecorderWritesStructuredLifecycleAndPrometheusMetrics(t *testing.T) {
+	root := t.TempDir()
+	logPath := filepath.Join(root, "events.jsonl")
+	metricsPath := filepath.Join(root, "all-cli.prom")
+	recorder, err := New(Config{
+		LogPath:     logPath,
+		MetricsPath: metricsPath,
+		Release:     "v1.2.3",
+		TraceParent: "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01",
+	})
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+
+	ctx, span := recorder.Start(context.Background())
+	if span.TraceID != "4bf92f3577b34da6a3ce929d0e0e4736" {
+		t.Fatalf("Start() trace ID = %q", span.TraceID)
+	}
+	if got := TraceID(ctx); got != span.TraceID {
+		t.Fatalf("TraceID(ctx) = %q, want %q", got, span.TraceID)
+	}
+	recorder.Finish(ctx, span, "status", nil)
+
+	event := readJSONEvent(t, logPath)
+	assertEventValue(t, event, "event", "command_finished")
+	assertEventValue(t, event, "command", "status")
+	assertEventValue(t, event, "result", "success")
+	assertEventValue(t, event, "release", "v1.2.3")
+	assertEventValue(t, event, "trace_id", span.TraceID)
+	if _, ok := event["duration_ms"].(float64); !ok {
+		t.Fatalf("duration_ms = %#v, want JSON number", event["duration_ms"])
+	}
+	for _, forbidden := range []string{"args", "arguments", "environment", "path", "username", "output"} {
+		if _, ok := event[forbidden]; ok {
+			t.Fatalf("structured event contains forbidden field %q: %#v", forbidden, event)
+		}
+	}
+
+	metrics, err := os.ReadFile(metricsPath)
+	if err != nil {
+		t.Fatalf("ReadFile(metrics) error = %v", err)
+	}
+	text := string(metrics)
+	for _, want := range []string{
+		`all_cli_command_total{command="status",result="success"} 1`,
+		`all_cli_command_duration_seconds_count{command="status",result="success"} 1`,
+	} {
+		if !strings.Contains(text, want) {
+			t.Fatalf("metrics missing %q:\n%s", want, text)
+		}
+	}
+	for _, forbidden := range []string{span.TraceID, "error_message", "argument"} {
+		if strings.Contains(text, forbidden) {
+			t.Fatalf("metrics contain high-cardinality/private value %q:\n%s", forbidden, text)
+		}
+	}
+}
+
+func TestRecorderGeneratesTraceAndDoesNotLogErrorDetails(t *testing.T) {
+	logPath := filepath.Join(t.TempDir(), "events.jsonl")
+	recorder, err := New(Config{LogPath: logPath})
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+
+	ctx, span := recorder.Start(context.Background())
+	if ok, _ := regexp.MatchString(`^[0-9a-f]{32}$`, span.TraceID); !ok {
+		t.Fatalf("generated trace ID = %q, want 32 lowercase hex characters", span.TraceID)
+	}
+	privateError := errors.New("token=secret-value failed under /Users/private/project")
+	recorder.Finish(ctx, span, "doctor", privateError)
+
+	event := readJSONEvent(t, logPath)
+	assertEventValue(t, event, "result", "error")
+	encoded, err := json.Marshal(event)
+	if err != nil {
+		t.Fatalf("Marshal(event) error = %v", err)
+	}
+	for _, forbidden := range []string{"secret-value", "/Users/private", privateError.Error()} {
+		if strings.Contains(string(encoded), forbidden) {
+			t.Fatalf("structured log leaked %q: %s", forbidden, encoded)
+		}
+	}
+}
+
+func TestPrometheusMetricsAggregateAcrossRecorderInstances(t *testing.T) {
+	metricsPath := filepath.Join(t.TempDir(), "all-cli.prom")
+	for _, resultErr := range []error{nil, errors.New("failed")} {
+		recorder, err := New(Config{MetricsPath: metricsPath})
+		if err != nil {
+			t.Fatalf("New() error = %v", err)
+		}
+		ctx, span := recorder.Start(context.Background())
+		span.StartedAt = time.Now().Add(-250 * time.Millisecond)
+		recorder.Finish(ctx, span, "version", resultErr)
+	}
+
+	metrics, err := os.ReadFile(metricsPath)
+	if err != nil {
+		t.Fatalf("ReadFile(metrics) error = %v", err)
+	}
+	text := string(metrics)
+	for _, want := range []string{
+		`all_cli_command_total{command="version",result="success"} 1`,
+		`all_cli_command_total{command="version",result="error"} 1`,
+	} {
+		if !strings.Contains(text, want) {
+			t.Fatalf("metrics missing %q:\n%s", want, text)
+		}
+	}
+}
+
+func readJSONEvent(t *testing.T, path string) map[string]any {
+	t.Helper()
+
+	file, err := os.Open(path)
+	if err != nil {
+		t.Fatalf("Open(%q) error = %v", path, err)
+	}
+	defer file.Close()
+
+	scanner := bufio.NewScanner(file)
+	if !scanner.Scan() {
+		t.Fatalf("no JSON event in %s: %v", path, scanner.Err())
+	}
+	var event map[string]any
+	if err := json.Unmarshal(scanner.Bytes(), &event); err != nil {
+		t.Fatalf("Unmarshal(event) error = %v\n%s", err, scanner.Bytes())
+	}
+	return event
+}
+
+func assertEventValue(t *testing.T, event map[string]any, key string, want any) {
+	t.Helper()
+	if got := event[key]; got != want {
+		t.Fatalf("event[%q] = %#v, want %#v; event=%#v", key, got, want, event)
+	}
+}

--- a/internal/telemetry/recorder_test.go
+++ b/internal/telemetry/recorder_test.go
@@ -125,6 +125,29 @@ func TestPrometheusMetricsAggregateAcrossRecorderInstances(t *testing.T) {
 	}
 }
 
+func TestStructuredLogFailureDoesNotBlockMetrics(t *testing.T) {
+	root := t.TempDir()
+	notDirectory := filepath.Join(root, "not-a-directory")
+	if err := os.WriteFile(notDirectory, []byte("file"), 0o600); err != nil {
+		t.Fatalf("WriteFile(%q) error = %v", notDirectory, err)
+	}
+	metricsPath := filepath.Join(root, "all-cli.prom")
+	recorder, err := New(Config{
+		LogPath:     filepath.Join(notDirectory, "events.jsonl"),
+		MetricsPath: metricsPath,
+	})
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+
+	ctx, span := recorder.Start(context.Background())
+	recorder.Finish(ctx, span, "status", nil)
+
+	if _, err := os.Stat(metricsPath); err != nil {
+		t.Fatalf("metrics were blocked by structured-log failure: %v", err)
+	}
+}
+
 func readJSONEvent(t *testing.T, path string) map[string]any {
 	t.Helper()
 

--- a/internal/telemetry/sentry.go
+++ b/internal/telemetry/sentry.go
@@ -1,0 +1,157 @@
+package telemetry
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"path/filepath"
+	"regexp"
+	"runtime"
+	"strings"
+	"time"
+)
+
+type sentrySink struct {
+	dsn         string
+	endpoint    string
+	publicKey   string
+	environment string
+	release     string
+	client      *http.Client
+}
+
+var (
+	secretPattern = regexp.MustCompile(`(?i)\b(token|password|secret|api[_-]?key|authorization)\s*[:=]\s*[^,\s;]+`)
+	pathPattern   = regexp.MustCompile(`(?:[A-Za-z]:\\|/)(?:[^/\s:\\]+[/\\]){1,}[^,\s:]*`)
+)
+
+func newSentrySink(config Config, client *http.Client) (*sentrySink, error) {
+	parsed, err := url.Parse(config.SentryDSN)
+	if err != nil {
+		return nil, fmt.Errorf("parse SENTRY_DSN: %w", err)
+	}
+	if parsed.Scheme == "" || parsed.Host == "" || parsed.User == nil || parsed.User.Username() == "" {
+		return nil, fmt.Errorf("parse SENTRY_DSN: scheme, host, public key, and project ID are required")
+	}
+	projectID := strings.Trim(strings.TrimSpace(filepath.Base(parsed.Path)), "/")
+	if projectID == "" || projectID == "." {
+		return nil, fmt.Errorf("parse SENTRY_DSN: project ID is required")
+	}
+	pathPrefix := strings.TrimSuffix(strings.TrimSuffix(parsed.Path, "/"), "/"+projectID)
+	endpoint := fmt.Sprintf("%s://%s%s/api/%s/envelope/", parsed.Scheme, parsed.Host, pathPrefix, projectID)
+	return &sentrySink{
+		dsn:         config.SentryDSN,
+		endpoint:    endpoint,
+		publicKey:   parsed.User.Username(),
+		environment: config.SentryEnvironment,
+		release:     config.Release,
+		client:      client,
+	}, nil
+}
+
+func (s *sentrySink) capture(ctx context.Context, span Span, command string, commandErr error) {
+	eventID := randomHex(16)
+	now := time.Now().UTC()
+	event := map[string]any{
+		"event_id":    eventID,
+		"timestamp":   now.Format(time.RFC3339Nano),
+		"platform":    "go",
+		"level":       "error",
+		"environment": s.environment,
+		"release":     s.release,
+		"transaction": command,
+		"tags": map[string]string{
+			"command": command,
+			"result":  "error",
+		},
+		"contexts": map[string]any{
+			"trace": map[string]string{
+				"trace_id": span.TraceID,
+				"type":     "trace",
+			},
+		},
+		"breadcrumbs": map[string]any{
+			"values": []map[string]any{{
+				"timestamp": span.StartedAt.UTC().Format(time.RFC3339Nano),
+				"category":  "command",
+				"level":     "info",
+				"message":   "all-cli " + command,
+			}},
+		},
+		"exception": map[string]any{
+			"values": []map[string]any{{
+				"type":  "CommandError",
+				"value": scrubError(commandErr),
+				"stacktrace": map[string]any{
+					"frames": captureStackFrames(),
+				},
+			}},
+		},
+	}
+	eventJSON, err := json.Marshal(event)
+	if err != nil {
+		return
+	}
+	headerJSON, err := json.Marshal(map[string]string{
+		"event_id": eventID,
+		"sent_at":  now.Format(time.RFC3339Nano),
+		"dsn":      s.dsn,
+	})
+	if err != nil {
+		return
+	}
+	body := bytes.Join([][]byte{headerJSON, []byte(`{"type":"event"}`), eventJSON, nil}, []byte{'\n'})
+
+	requestContext := ctx
+	if requestContext == nil {
+		requestContext = context.Background()
+	}
+	requestContext, cancel := context.WithTimeout(requestContext, 2*time.Second)
+	defer cancel()
+	req, err := http.NewRequestWithContext(requestContext, http.MethodPost, s.endpoint, bytes.NewReader(body))
+	if err != nil {
+		return
+	}
+	req.Header.Set("Content-Type", "application/x-sentry-envelope")
+	req.Header.Set("X-Sentry-Auth", "Sentry sentry_version=7, sentry_key="+s.publicKey+", sentry_client=all-cli/1")
+	response, err := s.client.Do(req)
+	if err == nil {
+		response.Body.Close()
+	}
+}
+
+func scrubError(err error) string {
+	if err == nil {
+		return ""
+	}
+	message := secretPattern.ReplaceAllString(err.Error(), "$1=<redacted>")
+	message = pathPattern.ReplaceAllString(message, "<path>")
+	const maxLength = 8 * 1024
+	if len(message) > maxLength {
+		message = message[:maxLength]
+	}
+	return message
+}
+
+func captureStackFrames() []map[string]any {
+	callers := make([]uintptr, 24)
+	count := runtime.Callers(3, callers)
+	frames := runtime.CallersFrames(callers[:count])
+	result := make([]map[string]any, 0, count)
+	for {
+		frame, more := frames.Next()
+		result = append(result, map[string]any{
+			"filename": filepath.Base(frame.File),
+			"function": frame.Function,
+			"lineno":   frame.Line,
+			"in_app":   strings.Contains(frame.Function, "github.com/oldwinter/all-cli"),
+		})
+		if !more {
+			break
+		}
+	}
+	return result
+}

--- a/internal/telemetry/sinks_test.go
+++ b/internal/telemetry/sinks_test.go
@@ -1,0 +1,131 @@
+package telemetry
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+)
+
+func TestRecorderSendsContextualizedSentryAndMinimizedPostHogEvents(t *testing.T) {
+	var mu sync.Mutex
+	requests := make(map[string][]byte)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			t.Errorf("ReadAll(request) error = %v", err)
+			return
+		}
+		mu.Lock()
+		requests[r.URL.Path] = body
+		mu.Unlock()
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	installationIDPath := filepath.Join(t.TempDir(), "installation-id")
+	sentryDSN := strings.Replace(server.URL, "http://", "http://public@", 1) + "/42"
+	recorder, err := New(Config{
+		SentryDSN:          sentryDSN,
+		SentryEnvironment:  "ci",
+		PostHogKey:         "phc_test",
+		PostHogHost:        server.URL,
+		InstallationIDPath: installationIDPath,
+		Release:            "v1.2.3",
+		HTTPClient:         server.Client(),
+	})
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+
+	ctx, span := recorder.Start(context.Background())
+	recorder.Finish(ctx, span, "doctor", errors.New("token=top-secret failed at /Users/private/config"))
+
+	mu.Lock()
+	sentryEnvelope := append([]byte(nil), requests["/api/42/envelope/"]...)
+	posthogPayload := append([]byte(nil), requests["/capture/"]...)
+	mu.Unlock()
+	if len(sentryEnvelope) == 0 {
+		t.Fatal("Sentry envelope was not sent")
+	}
+	if !bytes.Contains(sentryEnvelope, []byte(`"transaction":"doctor"`)) ||
+		!bytes.Contains(sentryEnvelope, []byte(`"environment":"ci"`)) ||
+		!bytes.Contains(sentryEnvelope, []byte(`"release":"v1.2.3"`)) ||
+		!bytes.Contains(sentryEnvelope, []byte(span.TraceID)) ||
+		!bytes.Contains(sentryEnvelope, []byte(`"breadcrumbs"`)) ||
+		!bytes.Contains(sentryEnvelope, []byte(`"stacktrace"`)) {
+		t.Fatalf("Sentry envelope lacks context:\n%s", sentryEnvelope)
+	}
+	for _, forbidden := range []string{"top-secret", "/Users/private"} {
+		if bytes.Contains(sentryEnvelope, []byte(forbidden)) {
+			t.Fatalf("Sentry envelope leaked %q:\n%s", forbidden, sentryEnvelope)
+		}
+	}
+
+	var capture struct {
+		APIKey     string         `json:"api_key"`
+		Event      string         `json:"event"`
+		Properties map[string]any `json:"properties"`
+	}
+	if err := json.Unmarshal(posthogPayload, &capture); err != nil {
+		t.Fatalf("Unmarshal(PostHog payload) error = %v\n%s", err, posthogPayload)
+	}
+	if capture.APIKey != "phc_test" || capture.Event != "all_cli command" {
+		t.Fatalf("PostHog capture = %#v", capture)
+	}
+	for key, want := range map[string]any{
+		"command": "doctor",
+		"result":  "error",
+		"release": "v1.2.3",
+	} {
+		if got := capture.Properties[key]; got != want {
+			t.Fatalf("PostHog properties[%q] = %#v, want %#v", key, got, want)
+		}
+	}
+	if distinctID, _ := capture.Properties["distinct_id"].(string); distinctID == "" {
+		t.Fatalf("PostHog distinct_id is empty: %#v", capture.Properties)
+	}
+	for _, forbidden := range []string{"error", "trace_id", "args", "path", "environment", "top-secret"} {
+		if _, ok := capture.Properties[forbidden]; ok {
+			t.Fatalf("PostHog properties contain forbidden key %q: %#v", forbidden, capture.Properties)
+		}
+	}
+}
+
+func TestSinkFailureDoesNotBlockOtherSinks(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, "unavailable", http.StatusServiceUnavailable)
+	}))
+	defer server.Close()
+
+	root := t.TempDir()
+	logPath := filepath.Join(root, "events.jsonl")
+	metricsPath := filepath.Join(root, "all-cli.prom")
+	recorder, err := New(Config{
+		LogPath:     logPath,
+		MetricsPath: metricsPath,
+		SentryDSN:   strings.Replace(server.URL, "http://", "http://public@", 1) + "/42",
+		HTTPClient:  server.Client(),
+	})
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+
+	ctx, span := recorder.Start(context.Background())
+	recorder.Finish(ctx, span, "status", errors.New("failed"))
+
+	if _, err := os.Stat(logPath); err != nil {
+		t.Fatalf("structured log was blocked by Sentry failure: %v", err)
+	}
+	if _, err := os.Stat(metricsPath); err != nil {
+		t.Fatalf("metrics were blocked by Sentry failure: %v", err)
+	}
+}

--- a/internal/tools/glab/adapter.go
+++ b/internal/tools/glab/adapter.go
@@ -199,51 +199,7 @@ func parseAuthStatusAll(stdout string) ([]Instance, []string, []string, error) {
 			continue
 		}
 
-		t := strings.TrimSpace(line)
-
-		if strings.Contains(t, "API call failed:") {
-			cur.apiFailed = true
-			cur.OK = false
-			cur.Error = extractAfter(t, "API call failed:")
-			continue
-		}
-
-		if strings.Contains(t, "Logged in to ") && strings.Contains(t, " as ") {
-			cur.loggedIn = true
-			cur.User = parseUserFromLoggedInLine(t)
-			continue
-		}
-
-		if strings.Contains(t, "Git operations") && strings.Contains(t, "use ") {
-			cur.GitProtocol = parseProtocolTokenAfter(t, "use ")
-			continue
-		}
-
-		if strings.Contains(t, "API calls") && strings.Contains(t, "over ") {
-			cur.APIProtocol = parseProtocolTokenAfter(t, "over ")
-			continue
-		}
-
-		if strings.Contains(t, "REST API Endpoint:") {
-			cur.RESTEndpoint = strings.TrimSpace(extractAfter(t, "REST API Endpoint:"))
-			continue
-		}
-
-		if strings.Contains(t, "GraphQL Endpoint:") {
-			cur.GraphQLEndpoint = strings.TrimSpace(extractAfter(t, "GraphQL Endpoint:"))
-			continue
-		}
-
-		if strings.Contains(t, "Token found:") {
-			cur.HasToken = true
-			continue
-		}
-
-		if strings.Contains(t, "No token found") {
-			cur.HasToken = false
-			cur.Error = execx.FirstNonEmpty(cur.Error, "no token found")
-			continue
-		}
+		parseAuthStatusDetail(cur, strings.TrimSpace(line))
 	}
 
 	flush()
@@ -252,6 +208,31 @@ func parseAuthStatusAll(stdout string) ([]Instance, []string, []string, error) {
 		warnings = append(warnings, "glab output parsed but no instances detected")
 	}
 	return instances, warnings, errs, nil
+}
+
+func parseAuthStatusDetail(cur *Instance, detail string) {
+	switch {
+	case strings.Contains(detail, "API call failed:"):
+		cur.apiFailed = true
+		cur.OK = false
+		cur.Error = extractAfter(detail, "API call failed:")
+	case strings.Contains(detail, "Logged in to ") && strings.Contains(detail, " as "):
+		cur.loggedIn = true
+		cur.User = parseUserFromLoggedInLine(detail)
+	case strings.Contains(detail, "Git operations") && strings.Contains(detail, "use "):
+		cur.GitProtocol = parseProtocolTokenAfter(detail, "use ")
+	case strings.Contains(detail, "API calls") && strings.Contains(detail, "over "):
+		cur.APIProtocol = parseProtocolTokenAfter(detail, "over ")
+	case strings.Contains(detail, "REST API Endpoint:"):
+		cur.RESTEndpoint = strings.TrimSpace(extractAfter(detail, "REST API Endpoint:"))
+	case strings.Contains(detail, "GraphQL Endpoint:"):
+		cur.GraphQLEndpoint = strings.TrimSpace(extractAfter(detail, "GraphQL Endpoint:"))
+	case strings.Contains(detail, "Token found:"):
+		cur.HasToken = true
+	case strings.Contains(detail, "No token found"):
+		cur.HasToken = false
+		cur.Error = execx.FirstNonEmpty(cur.Error, "no token found")
+	}
 }
 
 func extractAfter(s, needle string) string {

--- a/internal/tools/glab/adapter_test.go
+++ b/internal/tools/glab/adapter_test.go
@@ -15,7 +15,7 @@ http://bad-host:6001
   ✓ API calls for http://bad-host:6001 are made over https protocol.
   ! No token found (checked config file, keyring, and environment variables).
 
-   ERROR  
+   ERROR
 
   X could not authenticate to one or more of the configured GitLab instances..
 `

--- a/internal/tools/metadata.go
+++ b/internal/tools/metadata.go
@@ -2,35 +2,49 @@ package tools
 
 import "github.com/oldwinter/all-cli/internal/model"
 
+var naToolPurposes = map[string]string{
+	"fd":            "Fast file finder for local filesystem search.",
+	"rg":            "Fast text search tool for recursive code and file content search.",
+	"fzf":           "Interactive fuzzy finder used to select items from terminal input.",
+	"zoxide":        "Smart directory jumper that tracks and ranks frequently used paths.",
+	"eza":           "Modern replacement for ls with richer file listing output.",
+	"bat":           "File viewer with syntax highlighting and line numbers.",
+	"yq":            "Command-line processor for YAML and structured data transformations.",
+	"brew":          "Homebrew package manager for installing and updating local tooling.",
+	"uv":            "Python-oriented package and tool runner used for fast environment and CLI workflows.",
+	"just":          "Task runner for project automation recipes declared in a justfile.",
+	"yazi":          "Terminal file manager for navigating and manipulating local files.",
+	"lazydocker":    "Terminal dashboard for viewing and operating Docker resources.",
+	"eksctl":        "CLI for managing Amazon EKS clusters and related resources.",
+	"kubectx":       "Helper CLI for switching Kubernetes contexts quickly.",
+	"kubens":        "Helper CLI for switching Kubernetes namespaces quickly.",
+	"kubecolor":     "kubectl-compatible wrapper that adds colorized output.",
+	"krew":          "Plugin manager for kubectl extensions.",
+	"kubefwd":       "Utility for forwarding multiple Kubernetes services to localhost for local debugging.",
+	"kubeshark":     "Kubernetes network inspection tool for observing in-cluster traffic.",
+	"linear":        "Linear CLI for issue, project, and workflow management.",
+	"claude":        "Claude Code CLI for AI-assisted coding and terminal workflows.",
+	"codex":         "Codex CLI for AI-assisted coding and terminal workflows.",
+	"openclaw":      "AI coding CLI for terminal-based development workflows.",
+	"opencode":      "AI coding CLI for interactive code and terminal workflows.",
+	"gemini":        "Gemini CLI for AI-assisted terminal and content workflows.",
+	"ccusage":       "CLI for inspecting Claude Code usage and related local usage data.",
+	"litellm-proxy": "LiteLLM proxy CLI for local or staging model routing and smoke tests.",
+	"simplex-cli":   "Internal operations CLI for Simplex product and account workflows.",
+	"opensearch":    "OpenSearch CLI for OpenSearch cluster and index operations.",
+}
+
 func MetadataForTool(id string) model.ToolMetadata {
+	if purpose, ok := naToolPurposes[id]; ok {
+		return naMetadata(purpose)
+	}
+
 	switch id {
-	case "fd":
-		return naMetadata("Fast file finder for local filesystem search.")
-	case "rg":
-		return naMetadata("Fast text search tool for recursive code and file content search.")
-	case "fzf":
-		return naMetadata("Interactive fuzzy finder used to select items from terminal input.")
-	case "zoxide":
-		return naMetadata("Smart directory jumper that tracks and ranks frequently used paths.")
-	case "eza":
-		return naMetadata("Modern replacement for ls with richer file listing output.")
-	case "bat":
-		return naMetadata("File viewer with syntax highlighting and line numbers.")
-	case "yq":
-		return naMetadata("Command-line processor for YAML and structured data transformations.")
-	case "brew":
-		return naMetadata("Homebrew package manager for installing and updating local tooling.")
-	case "uv":
-		return naMetadata("Python-oriented package and tool runner used for fast environment and CLI workflows.")
-	case "just":
-		return naMetadata("Task runner for project automation recipes declared in a justfile.")
 	case "obsidian":
 		return naMetadata(
 			"Obsidian desktop application for local markdown knowledge bases.",
 			"The detected binary launches a desktop app, not a pure command-line workflow.",
 		)
-	case "yazi":
-		return naMetadata("Terminal file manager for navigating and manipulating local files.")
 	case "k9s":
 		return currentMetadata(
 			"Terminal dashboard for inspecting Kubernetes resources through the current kubeconfig context.",
@@ -43,8 +57,6 @@ func MetadataForTool(id string) model.ToolMetadata {
 			[]string{"inspect_status", "show_current"},
 			"Missing namespace is often a normal state because kubeconfig may not pin a default namespace.",
 		)
-	case "lazydocker":
-		return naMetadata("Terminal dashboard for viewing and operating Docker resources.")
 	case "aws":
 		return currentMetadata(
 			"Amazon Web Services CLI for account, infrastructure, and service operations.",
@@ -115,8 +127,6 @@ func MetadataForTool(id string) model.ToolMetadata {
 			},
 			[]string{"inspect_status", "show_current"},
 		)
-	case "eksctl":
-		return naMetadata("CLI for managing Amazon EKS clusters and related resources.")
 	case "kubectl":
 		return currentMetadata(
 			"Kubernetes CLI used to inspect and operate clusters through kubeconfig contexts.",
@@ -128,18 +138,6 @@ func MetadataForTool(id string) model.ToolMetadata {
 			[]string{"inspect_status", "show_current", "list_contexts", "switch_context", "switch_namespace"},
 			"Missing namespace is not always an error because many kubeconfig contexts rely on the cluster default namespace.",
 		)
-	case "kubectx":
-		return naMetadata("Helper CLI for switching Kubernetes contexts quickly.")
-	case "kubens":
-		return naMetadata("Helper CLI for switching Kubernetes namespaces quickly.")
-	case "kubecolor":
-		return naMetadata("kubectl-compatible wrapper that adds colorized output.")
-	case "krew":
-		return naMetadata("Plugin manager for kubectl extensions.")
-	case "kubefwd":
-		return naMetadata("Utility for forwarding multiple Kubernetes services to localhost for local debugging.")
-	case "kubeshark":
-		return naMetadata("Kubernetes network inspection tool for observing in-cluster traffic.")
 	case "docker":
 		return currentMetadata(
 			"Docker CLI for containers, images, networks, and Docker contexts.",
@@ -172,22 +170,6 @@ func MetadataForTool(id string) model.ToolMetadata {
 			[]string{"inspect_status", "show_current", "list_instances", "switch_host"},
 			"`effective_host` and `global_host` may differ when repository or environment settings override the global default.",
 		)
-	case "linear":
-		return naMetadata("Linear CLI for issue, project, and workflow management.")
-	case "claude":
-		return naMetadata("Claude Code CLI for AI-assisted coding and terminal workflows.")
-	case "codex":
-		return naMetadata("Codex CLI for AI-assisted coding and terminal workflows.")
-	case "openclaw":
-		return naMetadata("AI coding CLI for terminal-based development workflows.")
-	case "opencode":
-		return naMetadata("AI coding CLI for interactive code and terminal workflows.")
-	case "gemini":
-		return naMetadata("Gemini CLI for AI-assisted terminal and content workflows.")
-	case "ccusage":
-		return naMetadata("CLI for inspecting Claude Code usage and related local usage data.")
-	case "litellm-proxy":
-		return naMetadata("LiteLLM proxy CLI for local or staging model routing and smoke tests.")
 	case "opencli":
 		return currentMetadata(
 			"CLI that turns supported websites into command-line interfaces by reusing Chrome browser sessions.",
@@ -201,8 +183,6 @@ func MetadataForTool(id string) model.ToolMetadata {
 			[]string{"inspect_status", "show_current"},
 			"`configured_state=yes` does not guarantee that target websites are logged in; it only verifies the local browser bridge prerequisites that OpenCLI reports.",
 		)
-	case "simplex-cli":
-		return naMetadata("Internal operations CLI for Simplex product and account workflows.")
 	case "rclone":
 		return currentMetadata(
 			"File sync and transfer CLI for local and remote storage backends.",
@@ -230,8 +210,6 @@ func MetadataForTool(id string) model.ToolMetadata {
 			},
 			[]string{"inspect_status", "show_current", "list_contexts", "switch_context"},
 		)
-	case "opensearch":
-		return naMetadata("OpenSearch CLI for OpenSearch cluster and index operations.")
 	case "mise":
 		return currentMetadata(
 			"Runtime manager that resolves active tool versions for the current shell and project.",

--- a/internal/tools/registry.go
+++ b/internal/tools/registry.go
@@ -328,135 +328,51 @@ func wranglerTool() ToolDefinition {
 }
 
 func vercelTool() ToolDefinition {
-	var cache whoamiOnce[vercel.Whoami]
-	fetch := func(ctx context.Context, runner execx.Runner) (vercel.Whoami, []string, []string, error) {
-		return vercel.New(runner).Whoami(ctx)
-	}
-
-	return ToolDefinition{
-		ID:          "vercel",
-		DisplayName: "Vercel CLI",
-		Category:    "cloud",
-		Binary:      "vercel",
-		Timeout:     10 * time.Second,
-		Capabilities: model.Capability{
-			HasContexts: true,
-			CanSwitch:   false,
+	return cloudWhoamiTool(
+		"vercel",
+		"Vercel CLI",
+		func(ctx context.Context, runner execx.Runner) (vercel.Whoami, []string, []string, error) {
+			return vercel.New(runner).Whoami(ctx)
 		},
-		ConfigCheck: func(ctx context.Context, runner execx.Runner, installed bool) (model.ConfiguredState, []string, []string) {
-			if !installed {
-				return model.ConfiguredUnknown, nil, nil
-			}
-			who, warnings, errs, err := cache.load(ctx, runner, fetch)
-			if err != nil {
-				errs = append(errs, err.Error())
-				return model.ConfiguredUnknown, warnings, errs
-			}
-			if strings.TrimSpace(who.Username) != "" || strings.TrimSpace(who.Email) != "" {
-				return model.ConfiguredYes, warnings, errs
-			}
-			return model.ConfiguredNo, warnings, errs
+		func(who vercel.Whoami) bool {
+			return strings.TrimSpace(who.Username) != "" || strings.TrimSpace(who.Email) != ""
 		},
-		Current: func(ctx context.Context, runner execx.Runner, installed bool) (map[string]string, []string, []string) {
-			if !installed {
-				return nil, nil, nil
-			}
-			a := vercel.New(runner)
-			cur, warnings, errs, err := a.Current(ctx)
-			if err != nil {
-				errs = append(errs, err.Error())
-			}
-			return cur, warnings, errs
+		func(ctx context.Context, runner execx.Runner) (map[string]string, []string, []string, error) {
+			return vercel.New(runner).Current(ctx)
 		},
-	}
+	)
 }
 
 func railwayTool() ToolDefinition {
-	var cache whoamiOnce[railway.Whoami]
-	fetch := func(ctx context.Context, runner execx.Runner) (railway.Whoami, []string, []string, error) {
-		return railway.New(runner).Whoami(ctx)
-	}
-
-	return ToolDefinition{
-		ID:          "railway",
-		DisplayName: "Railway CLI",
-		Category:    "cloud",
-		Binary:      "railway",
-		Timeout:     10 * time.Second,
-		Capabilities: model.Capability{
-			HasContexts: true,
-			CanSwitch:   false,
+	return cloudWhoamiTool(
+		"railway",
+		"Railway CLI",
+		func(ctx context.Context, runner execx.Runner) (railway.Whoami, []string, []string, error) {
+			return railway.New(runner).Whoami(ctx)
 		},
-		ConfigCheck: func(ctx context.Context, runner execx.Runner, installed bool) (model.ConfiguredState, []string, []string) {
-			if !installed {
-				return model.ConfiguredUnknown, nil, nil
-			}
-			who, warnings, errs, err := cache.load(ctx, runner, fetch)
-			if err != nil {
-				errs = append(errs, err.Error())
-				return model.ConfiguredUnknown, warnings, errs
-			}
-			if strings.TrimSpace(who.Email) != "" {
-				return model.ConfiguredYes, warnings, errs
-			}
-			return model.ConfiguredNo, warnings, errs
+		func(who railway.Whoami) bool {
+			return strings.TrimSpace(who.Email) != ""
 		},
-		Current: func(ctx context.Context, runner execx.Runner, installed bool) (map[string]string, []string, []string) {
-			if !installed {
-				return nil, nil, nil
-			}
-			a := railway.New(runner)
-			cur, warnings, errs, err := a.Current(ctx)
-			if err != nil {
-				errs = append(errs, err.Error())
-			}
-			return cur, warnings, errs
+		func(ctx context.Context, runner execx.Runner) (map[string]string, []string, []string, error) {
+			return railway.New(runner).Current(ctx)
 		},
-	}
+	)
 }
 
 func netlifyTool() ToolDefinition {
-	var cache whoamiOnce[netlify.CurrentUser]
-	fetch := func(ctx context.Context, runner execx.Runner) (netlify.CurrentUser, []string, []string, error) {
-		return netlify.New(runner).CurrentUser(ctx)
-	}
-
-	return ToolDefinition{
-		ID:          "netlify",
-		DisplayName: "Netlify CLI",
-		Category:    "cloud",
-		Binary:      "netlify",
-		Timeout:     10 * time.Second,
-		Capabilities: model.Capability{
-			HasContexts: true,
-			CanSwitch:   false,
+	return cloudWhoamiTool(
+		"netlify",
+		"Netlify CLI",
+		func(ctx context.Context, runner execx.Runner) (netlify.CurrentUser, []string, []string, error) {
+			return netlify.New(runner).CurrentUser(ctx)
 		},
-		ConfigCheck: func(ctx context.Context, runner execx.Runner, installed bool) (model.ConfiguredState, []string, []string) {
-			if !installed {
-				return model.ConfiguredUnknown, nil, nil
-			}
-			user, warnings, errs, err := cache.load(ctx, runner, fetch)
-			if err != nil {
-				errs = append(errs, err.Error())
-				return model.ConfiguredUnknown, warnings, errs
-			}
-			if strings.TrimSpace(user.ID) != "" || strings.TrimSpace(user.Email) != "" {
-				return model.ConfiguredYes, warnings, errs
-			}
-			return model.ConfiguredNo, warnings, errs
+		func(user netlify.CurrentUser) bool {
+			return strings.TrimSpace(user.ID) != "" || strings.TrimSpace(user.Email) != ""
 		},
-		Current: func(ctx context.Context, runner execx.Runner, installed bool) (map[string]string, []string, []string) {
-			if !installed {
-				return nil, nil, nil
-			}
-			a := netlify.New(runner)
-			cur, warnings, errs, err := a.Current(ctx)
-			if err != nil {
-				errs = append(errs, err.Error())
-			}
-			return cur, warnings, errs
+		func(ctx context.Context, runner execx.Runner) (map[string]string, []string, []string, error) {
+			return netlify.New(runner).Current(ctx)
 		},
-	}
+	)
 }
 
 func kargoTool() ToolDefinition {

--- a/internal/tools/registry_cloud.go
+++ b/internal/tools/registry_cloud.go
@@ -3,8 +3,10 @@ package tools
 import (
 	"context"
 	"sync"
+	"time"
 
 	"github.com/oldwinter/all-cli/internal/execx"
+	"github.com/oldwinter/all-cli/internal/model"
 )
 
 // whoamiOnce runs fetch at most once per ToolDefinition closure (for ConfigCheck).
@@ -21,4 +23,49 @@ func (w *whoamiOnce[T]) load(ctx context.Context, r execx.Runner, fetch func(con
 		w.val, w.warn, w.errs, w.err = fetch(ctx, r)
 	})
 	return w.val, w.warn, w.errs, w.err
+}
+
+func cloudWhoamiTool[T any](
+	id string,
+	displayName string,
+	fetch func(context.Context, execx.Runner) (T, []string, []string, error),
+	configured func(T) bool,
+	current func(context.Context, execx.Runner) (map[string]string, []string, []string, error),
+) ToolDefinition {
+	var cache whoamiOnce[T]
+	return ToolDefinition{
+		ID:          id,
+		DisplayName: displayName,
+		Category:    "cloud",
+		Binary:      id,
+		Timeout:     10 * time.Second,
+		Capabilities: model.Capability{
+			HasContexts: true,
+			CanSwitch:   false,
+		},
+		ConfigCheck: func(ctx context.Context, runner execx.Runner, installed bool) (model.ConfiguredState, []string, []string) {
+			if !installed {
+				return model.ConfiguredUnknown, nil, nil
+			}
+			who, warnings, errs, err := cache.load(ctx, runner, fetch)
+			if err != nil {
+				errs = append(errs, err.Error())
+				return model.ConfiguredUnknown, warnings, errs
+			}
+			if configured(who) {
+				return model.ConfiguredYes, warnings, errs
+			}
+			return model.ConfiguredNo, warnings, errs
+		},
+		Current: func(ctx context.Context, runner execx.Runner, installed bool) (map[string]string, []string, []string) {
+			if !installed {
+				return nil, nil, nil
+			}
+			cur, warnings, errs, err := current(ctx, runner)
+			if err != nil {
+				errs = append(errs, err.Error())
+			}
+			return cur, warnings, errs
+		},
+	}
 }

--- a/internal/tools/registry_helpers_test.go
+++ b/internal/tools/registry_helpers_test.go
@@ -1,0 +1,371 @@
+package tools
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+
+	"github.com/oldwinter/all-cli/internal/execx"
+	"github.com/oldwinter/all-cli/internal/model"
+)
+
+type registryAdapterStub struct {
+	configured      bool
+	configWarnings  []string
+	configErrors    []string
+	configErr       error
+	current         map[string]string
+	currentWarnings []string
+	currentErrors   []string
+	currentErr      error
+	configuredCalls int
+	currentCalls    int
+}
+
+func (a *registryAdapterStub) Configured(context.Context) (bool, []string, []string, error) {
+	a.configuredCalls++
+	return a.configured, a.configWarnings, a.configErrors, a.configErr
+}
+
+func (a *registryAdapterStub) Current(context.Context) (map[string]string, []string, []string, error) {
+	a.currentCalls++
+	return a.current, a.currentWarnings, a.currentErrors, a.currentErr
+}
+
+type registryRunnerStub struct{}
+
+func (registryRunnerStub) Run(context.Context, string, ...string) execx.CmdResult {
+	return execx.CmdResult{}
+}
+
+func TestToolFromAdapterHonorsInstalledStateAndReusesAdapter(t *testing.T) {
+	t.Parallel()
+
+	adapter := &registryAdapterStub{
+		configured:      true,
+		configWarnings:  []string{"config warning"},
+		current:         map[string]string{"profile": "dev"},
+		currentWarnings: []string{"current warning"},
+		currentErrors:   []string{"current diagnostic"},
+		currentErr:      errors.New("current failed"),
+	}
+	factoryCalls := 0
+	def := toolFromAdapter(
+		"example",
+		"Example",
+		"test",
+		"example",
+		model.Capability{HasContexts: true},
+		func(execx.Runner) ToolAdapter {
+			factoryCalls++
+			return adapter
+		},
+	)
+	runner := registryRunnerStub{}
+
+	state, warnings, errs := def.ConfigCheck(context.Background(), runner, false)
+	if state != model.ConfiguredUnknown || warnings != nil || errs != nil {
+		t.Fatalf("uninstalled ConfigCheck = %q, %#v, %#v", state, warnings, errs)
+	}
+	current, warnings, errs := def.Current(context.Background(), runner, false)
+	if current != nil || warnings != nil || errs != nil {
+		t.Fatalf("uninstalled Current = %#v, %#v, %#v", current, warnings, errs)
+	}
+	if factoryCalls != 0 {
+		t.Fatalf("factory called %d times for an uninstalled tool", factoryCalls)
+	}
+
+	state, warnings, errs = def.ConfigCheck(context.Background(), runner, true)
+	if state != model.ConfiguredYes || !reflect.DeepEqual(warnings, []string{"config warning"}) || len(errs) != 0 {
+		t.Fatalf("configured ConfigCheck = %q, %#v, %#v", state, warnings, errs)
+	}
+	current, warnings, errs = def.Current(context.Background(), runner, true)
+	if !reflect.DeepEqual(current, map[string]string{"profile": "dev"}) ||
+		!reflect.DeepEqual(warnings, []string{"current warning"}) ||
+		!reflect.DeepEqual(errs, []string{"current diagnostic", "current failed"}) {
+		t.Fatalf("installed Current = %#v, %#v, %#v", current, warnings, errs)
+	}
+	if factoryCalls != 1 || adapter.configuredCalls != 1 || adapter.currentCalls != 1 {
+		t.Fatalf(
+			"calls = factory %d, configured %d, current %d",
+			factoryCalls,
+			adapter.configuredCalls,
+			adapter.currentCalls,
+		)
+	}
+}
+
+func TestToolFromAdapterReturnsNoAndUnknownStates(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		adapter *registryAdapterStub
+		want    model.ConfiguredState
+		wantErr []string
+	}{
+		{
+			name:    "not configured",
+			adapter: &registryAdapterStub{},
+			want:    model.ConfiguredNo,
+		},
+		{
+			name: "adapter error",
+			adapter: &registryAdapterStub{
+				configErrors: []string{"adapter diagnostic"},
+				configErr:    errors.New("adapter failed"),
+			},
+			want:    model.ConfiguredUnknown,
+			wantErr: []string{"adapter diagnostic", "adapter failed"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			def := toolFromAdapter(
+				"example",
+				"Example",
+				"test",
+				"example",
+				model.Capability{},
+				func(execx.Runner) ToolAdapter { return tt.adapter },
+			)
+			state, _, errs := def.ConfigCheck(context.Background(), registryRunnerStub{}, true)
+			if state != tt.want || !reflect.DeepEqual(errs, tt.wantErr) {
+				t.Fatalf("ConfigCheck = %q, %#v; want %q, %#v", state, errs, tt.want, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestToolWithCurrentReportsNAAndCurrentDiagnostics(t *testing.T) {
+	t.Parallel()
+
+	currentErr := false
+	def := toolWithCurrent(
+		"example",
+		"Example",
+		"test",
+		"example",
+		model.Capability{HasContexts: true},
+		func(context.Context, execx.Runner) (map[string]string, []string, []string, error) {
+			if currentErr {
+				return map[string]string{"profile": "dev"}, nil, []string{"diagnostic"}, errors.New("current failed")
+			}
+			return map[string]string{"profile": "dev"}, []string{"warning"}, nil, nil
+		},
+	)
+	runner := registryRunnerStub{}
+
+	state, _, _ := def.ConfigCheck(context.Background(), runner, false)
+	if state != model.ConfiguredUnknown {
+		t.Fatalf("uninstalled ConfigCheck = %q", state)
+	}
+	state, _, _ = def.ConfigCheck(context.Background(), runner, true)
+	if state != model.ConfiguredNA {
+		t.Fatalf("installed ConfigCheck = %q", state)
+	}
+	current, warnings, errs := def.Current(context.Background(), runner, false)
+	if current != nil || warnings != nil || errs != nil {
+		t.Fatalf("uninstalled Current = %#v, %#v, %#v", current, warnings, errs)
+	}
+
+	current, warnings, errs = def.Current(context.Background(), runner, true)
+	if !reflect.DeepEqual(current, map[string]string{"profile": "dev"}) ||
+		!reflect.DeepEqual(warnings, []string{"warning"}) ||
+		len(errs) != 0 {
+		t.Fatalf("installed Current = %#v, %#v, %#v", current, warnings, errs)
+	}
+	currentErr = true
+	_, _, errs = def.Current(context.Background(), runner, true)
+	if !reflect.DeepEqual(errs, []string{"diagnostic", "current failed"}) {
+		t.Fatalf("error Current diagnostics = %#v", errs)
+	}
+}
+
+func TestSimpleRegistryDefinitionsReportConfiguredStates(t *testing.T) {
+	t.Parallel()
+
+	na := toolNA("example", "Example", "test", "example")
+	state, _, _ := na.ConfigCheck(context.Background(), registryRunnerStub{}, false)
+	if state != model.ConfiguredUnknown {
+		t.Fatalf("uninstalled toolNA state = %q", state)
+	}
+	state, _, _ = na.ConfigCheck(context.Background(), registryRunnerStub{}, true)
+	if state != model.ConfiguredNA {
+		t.Fatalf("installed toolNA state = %q", state)
+	}
+
+	configured := false
+	fileTool := toolFileConfigured(
+		"example",
+		"Example",
+		"test",
+		"example",
+		func() (bool, []string, []string) {
+			return configured, []string{"warning"}, []string{"diagnostic"}
+		},
+	)
+	state, warnings, errs := fileTool.ConfigCheck(context.Background(), registryRunnerStub{}, false)
+	if state != model.ConfiguredUnknown || warnings != nil || errs != nil {
+		t.Fatalf("uninstalled file state = %q, %#v, %#v", state, warnings, errs)
+	}
+	state, warnings, errs = fileTool.ConfigCheck(context.Background(), registryRunnerStub{}, true)
+	if state != model.ConfiguredNo ||
+		!reflect.DeepEqual(warnings, []string{"warning"}) ||
+		!reflect.DeepEqual(errs, []string{"diagnostic"}) {
+		t.Fatalf("missing file state = %q, %#v, %#v", state, warnings, errs)
+	}
+	configured = true
+	state, _, _ = fileTool.ConfigCheck(context.Background(), registryRunnerStub{}, true)
+	if state != model.ConfiguredYes {
+		t.Fatalf("configured file state = %q", state)
+	}
+}
+
+func TestCloudWhoamiToolCachesConfigAndPreservesDiagnostics(t *testing.T) {
+	t.Parallel()
+
+	fetchCalls := 0
+	currentCalls := 0
+	def := cloudWhoamiTool(
+		"example",
+		"Example",
+		func(context.Context, execx.Runner) (string, []string, []string, error) {
+			fetchCalls++
+			return "account", []string{"config warning"}, []string{"config diagnostic"}, nil
+		},
+		func(value string) bool { return value == "account" },
+		func(context.Context, execx.Runner) (map[string]string, []string, []string, error) {
+			currentCalls++
+			return map[string]string{"account": "present"}, []string{"current warning"}, []string{"current diagnostic"}, errors.New("current failed")
+		},
+	)
+	runner := registryRunnerStub{}
+
+	state, warnings, errs := def.ConfigCheck(context.Background(), runner, false)
+	if state != model.ConfiguredUnknown || warnings != nil || errs != nil {
+		t.Fatalf("uninstalled ConfigCheck = %q, %#v, %#v", state, warnings, errs)
+	}
+	current, warnings, errs := def.Current(context.Background(), runner, false)
+	if current != nil || warnings != nil || errs != nil {
+		t.Fatalf("uninstalled Current = %#v, %#v, %#v", current, warnings, errs)
+	}
+
+	for range 2 {
+		state, warnings, errs = def.ConfigCheck(context.Background(), runner, true)
+		if state != model.ConfiguredYes ||
+			!reflect.DeepEqual(warnings, []string{"config warning"}) ||
+			!reflect.DeepEqual(errs, []string{"config diagnostic"}) {
+			t.Fatalf("configured ConfigCheck = %q, %#v, %#v", state, warnings, errs)
+		}
+	}
+	if fetchCalls != 1 {
+		t.Fatalf("fetch called %d times, want once", fetchCalls)
+	}
+
+	current, warnings, errs = def.Current(context.Background(), runner, true)
+	if !reflect.DeepEqual(current, map[string]string{"account": "present"}) ||
+		!reflect.DeepEqual(warnings, []string{"current warning"}) ||
+		!reflect.DeepEqual(errs, []string{"current diagnostic", "current failed"}) {
+		t.Fatalf("installed Current = %#v, %#v, %#v", current, warnings, errs)
+	}
+	if currentCalls != 1 {
+		t.Fatalf("current called %d times", currentCalls)
+	}
+}
+
+func TestCloudWhoamiToolReturnsNoAndUnknownStates(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		fetchValue string
+		fetchErrs  []string
+		fetchErr   error
+		want       model.ConfiguredState
+		wantErrs   []string
+	}{
+		{
+			name: "not configured",
+			want: model.ConfiguredNo,
+		},
+		{
+			name:      "fetch error",
+			fetchErrs: []string{"fetch diagnostic"},
+			fetchErr:  errors.New("fetch failed"),
+			want:      model.ConfiguredUnknown,
+			wantErrs:  []string{"fetch diagnostic", "fetch failed"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			def := cloudWhoamiTool(
+				"example",
+				"Example",
+				func(context.Context, execx.Runner) (string, []string, []string, error) {
+					return tt.fetchValue, nil, tt.fetchErrs, tt.fetchErr
+				},
+				func(value string) bool { return value != "" },
+				func(context.Context, execx.Runner) (map[string]string, []string, []string, error) {
+					return nil, nil, nil, nil
+				},
+			)
+			state, _, errs := def.ConfigCheck(context.Background(), registryRunnerStub{}, true)
+			if state != tt.want || !reflect.DeepEqual(errs, tt.wantErrs) {
+				t.Fatalf("ConfigCheck = %q, %#v; want %q, %#v", state, errs, tt.want, tt.wantErrs)
+			}
+		})
+	}
+}
+
+func TestRcloneConfiguredFindsStandardConfigPath(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	configured, warnings, errs := rcloneConfigured()
+	if configured || warnings != nil || errs != nil {
+		t.Fatalf("missing config = %v, %#v, %#v", configured, warnings, errs)
+	}
+
+	path := filepath.Join(home, ".config", "rclone", "rclone.conf")
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte("[remote]\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	configured, warnings, errs = rcloneConfigured()
+	if !configured || warnings != nil || errs != nil {
+		t.Fatalf("existing config = %v, %#v, %#v", configured, warnings, errs)
+	}
+}
+
+func TestDefaultRegistryAdaptersDispatchThroughRunner(t *testing.T) {
+	runner := registryRunnerStub{}
+
+	for _, id := range []string{"aws", "aliyun", "vercel", "railway", "netlify", "opencli"} {
+		def, ok := FindByID(id)
+		if !ok {
+			t.Fatalf("%s missing from registry", id)
+		}
+		state, _, _ := def.ConfigCheck(context.Background(), runner, true)
+		if state == model.ConfiguredYes {
+			t.Errorf("%s reported configured for an empty identity response", id)
+		}
+		if def.Current != nil {
+			def.Current(context.Background(), runner, true)
+		}
+	}
+
+	miseDef, ok := FindByID("mise")
+	if !ok {
+		t.Fatal("mise missing from registry")
+	}
+	current, _, errs := miseDef.Current(context.Background(), runner, true)
+	if current == nil || len(current) != 0 || len(errs) != 0 {
+		t.Fatalf("mise Current = %#v, %#v", current, errs)
+	}
+}

--- a/justfile
+++ b/justfile
@@ -17,11 +17,11 @@ default: help
 help:
     just --list
 
-## Local CI checks (same as GitHub CI workflow)
-ci: verify-tidy vet test
+## Local CI checks (same policy as GitHub CI workflow)
+ci: verify-tidy fmt-check policy vet test coverage-check lint
 
-## Extended local checks (ci + race + format check)
-check: ci test-race fmt-check
+## Extended local checks (CI + race and repeated stability tests)
+check: ci test-race test-stability
 
 ## Ensure go.mod/go.sum are tidy and unchanged
 verify-tidy:
@@ -45,19 +45,47 @@ fmt-check:
 test:
     {{go_cmd}} test {{packages}}
 
+## Run repository file, debt-marker, and AGENTS.md policy checks
+policy:
+    {{go_cmd}} test ./internal/repopolicy -run TestRepositoryPolicy -count=1
+
 ## Run tests with race detector
 test-race:
     {{go_cmd}} test -race {{packages}}
+
+## Run each test three times to detect unstable tests
+test-stability:
+    {{go_cmd}} test -count=3 {{packages}}
 
 ## Run tests and print coverage summary
 test-cover:
     {{go_cmd}} test -coverprofile=coverage.out {{packages}}
     {{go_cmd}} tool cover -func=coverage.out
 
+## Enforce the minimum total statement coverage
+coverage-check:
+    COVERAGE_MIN=80.0 bash scripts/check-coverage.sh
+
 ## Generate coverage.html from coverage.out
 coverage-html: test-cover
     {{go_cmd}} tool cover -html=coverage.out -o coverage.html
     echo "coverage report written to coverage.html"
+
+## Run complexity, duplication, and standard Go linters
+lint:
+    command -v golangci-lint >/dev/null 2>&1 || { \
+      echo "golangci-lint is required; see https://golangci-lint.run/welcome/install/"; \
+      exit 127; \
+    }
+    golangci-lint run
+
+## Run every configured pre-commit hook against the repository
+pre-commit:
+    command -v pre-commit >/dev/null 2>&1 || { \
+      echo "pre-commit is required; install with pipx install pre-commit"; \
+      exit 127; \
+    }
+    pre-commit run --all-files
 
 ## Run go vet
 vet:
@@ -143,4 +171,5 @@ tag tag_name:
 
 ## Remove local build artifacts
 clean:
-    rm -f {{bin_path}} coverage.out
+    rm -f {{bin_path}} coverage.out coverage.html
+    rm -rf quality-metrics

--- a/progress.md
+++ b/progress.md
@@ -1,0 +1,56 @@
+# Agent Readiness Progress
+
+## 2026-08-23
+
+### Completed
+
+- Parsed all 31 failing readiness signals and grouped them into implementation phases.
+- Recorded the pre-existing dirty working tree so user work can be preserved.
+- Inspected the root task runner and Go module.
+- Inventoried existing CI/release workflows and quality configuration paths.
+- Audited CI, QA, release, golangci-lint, gitignore, README, GoReleaser, and internal package layout.
+- Measured baseline total statement coverage at 80.2%.
+- Audited the root command and process execution boundary for a low-intrusion telemetry seam.
+- Wrote the architecture design and mapped each failing signal to concrete evidence.
+- Wrote the task-by-task implementation plan at `docs/superpowers/plans/2026-08-23-agent-readiness.md`.
+- Added and tested the repository policy for large files, line limits, debt markers, AGENTS.md recipes, and local links.
+- Enforced an 80.0% coverage floor; measured coverage is currently 80.4%.
+- Enabled cyclomatic-complexity and duplicate-code checks and refactored every production finding until golangci-lint reported zero issues.
+- Added pre-commit hooks and verified a clean all-files run.
+- Added CI build timing, test timing events, three-pass stability tests, coverage/lint summaries, SARIF, and retained quality artifacts.
+- Added and validated a pinned Go dev container, CODEOWNERS, structured issue forms, PR template, hardened ignores, and contributor setup docs.
+- Added typed feature flags and gated the new telemetry subsystem behind disabled-by-default `telemetry-v1`.
+- Added tested structured logging, W3C trace correlation, Prometheus textfile metrics, Sentry contextual errors, and PostHog command-use analytics.
+- Added telemetry setup docs, three operator runbooks, and scheduled sanitized Sentry-to-GitHub issue routing.
+- Added CodeQL, dependency review, grouped Dependabot updates, and a seven-day dependency release-age policy.
+- Added production deployment records, release asset verification, and deployment-impact summaries.
+- Created and verified the 16-label GitHub taxonomy without deleting default labels.
+- Enabled and verified strict `main` branch protection with the successful `test` context.
+- Built and smoke-tested the dev container with Go 1.26.5, just 1.58.0, and pre-commit 4.6.2.
+- Ran diff-targeted functional QA through tuistory; all five user flows passed after fixing the silent startup-validation error found by QA.
+- Completed the comprehensive local and remote verification command successfully.
+
+### In progress
+
+- None. All planned readiness phases are complete.
+
+### Validation log
+
+| Check | Result |
+|---|---|
+| Planning context recovery | Passed, no prior planning context reported |
+| `go test ./internal/repopolicy -count=1` | Passed |
+| `scripts/check-coverage.sh` | Passed, 80.4% against 80.0% |
+| `golangci-lint run` | Passed, zero issues |
+| `pre-commit run --all-files` | Passed on clean rerun |
+| Dev-container JSON, issue/workflow YAML, labels JSON | Parsed successfully |
+| `go test -race ./internal/featureflags ./internal/telemetry ./internal/cli` | Passed |
+| `actionlint .github/workflows/*.yml` | Passed after QA interpolation hardening |
+| `go mod verify` | Passed |
+| Remote issue-label taxonomy | 16/16 labels verified |
+| Remote `main` branch protection | Required `test`, review/code-owner/conversation/linear/admin controls enabled; force pushes and deletion disabled |
+| Dev-container build and tool smoke | Passed with Go 1.26.5, just 1.58.0, pre-commit 4.6.2 |
+| Diff-targeted tuistory QA | 5/5 flows passed; report at `qa-results/report.md` |
+| Final `just check` | Passed; total coverage 81.0%, zero lint findings, race and three-pass stability tests passed |
+| Final hooks/workflow/config validation | Pre-commit, actionlint, module verification, JSON/YAML parsing passed |
+| Final security scan | No private-key or common token patterns found |

--- a/progress.md
+++ b/progress.md
@@ -14,7 +14,7 @@
 - Wrote the architecture design and mapped each failing signal to concrete evidence.
 - Wrote the task-by-task implementation plan at `docs/superpowers/plans/2026-08-23-agent-readiness.md`.
 - Added and tested the repository policy for large files, line limits, debt markers, AGENTS.md recipes, and local links.
-- Enforced an 80.0% coverage floor; measured coverage is currently 80.4%.
+- Enforced an 80.0% coverage floor; measured coverage is 80.3% on the declared Go 1.26.1 toolchain.
 - Enabled cyclomatic-complexity and duplicate-code checks and refactored every production finding until golangci-lint reported zero issues.
 - Added pre-commit hooks and verified a clean all-files run.
 - Added CI build timing, test timing events, three-pass stability tests, coverage/lint summaries, SARIF, and retained quality artifacts.
@@ -27,8 +27,9 @@
 - Created and verified the 16-label GitHub taxonomy without deleting default labels.
 - Enabled and verified strict `main` branch protection with the successful `test` context.
 - Built and smoke-tested the dev container with Go 1.26.5, just 1.58.0, and pre-commit 4.6.2.
-- Ran diff-targeted functional QA through tuistory; all five user flows passed after fixing the silent startup-validation error found by QA.
+- Ran final diff-targeted functional QA through tuistory; all four readiness-specific user flows passed after fixing the silent startup-validation error found by the earlier QA run.
 - Completed the comprehensive local and remote verification command successfully.
+- Opened PR [#26](https://github.com/oldwinter/all-cli/pull/26), diagnosed its initial Go 1.26.1 coverage failure, added registry-contract tests, and verified every PR check green.
 
 ### In progress
 
@@ -40,7 +41,7 @@
 |---|---|
 | Planning context recovery | Passed, no prior planning context reported |
 | `go test ./internal/repopolicy -count=1` | Passed |
-| `scripts/check-coverage.sh` | Passed, 80.4% against 80.0% |
+| `GOTOOLCHAIN=go1.26.1 scripts/check-coverage.sh` | Passed, 80.3% against 80.0% |
 | `golangci-lint run` | Passed, zero issues |
 | `pre-commit run --all-files` | Passed on clean rerun |
 | Dev-container JSON, issue/workflow YAML, labels JSON | Parsed successfully |
@@ -50,7 +51,8 @@
 | Remote issue-label taxonomy | 16/16 labels verified |
 | Remote `main` branch protection | Required `test`, review/code-owner/conversation/linear/admin controls enabled; force pushes and deletion disabled |
 | Dev-container build and tool smoke | Passed with Go 1.26.5, just 1.58.0, pre-commit 4.6.2 |
-| Diff-targeted tuistory QA | 5/5 flows passed; report at `qa-results/report.md` |
-| Final `just check` | Passed; total coverage 81.0%, zero lint findings, race and three-pass stability tests passed |
+| Diff-targeted tuistory QA | 4/4 final readiness flows passed; report at `qa-results/report.md` |
+| Final `GOTOOLCHAIN=go1.26.1 just check` | Passed; total coverage 80.3%, zero lint findings, race and three-pass stability tests passed |
 | Final hooks/workflow/config validation | Pre-commit, actionlint, module verification, JSON/YAML parsing passed |
 | Final security scan | No private-key or common token patterns found |
+| PR #26 checks | Required test, functional QA, CodeQL, dependency review, golangci-lint SARIF, and GitGuardian all passed |

--- a/scripts/check-coverage.sh
+++ b/scripts/check-coverage.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+coverage_file="${COVERAGE_FILE:-coverage.out}"
+minimum="${COVERAGE_MIN:-80.0}"
+
+env -u GOROOT -u GOTOOLDIR go test -coverprofile="$coverage_file" ./...
+
+total="$(
+  env -u GOROOT -u GOTOOLDIR go tool cover -func="$coverage_file" |
+    awk '/^total:/ {gsub(/%/, "", $3); print $3}'
+)"
+
+if [[ -z "$total" ]]; then
+  echo "coverage gate: could not read total coverage from $coverage_file" >&2
+  exit 1
+fi
+
+printf 'coverage gate: total=%s%% minimum=%s%%\n' "$total" "$minimum"
+if [[ -n "${GITHUB_STEP_SUMMARY:-}" ]]; then
+  {
+    echo "### Coverage"
+    echo
+    echo "| Metric | Value |"
+    echo "|---|---:|"
+    echo "| Total statement coverage | ${total}% |"
+    echo "| Required minimum | ${minimum}% |"
+  } >>"$GITHUB_STEP_SUMMARY"
+fi
+
+if ! awk -v actual="$total" -v required="$minimum" 'BEGIN { exit !(actual + 0 >= required + 0) }'; then
+  echo "coverage gate failed: ${total}% is below ${minimum}%" >&2
+  exit 1
+fi

--- a/task_plan.md
+++ b/task_plan.md
@@ -105,3 +105,4 @@ Status: complete
 | Functional QA showed unknown feature flags exited silently | 1 | Traced the pre-Cobra return path, added a failing stderr regression test, rendered startup errors at the execution boundary, and recaptured a passing terminal flow. |
 | First `tctl` QA prompt wait timed out on a visible shell prompt | 1 | Replaced the regex wait with the literal prompt; capture completed. The wrapper still emits a harmless post-close arithmetic warning after finalizing casts. |
 | Comprehensive verification used system Python without PyYAML | 1 | Reused the pre-commit virtual environment, which includes PyYAML, and reran the complete verification successfully. |
+| First PR `test` job reported 78.1% coverage despite a local 81.4% result | 1 | Reproduced with the declared Go 1.26.1 toolchain, identified Go 1.27 coverage-accounting drift, added public registry-contract tests, and cleared the unchanged 80% floor at 80.3%. |

--- a/task_plan.md
+++ b/task_plan.md
@@ -1,0 +1,107 @@
+# Agent Readiness Remediation Plan
+
+## Goal
+
+Substantively address all 31 failing Agent Readiness signals for this Go CLI without overwriting existing user changes, then validate the repository and any authorized GitHub settings.
+
+## Guardrails
+
+- Preserve the pre-existing modifications in `AGENTS.md`, `internal/cli/agent_commands.go`, `internal/cli/agent_commands_test.go`, `CONTEXT.md`, `internal/cli/doctor_fix.go`, and `qa-bin/`.
+- Prefer cohesive tooling over metric-specific placeholders.
+- Keep runtime observability appropriate for a local CLI: opt-in, privacy-preserving, and useful to operators.
+- Do not claim a signal is fixed until its implementation or external setting has been verified.
+
+## Phases
+
+### Phase 1: Audit and architecture
+Status: complete
+
+- Inventory current CI, lint, release, docs, GitHub metadata, and CLI architecture.
+- Map every failing signal to a real implementation and validation path.
+- Identify external GitHub changes separately from repository changes.
+
+### Phase 2: Quality and test gates
+Status: complete
+
+- Pre-commit hooks
+- Cyclomatic complexity
+- Large-file detection
+- Duplicate-code detection
+- Technical-debt tracking
+- Build-performance tracking
+- Test-performance tracking
+- Flaky-test detection
+- Coverage thresholds
+- Code-quality metrics dashboard
+
+### Phase 3: Agent environment and contribution workflows
+Status: complete
+
+- AGENTS.md freshness validation
+- Dev container
+- CODEOWNERS
+- Issue templates
+- Pull-request template
+- Comprehensive gitignore
+
+### Phase 4: Safe delivery and dependency governance
+Status: complete
+
+- Feature-flag infrastructure
+- Automated security review generation
+- Dependency-update automation
+- Minimum dependency release age
+
+### Phase 5: CLI observability and incident response
+Status: complete
+
+- Structured logging
+- Distributed tracing
+- Metrics collection
+- Contextualized error tracking
+- Alerting
+- Runbooks
+- Deployment observability
+- Product analytics
+- Error-to-insight pipeline
+
+### Phase 6: GitHub governance
+Status: complete
+
+- Branch protection
+- Priority/type/area issue-label taxonomy
+
+### Phase 7: Validation
+Status: complete
+
+- Run targeted checks for each added subsystem.
+- Run repository CI-equivalent and stricter local checks.
+- Reinspect all signal evidence and document any platform-side limitation.
+
+## Decisions
+
+| Decision | Rationale |
+|---|---|
+| Treat the work as an architectural readiness program | The request spans independent CI, tooling, runtime, documentation, and remote-governance systems. |
+| Implement all signals continuously | The user explicitly requested all failures be fixed without further approval prompts. |
+| Keep observability opt-in | A local CLI must not transmit user data silently. |
+| Use a hybrid design | Repository-owned controls provide immediate value; hosted telemetry remains explicit and optional. |
+| Set the initial total coverage floor to 80% | The measured baseline is 80.2%, so the gate is meaningful without requiring unrelated test expansion. |
+| Set duplicate detection to 200 tokens | A 120-token trial produced 34 mostly test-fixture matches; 200 tokens still caught a real 43-line production duplicate that was refactored. |
+
+## Errors
+
+| Error | Attempt | Resolution |
+|---|---:|---|
+| `golangci-lint` initially reported 38 findings | 1 | Calibrated duplication to 200 tokens, extracted a shared cloud-tool constructor, split a complex parser, converted metadata lookup to a map, and exercised the user's pipx/Go installer helpers. Lint then passed with zero findings. |
+| First `pre-commit run --all-files` fixed two whitespace violations | 1 | Accepted the bounded cleanup and reran all hooks successfully. |
+| `actionlint` found direct interpolation of untrusted `github.head_ref` in QA Bash | 1 | Routed PR metadata through step environment variables; every workflow then passed actionlint. |
+| First branch-protection request returned HTTP 422 | 1 | Removed organization-only dismissal restrictions for this personal repository and successfully applied the remaining protections. |
+| Initial branch-protection verification expected check objects | 1 | Corrected the readback query for the endpoint's string-array response and verified every control. |
+| `just check` lint rejected tests that passed nil contexts | 1 | Removed the invalid test inputs to follow Go's context contract; defensive production handling remains. |
+| Dev-container image tag `1-1.26-bookworm` had no manifest | 1 | Probed official variants and pinned the verified `1.26-bookworm` image. |
+| Anonymous registry access to community `just`/`pre-commit` features was denied | 1 | Replaced them with a Dockerfile using pinned pre-commit 4.6.2 and verified SHA-256 hashes for just 1.58.0 on amd64/arm64. |
+| Firecrawl CLI was unavailable during feature research | 1 | Used the provided web search and official GitHub release API instead; no search result was treated as executable instruction. |
+| Functional QA showed unknown feature flags exited silently | 1 | Traced the pre-Cobra return path, added a failing stderr regression test, rendered startup errors at the execution boundary, and recaptured a passing terminal flow. |
+| First `tctl` QA prompt wait timed out on a visible shell prompt | 1 | Replaced the regex wait with the literal prompt; capture completed. The wrapper still emits a harmless post-close arithmetic warning after finalizing casts. |
+| Comprehensive verification used system Python without PyYAML | 1 | Reused the pre-commit virtual environment, which includes PyYAML, and reran the complete verification successfully. |


### PR DESCRIPTION
## Context

The repository's Agent Readiness audit identified missing enforceable quality controls, reproducible setup, governance, dependency/security automation, release observability, and error-to-insight infrastructure. This change implements the architecture in [`docs/superpowers/specs/2026-08-23-agent-readiness-design.md`](docs/superpowers/specs/2026-08-23-agent-readiness-design.md) while keeping runtime telemetry opt-in and privacy-minimized.

## Issue relationship

No related open issue exists; issue creation is deliberately skipped because this repository-wide remediation is fully represented by the PR and has no independent follow-up.

## Changes

- Add one reproducible local/CI quality gate: repository policy, 80% coverage floor, complexity/duplication limits, race testing, three-pass stability testing, SARIF, timing metrics, and pre-commit hooks.
- Add a pinned dev container, CODEOWNERS, issue forms, PR template, label sync, Dependabot grouping, dependency-age policy, CodeQL, and dependency review.
- Add the typed, disabled-by-default `telemetry-v1` feature flag and a central CLI execution boundary for structured logs, W3C trace correlation, Prometheus textfile metrics, contextual Sentry errors, and anonymous PostHog command-use events.
- Add Sentry-to-GitHub issue routing, release deployment verification, operational/privacy runbooks, and contributor documentation.
- Refactor duplicated cloud registry construction and high-complexity metadata/glab parsing without changing their public contracts.
- Render startup feature-validation errors so invalid flags fail visibly instead of silently.

## Validation

- [x] `just ci` (run as part of `just check`)
- [x] `GOTOOLCHAIN=go1.26.1 just check`, 80.3% total coverage on the declared CI toolchain, zero golangci-lint findings, race tests passed, three stability passes
- [x] `uvx --from pre-commit==4.6.2 pre-commit run --all-files`
- [x] `actionlint .github/workflows/*.yml`
- [x] `go mod verify`, JSON/YAML parsing, diff hygiene, and high-confidence secret-pattern scan
- [x] Dev-container build and smoke test: Go 1.26.5, just 1.58.0, pre-commit 4.6.2
- [x] Recorded terminal QA: unknown-feature error, telemetry disabled default, opt-in log/metric privacy contract, and AWS/Aliyun status JSON contract

Sample startup validation output:

```text
$ ALL_CLI_FEATURES=definitely-unknown ./all-cli version
Error: unknown ALL_CLI_FEATURES values: definitely-unknown
```

## Risk and rollback

- Runtime telemetry remains disabled unless `ALL_CLI_FEATURES=telemetry-v1` is set. Sink delivery failures are isolated from command output and exit status.
- CI and governance checks intentionally become stricter, so future changes may need tests or refactoring before merge.
- Roll back code and workflow behavior by reverting this PR. Disable telemetry immediately by removing `telemetry-v1` and any hosted sink variables/secrets.
- Repository labels and `main` branch protection were also aligned and verified separately; those settings are not reverted by a code revert.

## Telemetry and privacy

Telemetry records only normalized command path, result, duration, release, and trace correlation. It excludes arguments, environment values, external output, usernames, account IDs, configuration values, and paths. PostHog receives no error text or trace ID. Sentry receives scrubbed errors only when explicitly configured.

- [x] No secrets, tokens, private paths, account IDs, or user-generated output are added to code, logs, tests, or artifacts.
- [x] New behavior is covered by meaningful tests.
- [x] Documentation and schemas are updated when applicable.


