### PR TITLE
feat(cli): filter catalog by categories

### DIFF
--- a/README.md
+++ b/README.md
@@ -264,11 +264,14 @@ Example shape:
 
 Use `all-cli catalog` to browse every tracked tool without running any external
 commands. Add an optional search term to match tool IDs, names, categories,
-binary names, and purposes:
+binary names, and purposes. Use `--categories` to browse one or more exact
+registry categories; category filters and search terms can be combined:
 
 ```bash
 all-cli catalog
 all-cli catalog kubernetes
+all-cli catalog --categories ai,cloud
+all-cli catalog kubernetes --categories k8s,cloud
 all-cli catalog cloud --json
 ```
 

--- a/internal/cli/catalog.go
+++ b/internal/cli/catalog.go
@@ -26,13 +26,17 @@ type catalogReport struct {
 }
 
 func newCatalogCommand(opts *rootOptions) *cobra.Command {
+	var categoriesFilter string
+
 	cmd := &cobra.Command{
 		Use:   "catalog [search]",
 		Short: "Browse and search tracked CLI tools",
 		Long: `Lists the built-in tool catalog without running external commands. An optional
-search term matches tool IDs, names, categories, binary names, and purposes.`,
+search term matches tool IDs, names, categories, binary names, and purposes.
+Use --categories to limit results to one or more exact registry categories.`,
 		Example: `  all-cli catalog
   all-cli catalog kubernetes
+  all-cli catalog --categories ai,cloud
   all-cli catalog cloud --json`,
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -40,7 +44,11 @@ search term matches tool IDs, names, categories, binary names, and purposes.`,
 			if len(args) == 1 {
 				query = args[0]
 			}
-			report := buildCatalogReport(query)
+			registry, err := registryForCategoriesFilter(defaultRegistry(), categoriesFilter)
+			if err != nil {
+				return err
+			}
+			report := buildCatalogReport(query, registry)
 			if opts.JSON {
 				return output.PrintJSON(cmd.OutOrStdout(), report)
 			}
@@ -60,12 +68,12 @@ search term matches tool IDs, names, categories, binary names, and purposes.`,
 			return nil, cobra.ShellCompDirectiveNoFileComp
 		},
 	}
+	cmd.Flags().StringVar(&categoriesFilter, "categories", "", "Comma-separated categories to browse (e.g. ai,cloud)")
 	return cmd
 }
 
-func buildCatalogReport(query string) catalogReport {
+func buildCatalogReport(query string, registry []tools.ToolDefinition) catalogReport {
 	normalizedQuery := strings.ToLower(strings.TrimSpace(query))
-	registry := tools.DefaultRegistry()
 	entries := make([]catalogTool, 0, len(registry))
 	for _, def := range registry {
 		metadata := tools.MetadataForTool(def.ID)

--- a/internal/cli/catalog_test.go
+++ b/internal/cli/catalog_test.go
@@ -4,6 +4,8 @@ import (
 	"encoding/json"
 	"strings"
 	"testing"
+
+	"github.com/oldwinter/all-cli/internal/tools"
 )
 
 func TestCatalogCommandListsTrackedTools(t *testing.T) {
@@ -89,6 +91,84 @@ func TestCatalogCommandExplainsNoMatches(t *testing.T) {
 	}
 	if got, want := stdout, "No tracked tools match \"not-a-real-tool\".\n"; got != want {
 		t.Fatalf("stdout = %q, want %q", got, want)
+	}
+}
+
+func TestCatalogCommandFiltersByCategories(t *testing.T) {
+	stubStatusRegistry(t, []tools.ToolDefinition{
+		{ID: "aws", DisplayName: "AWS CLI", Category: "cloud", Binary: "aws"},
+		{ID: "gh", DisplayName: "gh", Category: "code", Binary: "gh"},
+		{ID: "kubectl", DisplayName: "kubectl", Category: "k8s", Binary: "kubectl"},
+	})
+
+	opts := &rootOptions{JSON: true}
+	stdout, stderr, err := executeTestCommand(t, newCatalogCommand(opts), "--categories", "cloud,k8s")
+	if err != nil {
+		t.Fatalf("catalog --categories cloud,k8s --json: %v", err)
+	}
+	if stderr != "" {
+		t.Fatalf("stderr = %q, want empty", stderr)
+	}
+
+	var got catalogReport
+	if err := json.Unmarshal([]byte(stdout), &got); err != nil {
+		t.Fatalf("decode catalog json: %v", err)
+	}
+	if got.Count != 2 || len(got.Tools) != 2 || got.Tools[0].ID != "aws" || got.Tools[1].ID != "kubectl" {
+		t.Fatalf("unexpected category-filtered catalog: %#v", got)
+	}
+}
+
+func TestCatalogCommandCombinesSearchAndCategories(t *testing.T) {
+	stubStatusRegistry(t, []tools.ToolDefinition{
+		{ID: "aws", DisplayName: "AWS CLI", Category: "cloud", Binary: "aws"},
+		{ID: "kubectl", DisplayName: "kubectl", Category: "k8s", Binary: "kubectl"},
+	})
+
+	opts := &rootOptions{JSON: true}
+	stdout, _, err := executeTestCommand(t, newCatalogCommand(opts), "kubernetes", "--categories", "cloud,k8s")
+	if err != nil {
+		t.Fatalf("catalog kubernetes --categories cloud,k8s --json: %v", err)
+	}
+
+	var got catalogReport
+	if err := json.Unmarshal([]byte(stdout), &got); err != nil {
+		t.Fatalf("decode catalog json: %v", err)
+	}
+	if got.Count != 1 || len(got.Tools) != 1 || got.Tools[0].ID != "kubectl" {
+		t.Fatalf("unexpected search/category intersection: %#v", got)
+	}
+}
+
+func TestCatalogCommandRejectsInvalidCategories(t *testing.T) {
+	tests := []struct {
+		name       string
+		categories string
+		want       string
+	}{
+		{name: "unknown", categories: "cloud,unknown", want: "unknown categories: unknown"},
+		{name: "empty", categories: ",", want: "invalid --categories value"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, _, err := executeTestCommand(t, newCatalogCommand(&rootOptions{}), "--categories", tt.categories)
+			if err == nil || !strings.Contains(err.Error(), tt.want) {
+				t.Fatalf("catalog --categories %q error = %v, want %q", tt.categories, err, tt.want)
+			}
+		})
+	}
+}
+
+func TestCategoryFilterFlagCompletesCatalog(t *testing.T) {
+	root := NewRootCommand()
+
+	stdout, _, err := executeTestCommand(t, root, "__complete", "catalog", "--categories", "cl")
+	if err != nil {
+		t.Fatalf("complete catalog --categories: %v", err)
+	}
+	if !strings.Contains(stdout, "cloud") {
+		t.Fatalf("cloud completion missing: %q", stdout)
 	}
 }
 


### PR DESCRIPTION
`all-cli catalog` can now filter the built-in tool inventory by one or more exact registry categories through `--categories`, while still composing with the existing free-text search and JSON output. This is worth merging because it turns the catalog into a much faster discovery surface: users can jump straight to areas such as `ai`, `cloud`, or `k8s`, use comma-separated category completion, and do it without invoking any external CLI tools.

## Validation

- `just check` passed at exact commit `7b18dfaa258f4799ae718e740ffb40d6e9b8bf68` (83.3% total coverage, golangci-lint 0 issues, race suite and three-pass stability suite passed).
- `just build-release` passed at the exact commit.
- Focused catalog tests were added red-to-green for multi-category filtering, search/filter intersection, invalid input, and shell completion.
- Real binary QA passed for text, JSON, help, completion, unknown-category, and empty-category paths; catalog filtering also passed with `PATH=/nonexistent`.
- `git diff --check` passed and the committed diff contains only `README.md`, `internal/cli/catalog.go`, and `internal/cli/catalog_test.go`.
- `just pre-commit` could not start because the host does not have the `pre-commit` executable installed (exit 127); no machine-state changes were made. Its formatting, policy, vet, and Go test coverage is included in the passing `just check` gate.

## Impact

- Adds an optional, backward-compatible `catalog --categories <values>` flag.
- Reuses the existing registry-backed category validator and dynamic comma-list completion.
- Does not change dependencies, schemas, configuration, CI, infrastructure, permissions, secrets, telemetry, or external-command behavior.

## Rollback

Revert commit `7b18dfaa258f4799ae718e740ffb40d6e9b8bf68`; no data or configuration migration is required.

## Blockers

None for review. The repository currently has no open issue associated with this small improvement.
