### PR TITLE
feat(cli): filter current contexts by categories

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,10 +153,12 @@ reported by every installed context-aware tool in one compact view.
 ```bash
 all-cli current
 all-cli current --tools kubectl,docker
+all-cli current --categories cloud,k8s
 all-cli current --json
 ```
 
-Use `--tools` to check only the contexts you need and avoid invoking unrelated CLIs.
+Use `--tools` or `--categories` to check only the contexts you need and avoid invoking
+unrelated CLIs. When combined, both filters must match.
 
 Example text output:
 

--- a/internal/cli/current.go
+++ b/internal/cli/current.go
@@ -10,6 +10,7 @@ import (
 
 func newCurrentCommand(opts *rootOptions, runner execx.Runner) *cobra.Command {
 	var toolsFilter string
+	var categoriesFilter string
 
 	cmd := &cobra.Command{
 		Use:   "current",
@@ -17,13 +18,19 @@ func newCurrentCommand(opts *rootOptions, runner execx.Runner) *cobra.Command {
 		Long: `Shows one compact view of the active accounts, clusters, projects, and
 environments reported by installed tools that expose context-like state.
 
-Use --tools to evaluate only selected tools and skip unrelated external commands.`,
+Use --tools or --categories to evaluate only selected tools and skip unrelated
+	external commands. When combined, both filters must match.`,
 		Example: `  all-cli current
   all-cli current --tools kubectl,docker
+  all-cli current --categories cloud,k8s
   all-cli current --json`,
 		Args: cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			registry, err := registryForToolsFilter(toolsFilter)
+			if err != nil {
+				return err
+			}
+			registry, err = registryForCategoriesFilter(registry, categoriesFilter)
 			if err != nil {
 				return err
 			}
@@ -63,5 +70,6 @@ Use --tools to evaluate only selected tools and skip unrelated external commands
 		},
 	}
 	cmd.Flags().StringVar(&toolsFilter, "tools", "", "Comma-separated tool IDs to show (e.g. kubectl,docker)")
+	cmd.Flags().StringVar(&categoriesFilter, "categories", "", "Comma-separated categories to show (e.g. cloud,k8s)")
 	return cmd
 }

--- a/internal/cli/current_test.go
+++ b/internal/cli/current_test.go
@@ -149,6 +149,96 @@ func TestCurrentCommandToolsFilterEvaluatesOnlySelectedContextTools(t *testing.T
 	}
 }
 
+func TestCurrentCommandCategoriesFilterEvaluatesOnlyMatchingContextTools(t *testing.T) {
+	// Given
+	stubStatusRegistry(t, []tools.ToolDefinition{
+		{ID: "aws", Category: "cloud", Binary: "aws", Capabilities: model.Capability{HasContexts: true}},
+		{ID: "docker", Category: "containers", Binary: "docker", Capabilities: model.Capability{HasContexts: true}},
+		{ID: "kubectl", Category: "k8s", Binary: "kubectl", Capabilities: model.Capability{HasContexts: true}},
+	})
+	evaluated := make(chan string, 3)
+	oldEvaluate := evaluateToolSummary
+	evaluateToolSummary = func(_ context.Context, def tools.ToolDefinition, _ execx.Runner) model.ToolSummary {
+		evaluated <- def.ID
+		return model.ToolSummary{
+			ID:           def.ID,
+			Installed:    true,
+			Capabilities: def.Capabilities,
+			Current:      map[string]string{"profile": "work"},
+		}
+	}
+	t.Cleanup(func() { evaluateToolSummary = oldEvaluate })
+	stubShowStatusSpinner(t, false)
+
+	// When
+	stdout, stderr, err := executeTestCommand(
+		t,
+		newCurrentCommand(&rootOptions{Timeout: time.Second}, cliFakeRunner{}),
+		"--tools", "aws,kubectl", "--categories", "cloud",
+	)
+
+	// Then
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if stderr != "" {
+		t.Fatalf("expected empty stderr, got %q", stderr)
+	}
+	if got := <-evaluated; got != "aws" {
+		t.Fatalf("evaluated tool = %q, want aws", got)
+	}
+	select {
+	case got := <-evaluated:
+		t.Fatalf("unexpected additional tool evaluation: %q", got)
+	default:
+	}
+	if !strings.Contains(stdout, "aws   profile=work") || strings.Contains(stdout, "kubectl") {
+		t.Fatalf("expected only cloud current context, got:\n%s", stdout)
+	}
+}
+
+func TestCurrentCommandRejectsUnknownCategoriesBeforeEvaluation(t *testing.T) {
+	// Given
+	stubStatusRegistry(t, []tools.ToolDefinition{
+		{ID: "aws", Category: "cloud", Binary: "aws", Capabilities: model.Capability{HasContexts: true}},
+	})
+	oldEvaluate := evaluateToolSummary
+	evaluateToolSummary = func(_ context.Context, _ tools.ToolDefinition, _ execx.Runner) model.ToolSummary {
+		t.Fatal("unexpected tool evaluation")
+		return model.ToolSummary{}
+	}
+	t.Cleanup(func() { evaluateToolSummary = oldEvaluate })
+	stubShowStatusSpinner(t, false)
+
+	// When
+	_, _, err := executeTestCommand(
+		t,
+		newCurrentCommand(&rootOptions{Timeout: time.Second}, cliFakeRunner{}),
+		"--categories", "workflows",
+	)
+
+	// Then
+	if err == nil || !strings.Contains(err.Error(), "unknown categories: workflows") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestCurrentCommandCompletesCategoryFilters(t *testing.T) {
+	// Given
+	root := NewRootCommand()
+
+	// When
+	stdout, _, err := executeTestCommand(t, root, "__complete", "current", "--categories", "cl")
+
+	// Then
+	if err != nil {
+		t.Fatalf("complete current --categories: %v", err)
+	}
+	if !strings.Contains(stdout, "cloud") {
+		t.Fatalf("cloud completion missing: %q", stdout)
+	}
+}
+
 func TestRootRegistersCurrentAsPrimaryCommand(t *testing.T) {
 	// Given
 	root := NewRootCommand()


### PR DESCRIPTION
This builds a new `all-cli current --categories <values>` filter that limits context discovery to one or more registry categories before any external CLI is evaluated. It is worth merging because users can jump straight to the cloud, Kubernetes, or container contexts they care about, avoid unrelated command startup, combine the filter with exact tool IDs, and receive the existing comma-separated shell completion for free.

## Validation

- `just check` passed at exact commit `0a67de2dc09a2dc2b0d817b49ca8525db0758be2` (83.2% total coverage, golangci-lint 0 issues, race suite, and three-pass stability suite passed).
- `just build-release` passed and embedded commit `0a67de2` in the binary.
- Focused tests were added red-to-green for category/tool intersection, rejection before evaluation, and category completion registration.
- Real binary QA used observable `aws` and `kubectl` stubs: `current --categories cloud` invoked only `aws`, while text, JSON, help, unknown-category, empty intersection, and completion paths all passed.
- `git diff --check` passed and the committed scope contains only `README.md`, `internal/cli/current.go`, and `internal/cli/current_test.go`.
- `just pre-commit` could not start because this host does not have the `pre-commit` executable installed (exit 127). No machine state was changed; its formatting, policy, vet, and Go test coverage is included in the passing `just check` gate.

## Impact

- Adds an optional, backward-compatible `current --categories <values>` flag.
- Applies `--tools` and `--categories` as an intersection before context capability filtering and external command evaluation.
- Reuses existing category validation and dynamic comma-list completion.
- Does not change dependencies, schemas, configuration, CI, infrastructure, permissions, secrets, telemetry, or mutation behavior.

## Rollback

Revert commit `0a67de2dc09a2dc2b0d817b49ca8525db0758be2`; no data, configuration, or cleanup migration is required.

## Blockers

None for review. The repository currently has no open issue associated with this small improvement.
