### PR TITLE
fix(cli): report go install version metadata

### DIFF
--- a/internal/cli/version.go
+++ b/internal/cli/version.go
@@ -18,14 +18,11 @@ func newVersionCommand(opts *rootOptions) *cobra.Command {
 		Use:   "version",
 		Short: "Print version information",
 		RunE: func(cmd *cobra.Command, _ []string) error {
+			report := resolvedVersionReport()
 			if opts.JSON {
-				return output.PrintJSON(cmd.OutOrStdout(), versionReport{
-					Version: version,
-					Commit:  commit,
-					Date:    date,
-				})
+				return output.PrintJSON(cmd.OutOrStdout(), report)
 			}
-			fmt.Fprintln(cmd.OutOrStdout(), VersionString())
+			fmt.Fprintln(cmd.OutOrStdout(), formatVersionReport(report))
 			return nil
 		},
 	}

--- a/internal/cli/version_info.go
+++ b/internal/cli/version_info.go
@@ -1,11 +1,52 @@
 package cli
 
-import "fmt"
+import (
+	"fmt"
+	"runtime/debug"
+	"strings"
+)
+
+var readBuildInfo = debug.ReadBuildInfo
 
 // VersionString returns the full version line for CLI output (e.g. all-cli --version, version subcommand).
 func VersionString() string {
-	if commit != "" || date != "" {
-		return fmt.Sprintf("%s (commit=%s date=%s)", version, commit, date)
+	return formatVersionReport(resolvedVersionReport())
+}
+
+func resolvedVersionReport() versionReport {
+	report := versionReport{Version: version, Commit: commit, Date: date}
+	if report.Version != "dev" || report.Commit != "" || report.Date != "" {
+		return report
 	}
-	return version
+
+	info, ok := readBuildInfo()
+	if !ok {
+		return report
+	}
+	return resolveVersionReport(report, info)
+}
+
+func resolveVersionReport(report versionReport, info *debug.BuildInfo) versionReport {
+	if info == nil {
+		return report
+	}
+	if moduleVersion := strings.TrimSpace(info.Main.Version); moduleVersion != "" && moduleVersion != "(devel)" {
+		report.Version = moduleVersion
+	}
+	for _, setting := range info.Settings {
+		switch setting.Key {
+		case "vcs.revision":
+			report.Commit = strings.TrimSpace(setting.Value)
+		case "vcs.time":
+			report.Date = strings.TrimSpace(setting.Value)
+		}
+	}
+	return report
+}
+
+func formatVersionReport(report versionReport) string {
+	if report.Commit != "" || report.Date != "" {
+		return fmt.Sprintf("%s (commit=%s date=%s)", report.Version, report.Commit, report.Date)
+	}
+	return report.Version
 }

--- a/internal/cli/version_test.go
+++ b/internal/cli/version_test.go
@@ -3,11 +3,13 @@ package cli
 import (
 	"bytes"
 	"encoding/json"
+	"runtime/debug"
 	"strings"
 	"testing"
 )
 
 func TestVersionStringDev(t *testing.T) {
+	stubVersionBuildInfo(t, nil, false)
 	oldVersion, oldCommit, oldDate := version, commit, date
 	version = "dev"
 	commit = ""
@@ -22,6 +24,7 @@ func TestVersionStringDev(t *testing.T) {
 }
 
 func TestVersionCommandDevOutput(t *testing.T) {
+	stubVersionBuildInfo(t, nil, false)
 	buf := &bytes.Buffer{}
 	cmd := newVersionCommand(&rootOptions{})
 	cmd.SetOut(buf)
@@ -32,6 +35,84 @@ func TestVersionCommandDevOutput(t *testing.T) {
 	out := strings.TrimSpace(buf.String())
 	if out != "dev" {
 		t.Fatalf("expected %q, got %q", "dev", out)
+	}
+}
+
+func TestVersionCommandUsesGoInstallBuildInfo(t *testing.T) {
+	oldVersion, oldCommit, oldDate := version, commit, date
+	version = "dev"
+	commit = ""
+	date = ""
+	defer func() {
+		version, commit, date = oldVersion, oldCommit, oldDate
+	}()
+	stubVersionBuildInfo(t, &debug.BuildInfo{
+		Main: debug.Module{Version: "v0.0.0-33.1.71ef29f"},
+		Settings: []debug.BuildSetting{
+			{Key: "vcs.revision", Value: "71ef29f4722abdb5921e5094fb1759a6da5a83fd"},
+			{Key: "vcs.time", Value: "2026-08-23T13:12:12Z"},
+		},
+	}, true)
+
+	stdout, stderr, err := executeTestCommand(t, NewRootCommand(), "version", "--json")
+	if err != nil {
+		t.Fatalf("version --json: %v", err)
+	}
+	if stderr != "" {
+		t.Fatalf("stderr = %q, want empty", stderr)
+	}
+
+	var got versionReport
+	if err := json.Unmarshal([]byte(stdout), &got); err != nil {
+		t.Fatalf("decode version JSON: %v\noutput: %s", err, stdout)
+	}
+	want := versionReport{
+		Version: "v0.0.0-33.1.71ef29f",
+		Commit:  "71ef29f4722abdb5921e5094fb1759a6da5a83fd",
+		Date:    "2026-08-23T13:12:12Z",
+	}
+	if got != want {
+		t.Fatalf("version report = %#v, want %#v", got, want)
+	}
+	wantLine := "v0.0.0-33.1.71ef29f (commit=71ef29f4722abdb5921e5094fb1759a6da5a83fd date=2026-08-23T13:12:12Z)"
+	if got := VersionString(); got != wantLine {
+		t.Fatalf("VersionString = %q, want %q", got, wantLine)
+	}
+}
+
+func TestVersionStringPreservesInjectedBuildMetadata(t *testing.T) {
+	oldVersion, oldCommit, oldDate := version, commit, date
+	version = "v1.2.3"
+	commit = "release-commit"
+	date = "release-date"
+	defer func() {
+		version, commit, date = oldVersion, oldCommit, oldDate
+	}()
+	stubVersionBuildInfo(t, &debug.BuildInfo{
+		Main: debug.Module{Version: "v9.9.9"},
+		Settings: []debug.BuildSetting{
+			{Key: "vcs.revision", Value: "build-info-commit"},
+			{Key: "vcs.time", Value: "build-info-date"},
+		},
+	}, true)
+
+	if got := VersionString(); got != "v1.2.3 (commit=release-commit date=release-date)" {
+		t.Fatalf("VersionString = %q", got)
+	}
+}
+
+func TestVersionStringKeepsDevForLocalBuildInfo(t *testing.T) {
+	oldVersion, oldCommit, oldDate := version, commit, date
+	version = "dev"
+	commit = ""
+	date = ""
+	defer func() {
+		version, commit, date = oldVersion, oldCommit, oldDate
+	}()
+	stubVersionBuildInfo(t, &debug.BuildInfo{Main: debug.Module{Version: "(devel)"}}, true)
+
+	if got := VersionString(); got != "dev" {
+		t.Fatalf("VersionString = %q, want dev", got)
 	}
 }
 
@@ -85,4 +166,15 @@ func TestVersionCommandJSONIncludesBuildMetadata(t *testing.T) {
 	if got.Version != version || got.Commit != commit || got.Date != date {
 		t.Fatalf("unexpected version JSON: %#v", got)
 	}
+}
+
+func stubVersionBuildInfo(t *testing.T, info *debug.BuildInfo, ok bool) {
+	t.Helper()
+	old := readBuildInfo
+	readBuildInfo = func() (*debug.BuildInfo, bool) {
+		return info, ok
+	}
+	t.Cleanup(func() {
+		readBuildInfo = old
+	})
 }


### PR DESCRIPTION
This builds a version metadata fallback for binaries installed with `go install`: when release ldflags are absent, all-cli now reads the embedded Go module version and available VCS fields, while preserving explicit GoReleaser values. It is worth merging because the documented install path finally tells users which build they are running, making bug reports and upgrade checks reliable instead of returning only `dev`.

Fixes #35.

## Validation

- `just check` passed at exact commit `ca9592d830b16a2f3daf8cf23a9f110b3bd30386` (format, repository policy, vet, full tests, 83.3% total coverage, golangci-lint with 0 issues, race tests, and three-pass stability tests).
- A real isolated `go install github.com/oldwinter/all-cli/cmd/all-cli@ca9592d830b16a2f3daf8cf23a9f110b3bd30386` installed the public pseudo-version and reported it instead of `dev` in both text and JSON output:

  ```text
  v0.0.0-33.1.71ef29f.0.20260828182615-ca9592d830b1
  ```

- `go version -m` confirmed the installed binary embeds that same module version. This `go install` build did not expose `vcs.revision` or `vcs.time`, so the additive commit/date fallback correctly remained empty.
- `just build-release` passed at the same commit and printed the injected release-style version, commit, and date unchanged, proving ldflags still take precedence.
- `just pre-commit` could not run because `pre-commit` is not installed (exit 127); no machine-state change was made. Its formatting, policy, vet, and test coverage overlaps passed through `just check`.

## Impact

- Changes only version reporting and its colocated tests in `internal/cli`.
- Affects `all-cli --version`, `all-cli version`, and `all-cli version --json` only when all release ldflags retain their defaults.
- Adds no dependencies and does not change schemas, configuration, CI, infrastructure, permissions, secrets, or external tool execution.

## Rollback

Revert commit `ca9592d830b16a2f3daf8cf23a9f110b3bd30386`; no data, configuration, or migration cleanup is required.
