### PR TITLE
fix(kubectl): preserve command failure details

### DIFF
--- a/internal/tools/kubectl/adapter.go
+++ b/internal/tools/kubectl/adapter.go
@@ -74,7 +74,7 @@ func (a Adapter) ListContexts(ctx context.Context) ([]string, []string, []string
 func (a Adapter) UseContext(ctx context.Context, contextName string) error {
 	res := a.runner.Run(ctx, "kubectl", "config", "use-context", contextName)
 	if res.Err != nil {
-		return fmt.Errorf("kubectl config use-context %q failed (exit=%d): %s", contextName, res.ExitCode, strings.TrimSpace(res.Stderr))
+		return fmt.Errorf("kubectl config use-context %q failed (exit=%d): %s", contextName, res.ExitCode, execx.ErrMessage(res))
 	}
 	return nil
 }
@@ -82,7 +82,7 @@ func (a Adapter) UseContext(ctx context.Context, contextName string) error {
 func (a Adapter) SetNamespaceForContext(ctx context.Context, contextName, namespace string) error {
 	res := a.runner.Run(ctx, "kubectl", "config", "set-context", contextName, "--namespace", namespace)
 	if res.Err != nil {
-		return fmt.Errorf("kubectl config set-context %q --namespace %q failed (exit=%d): %s", contextName, namespace, res.ExitCode, strings.TrimSpace(res.Stderr))
+		return fmt.Errorf("kubectl config set-context %q --namespace %q failed (exit=%d): %s", contextName, namespace, res.ExitCode, execx.ErrMessage(res))
 	}
 	return nil
 }
@@ -90,7 +90,7 @@ func (a Adapter) SetNamespaceForContext(ctx context.Context, contextName, namesp
 func (a Adapter) SetNamespaceForCurrentContext(ctx context.Context, namespace string) error {
 	res := a.runner.Run(ctx, "kubectl", "config", "set-context", "--current", "--namespace", namespace)
 	if res.Err != nil {
-		return fmt.Errorf("kubectl config set-context --current --namespace %q failed (exit=%d): %s", namespace, res.ExitCode, strings.TrimSpace(res.Stderr))
+		return fmt.Errorf("kubectl config set-context --current --namespace %q failed (exit=%d): %s", namespace, res.ExitCode, execx.ErrMessage(res))
 	}
 	return nil
 }
@@ -98,7 +98,7 @@ func (a Adapter) SetNamespaceForCurrentContext(ctx context.Context, namespace st
 func (a Adapter) currentContext(ctx context.Context) (string, error) {
 	res := a.runner.Run(ctx, "kubectl", "config", "current-context")
 	if res.Err != nil {
-		return "", fmt.Errorf("kubectl config current-context failed (exit=%d): %s", res.ExitCode, strings.TrimSpace(res.Stderr))
+		return "", fmt.Errorf("kubectl config current-context failed (exit=%d): %s", res.ExitCode, execx.ErrMessage(res))
 	}
 	return strings.TrimSpace(res.Stdout), nil
 }
@@ -106,7 +106,7 @@ func (a Adapter) currentContext(ctx context.Context) (string, error) {
 func (a Adapter) currentNamespace(ctx context.Context) (string, error) {
 	res := a.runner.Run(ctx, "kubectl", "config", "view", "--minify", "--output", "jsonpath={..namespace}{\"\\n\"}")
 	if res.Err != nil {
-		return "", fmt.Errorf("kubectl config view (namespace) failed (exit=%d): %s", res.ExitCode, strings.TrimSpace(res.Stderr))
+		return "", fmt.Errorf("kubectl config view (namespace) failed (exit=%d): %s", res.ExitCode, execx.ErrMessage(res))
 	}
 	return strings.TrimSpace(res.Stdout), nil
 }

--- a/internal/tools/kubectl/adapter_test.go
+++ b/internal/tools/kubectl/adapter_test.go
@@ -60,3 +60,72 @@ func TestAdapterListContexts(t *testing.T) {
 		t.Fatalf("unexpected contexts: %#v", contexts)
 	}
 }
+
+func TestAdapterErrorsIncludeRunnerCause(t *testing.T) {
+	tests := []struct {
+		name    string
+		command string
+		invoke  func(Adapter) error
+		want    string
+	}{
+		{
+			name:    "use context",
+			command: "kubectl config use-context prod",
+			invoke: func(a Adapter) error {
+				return a.UseContext(context.Background(), "prod")
+			},
+			want: "kubectl config use-context",
+		},
+		{
+			name:    "set namespace for context",
+			command: "kubectl config set-context prod --namespace payments",
+			invoke: func(a Adapter) error {
+				return a.SetNamespaceForContext(context.Background(), "prod", "payments")
+			},
+			want: "kubectl config set-context",
+		},
+		{
+			name:    "set namespace for current context",
+			command: "kubectl config set-context --current --namespace payments",
+			invoke: func(a Adapter) error {
+				return a.SetNamespaceForCurrentContext(context.Background(), "payments")
+			},
+			want: "kubectl config set-context --current",
+		},
+		{
+			name:    "get current context",
+			command: "kubectl config current-context",
+			invoke: func(a Adapter) error {
+				_, err := a.currentContext(context.Background())
+				return err
+			},
+			want: "kubectl config current-context",
+		},
+		{
+			name:    "get current namespace",
+			command: "kubectl config view --minify --output jsonpath={..namespace}{\"\\n\"}",
+			invoke: func(a Adapter) error {
+				_, err := a.currentNamespace(context.Background())
+				return err
+			},
+			want: "kubectl config view (namespace)",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cause := errors.New(`exec: "kubectl": executable file not found in $PATH`)
+			a := New(fakeRunner{results: map[string]execx.CmdResult{
+				tt.command: {ExitCode: 1, Err: cause},
+			}})
+
+			err := tt.invoke(a)
+			if err == nil {
+				t.Fatal("expected error")
+			}
+			if !strings.Contains(err.Error(), tt.want) || !strings.Contains(err.Error(), cause.Error()) {
+				t.Fatalf("error = %q, want command and runner cause", err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This builds actionable failure details for every kubectl context and namespace command path by routing failed command results through the existing `execx.ErrMessage` fallback. It is worth merging because users with a missing `kubectl` binary now see the real `executable file not found` cause instead of an empty `exit=1:` suffix, while ordinary kubectl stderr remains the preferred explanation.

Fixes #34.

## Validation

- Added a table-driven regression test for all five affected adapter paths; it failed 5/5 before the implementation and passed afterward.
- `just check` passed at exact commit `3f80f47a518119eb64b3f890cb1562639a4c9595` (83.5% total coverage, golangci-lint with 0 issues, race tests, and three-pass stability tests).
- `just build-release` passed and embedded commit `3f80f47` in the release-style binary.
- With `PATH=/usr/bin:/bin`, real-binary text and JSON checks confirmed that `kubectl current`, `kubectl use`, and `kubectl namespace` include `executable file not found in $PATH`.
- The same restricted-PATH QA confirmed `kubectl list` remains explicit and `status --tools kubectl` still reports `INSTALLED=no` without promoting the missing binary to a collection error.
- `go test ./internal/tools/kubectl -run TestAdapterErrorsIncludeRunnerCause -count=20` passed.
- `just pre-commit` could not run because `pre-commit` is not installed (exit 127); no machine-state change was made. Its formatting, policy, vet, and test coverage overlaps passed through `just check`.

## Impact

- Changes only `internal/tools/kubectl/adapter.go` and its colocated tests.
- Preserves command names, exit codes, JSON shapes, successful behavior, and stderr precedence.
- Adds no dependencies and does not change schemas, configuration, CI, infrastructure, permissions, secrets, or machine state.

## Rollback

Revert commit `3f80f47a518119eb64b3f890cb1562639a4c9595`; no data or configuration migration is involved.

## Blockers

None in the implementation. Repository review and hosted checks still apply.
