### PR TITLE
feat(cli): add missing-only status filter

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,7 @@ all-cli status
 all-cli status --json
 all-cli status --tools kubectl,docker
 all-cli status --categories ai,cloud
+all-cli status --categories ai --missing-only
 all-cli status --group-by none
 all-cli status --sort tool-desc
 all-cli status --sort category-desc
@@ -144,6 +145,10 @@ Use `--categories` to check one or more registry categories at once. When combin
 `--tools`, both filters apply, so the result contains only tools matching both selections.
 With shell completion loaded, comma-separated category values complete in place: for
 example, `--categories cloud,k<TAB>` keeps `cloud` and offers `k8s`.
+
+Use `--missing-only` to turn the inventory into a focused installation checklist. It can
+be combined with `--categories` or `--tools`, and is mutually exclusive with
+`--installed-only`.
 
 ### Current contexts at a glance
 

--- a/internal/cli/status.go
+++ b/internal/cli/status.go
@@ -40,6 +40,7 @@ func newStatusCommand(opts *rootOptions, runner execx.Runner) *cobra.Command {
 	var sortBy string
 	var quiet bool
 	var installedOnly bool
+	var missingOnly bool
 
 	cmd := &cobra.Command{
 		Use:   "status",
@@ -51,6 +52,7 @@ When not using --json, a progress indicator may be shown on stderr while tools a
 		Example: `  all-cli status
   all-cli status --tools kubectl,docker --group-by none
   all-cli status --categories ai,cloud
+  all-cli status --categories ai --missing-only
   all-cli status --installed-only --quiet`,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			groupByValue, err := parseStatusGroupBy(groupBy)
@@ -84,26 +86,7 @@ When not using --json, a progress indicator may be shown on stderr while tools a
 			}
 
 			sortToolSummaries(report.Tools, sortByValue)
-
-			if installedOnly {
-				filtered := report.Tools[:0]
-				for _, t := range report.Tools {
-					if t.Installed {
-						filtered = append(filtered, t)
-					}
-				}
-				report.Tools = filtered
-			}
-			if quiet {
-				filtered := report.Tools[:0]
-				for _, t := range report.Tools {
-					if !t.Installed || t.ConfiguredState == model.ConfiguredNo ||
-						len(t.Warnings) > 0 || len(t.Errors) > 0 {
-						filtered = append(filtered, t)
-					}
-				}
-				report.Tools = filtered
-			}
+			report.Tools = filterStatusTools(report.Tools, installedOnly, missingOnly, quiet)
 
 			if opts.JSON {
 				report.Diagnostics = diag.Generate(report, diag.Options{Profile: diag.ProfileAgent}).Diagnostics
@@ -123,7 +106,27 @@ When not using --json, a progress indicator may be shown on stderr while tools a
 	cmd.Flags().StringVar(&sortBy, "sort", statusSortTool, "Sort order: tool|tool-desc|category|category-desc")
 	cmd.Flags().BoolVar(&quiet, "quiet", false, "Only show tools with issues (not installed, unconfigured, warnings, or errors)")
 	cmd.Flags().BoolVar(&installedOnly, "installed-only", false, "Only show installed tools")
+	cmd.Flags().BoolVar(&missingOnly, "missing-only", false, "Only show tools that are not installed")
+	cmd.MarkFlagsMutuallyExclusive("installed-only", "missing-only")
 	return cmd
+}
+
+func filterStatusTools(toolsList []model.ToolSummary, installedOnly, missingOnly, quiet bool) []model.ToolSummary {
+	filtered := toolsList[:0]
+	for _, tool := range toolsList {
+		if installedOnly && !tool.Installed {
+			continue
+		}
+		if missingOnly && tool.Installed {
+			continue
+		}
+		if quiet && tool.Installed && tool.ConfiguredState != model.ConfiguredNo &&
+			len(tool.Warnings) == 0 && len(tool.Errors) == 0 {
+			continue
+		}
+		filtered = append(filtered, tool)
+	}
+	return filtered
 }
 
 func buildStatusReport(ctx context.Context, runner execx.Runner, defaultTimeout time.Duration, toolsFilter string) (model.StatusReport, error) {

--- a/internal/cli/status_command_test.go
+++ b/internal/cli/status_command_test.go
@@ -56,6 +56,50 @@ func TestStatusCommandJSONInstalledOnlyAndQuiet(t *testing.T) {
 	}
 }
 
+func TestStatusCommandJSONMissingOnly(t *testing.T) {
+	stubStatusRegistry(t, []tools.ToolDefinition{
+		{ID: "aws", DisplayName: "AWS CLI", Category: "cloud", Binary: "aws"},
+		{ID: "kubectl", DisplayName: "kubectl", Category: "k8s", Binary: "kubectl"},
+		{ID: "gh", DisplayName: "gh", Category: "code", Binary: "gh"},
+	})
+	oldEvaluate := evaluateToolSummary
+	evaluateToolSummary = func(_ context.Context, def tools.ToolDefinition, _ execx.Runner) model.ToolSummary {
+		return model.ToolSummary{
+			ID:              def.ID,
+			Category:        def.Category,
+			Installed:       def.ID != "gh",
+			ConfiguredState: model.ConfiguredYes,
+		}
+	}
+	t.Cleanup(func() { evaluateToolSummary = oldEvaluate })
+	stubShowStatusSpinner(t, false)
+
+	opts := &rootOptions{JSON: true, Timeout: time.Second}
+	stdout, stderr, err := executeTestCommand(t, newStatusCommand(opts, cliFakeRunner{}), "--missing-only")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if stderr != "" {
+		t.Fatalf("expected empty stderr, got %q", stderr)
+	}
+
+	var got model.StatusReport
+	if err := json.Unmarshal([]byte(stdout), &got); err != nil {
+		t.Fatalf("decode json: %v", err)
+	}
+	if len(got.Tools) != 1 || got.Tools[0].ID != "gh" {
+		t.Fatalf("unexpected tools payload: %#v", got.Tools)
+	}
+}
+
+func TestStatusCommandRejectsConflictingInstallationFilters(t *testing.T) {
+	opts := &rootOptions{Timeout: time.Second}
+	_, _, err := executeTestCommand(t, newStatusCommand(opts, cliFakeRunner{}), "--installed-only", "--missing-only")
+	if err == nil || !strings.Contains(err.Error(), "if any flags in the group") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
 func TestStatusCommandPlainToolsFilterAndSpinner(t *testing.T) {
 	stubStatusRegistry(t, []tools.ToolDefinition{
 		{ID: "aws", DisplayName: "AWS CLI", Category: "cloud", Binary: "aws"},


### PR DESCRIPTION
This builds a new `all-cli status --missing-only` view that turns the tracked inventory into a focused installation checklist. It feels worth merging because users can now combine it with `--categories` or `--tools` to answer questions such as "which AI CLIs am I still missing?" without mixing in installed tools that merely need configuration or attention.

## Context

`--quiet` includes every tool needing attention, while `--installed-only` keeps installed tools. There was no direct way to request the complementary set of tools whose binaries are absent from `PATH`. No open issue currently tracks this small improvement.

## Changes

- Add `status --missing-only` for both text and JSON output.
- Reject `--missing-only` together with `--installed-only` before evaluation.
- Preserve combinations with `--tools`, `--categories`, `--quiet`, grouping, and sorting.
- Document a category-scoped installation checklist example.

## Validation

- [x] `just check` at `661c7aa236d056c06c72e54f6429912c0a46ce02` (tidy, format, policy, vet, tests, 83.2% coverage, lint, race, and three-pass stability)
- [x] `just build-release`
- [x] Restricted-`PATH` JSON assertion confirmed exactly `aws` and `gh` were returned as missing with matching diagnostics.
- [x] Restricted-`PATH` text QA confirmed missing rows, an empty `--installed-only` view, and exit 1 for conflicting filters.

Sample output:

```text
TOOL  CATEGORY  INSTALLED  CONFIGURED  CURRENT
aws   cloud     no         unknown
gh    code      no         unknown
```

## Impact

The change is additive and limited to the `status` command, its tests, and README usage. It adds no dependencies, external requests, schema changes, configuration, CI, infrastructure, permissions, or machine-state mutation. Status evaluation still completes before the display/report filter is applied, matching the existing `--installed-only` and `--quiet` behavior.

## Risk and rollback

Risk is low: existing invocations are unchanged, and conflicting installation filters fail explicitly. Roll back by reverting commit `661c7aa236d056c06c72e54f6429912c0a46ce02`.

## Telemetry and privacy

Telemetry behavior and data collection are unchanged.

- [x] No secrets, tokens, private paths, account IDs, or user-generated output are added to code, logs, tests, or artifacts.
- [x] New behavior is covered by meaningful tests.
- [x] Documentation is updated; schemas are not affected.
