### PR TITLE
feat(cli): add diff exit-code mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,6 +200,13 @@ all-cli snapshot --json > after.json
 all-cli diff before.json after.json --json
 ```
 
+Add `--exit-code` when a script or CI job should return status 1 if any tool was
+added, removed, or changed. The complete text or JSON report is still printed:
+
+```bash
+all-cli diff before.json after.json --json --exit-code
+```
+
 Use `-` for either diff input to compare a saved snapshot with a live pipeline
 without creating another file. Standard input snapshots are limited to 1 MiB:
 

--- a/internal/cli/agent_commands.go
+++ b/internal/cli/agent_commands.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -16,6 +17,8 @@ import (
 )
 
 const maxStdinSnapshotBytes int64 = 1 << 20
+
+var errSnapshotDifferences = errors.New("snapshot differences found")
 
 func newDiagnoseCommand(opts *rootOptions, runner execx.Runner) *cobra.Command {
 	var toolsFilter string
@@ -126,13 +129,17 @@ func newSnapshotCommand(opts *rootOptions, runner execx.Runner) *cobra.Command {
 }
 
 func newDiffCommand(opts *rootOptions) *cobra.Command {
-	return &cobra.Command{
+	var exitCode bool
+
+	cmd := &cobra.Command{
 		Use:   "diff <snapshot-a> <snapshot-b>",
 		Short: "Diff two status snapshots",
 		Long: `Diffs two status snapshots. Use - for either snapshot to read it from
 standard input, which makes it possible to compare a saved snapshot with a live pipeline.
-Standard input snapshots are limited to 1 MiB.`,
+Standard input snapshots are limited to 1 MiB. Add --exit-code to return status 1 when
+the snapshots differ while still printing the complete report.`,
 		Example: `  all-cli diff before.json after.json
+  all-cli diff before.json after.json --exit-code
   all-cli snapshot --json | all-cli diff before.json - --json`,
 		Args: cobra.ExactArgs(2),
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -149,12 +156,22 @@ Standard input snapshots are limited to 1 MiB.`,
 			}
 			report := diag.DiffSnapshots(before, after)
 			if opts.JSON {
-				return output.PrintJSON(cmd.OutOrStdout(), report)
+				if err := output.PrintJSON(cmd.OutOrStdout(), report); err != nil {
+					return err
+				}
+			} else {
+				printSnapshotDiff(cmd.OutOrStdout(), report)
 			}
-			printSnapshotDiff(cmd.OutOrStdout(), report)
+			if exitCode && len(report.Changes) > 0 {
+				cmd.Root().SilenceErrors = true
+				return errSnapshotDifferences
+			}
 			return nil
 		},
 	}
+
+	cmd.Flags().BoolVar(&exitCode, "exit-code", false, "Return status 1 when snapshots differ")
+	return cmd
 }
 
 func buildDiagnosticReport(cmd *cobra.Command, opts *rootOptions, runner execx.Runner, toolsFilter, profile string) (model.DiagnosticReport, error) {

--- a/internal/cli/agent_commands_test.go
+++ b/internal/cli/agent_commands_test.go
@@ -189,6 +189,59 @@ func TestDiffCommandJSONReportsChangedTools(t *testing.T) {
 	}
 }
 
+func TestDiffCommandExitCodeFailsSilentlyWhenSnapshotsDiffer(t *testing.T) {
+	dir := t.TempDir()
+	before := model.NewStatusReport(0)
+	after := model.NewStatusReport(1)
+	after.Tools[0] = model.ToolSummary{ID: "aws", DisplayName: "AWS CLI", Category: "cloud", Installed: true}
+
+	beforePath := writeStatusReportFixture(t, dir, "before.json", before)
+	afterPath := writeStatusReportFixture(t, dir, "after.json", after)
+
+	var stdout strings.Builder
+	var stderr strings.Builder
+	err := Execute(
+		context.Background(),
+		[]string{"diff", beforePath, afterPath, "--json", "--exit-code"},
+		&stdout,
+		&stderr,
+		func(string) string { return "" },
+	)
+	if err != errSnapshotDifferences {
+		t.Fatalf("diff --exit-code error = %v, want snapshot differences found", err)
+	}
+	if stderr.String() != "" {
+		t.Fatalf("stderr = %q, want empty", stderr.String())
+	}
+
+	var got model.SnapshotDiffReport
+	if err := json.Unmarshal([]byte(stdout.String()), &got); err != nil {
+		t.Fatalf("decode diff: %v", err)
+	}
+	if got.Summary.Added != 1 || len(got.Changes) != 1 {
+		t.Fatalf("unexpected diff report: %#v", got)
+	}
+}
+
+func TestDiffCommandExitCodeSucceedsWhenSnapshotsMatch(t *testing.T) {
+	report := model.NewStatusReport(0)
+	path := writeStatusReportFixture(t, t.TempDir(), "snapshot.json", report)
+
+	opts := &rootOptions{JSON: true, Timeout: time.Second}
+	stdout, _, err := executeTestCommand(t, newDiffCommand(opts), path, path, "--exit-code")
+	if err != nil {
+		t.Fatalf("diff --exit-code: %v", err)
+	}
+
+	var got model.SnapshotDiffReport
+	if err := json.Unmarshal([]byte(stdout), &got); err != nil {
+		t.Fatalf("decode diff: %v", err)
+	}
+	if len(got.Changes) != 0 {
+		t.Fatalf("unexpected diff report: %#v", got)
+	}
+}
+
 func TestDiffCommandReadsSnapshotFromStdin(t *testing.T) {
 	before := model.NewStatusReport(1)
 	before.Tools[0] = model.ToolSummary{ID: "aws", DisplayName: "AWS CLI", Category: "cloud", Installed: false, ConfiguredState: model.ConfiguredUnknown}


### PR DESCRIPTION
Built an opt-in `all-cli diff --exit-code` mode that keeps printing the complete text or JSON diff, but returns status 1 when any tool was added, removed, or changed. This is worth merging because it turns the existing snapshot diff into a drop-in drift gate for scripts and CI without changing default behavior or the stable JSON schema.

## Validation

- `just check` at `75173688a1edc4f2f9a857c50c918da0f86c9945` (tests, vet, 83.3% coverage, golangci-lint, race tests, and three-pass stability tests)
- `just build-release`
- Focused diff command tests, including opt-in changed/unchanged behavior and legacy behavior
- Real release-style binary QA: changed snapshots returned 1 with valid JSON and empty stderr; matching snapshots returned 0; changed snapshots without the flag remained 0
- `git diff --check`

## Impact

- Adds one optional `diff` flag and documents it in the README
- Preserves the existing default exit status, text output, JSON output, and schema
- No dependency, configuration, CI, infrastructure, permission, secret, telemetry, external-command, or machine-state changes

## Rollback

Revert commit `75173688a1edc4f2f9a857c50c918da0f86c9945`; no data migration or cleanup is required.

## Issues

No matching open issue was found, so no issue was linked or created for this small self-contained feature.
