### PR TITLE
fix(gh): fall back to text auth status on old GitHub CLI

### DIFF
--- a/internal/cli/gh_cli_test.go
+++ b/internal/cli/gh_cli_test.go
@@ -263,3 +263,50 @@ func TestGHUsePlainSuccess(t *testing.T) {
 		t.Fatalf("unexpected stdout:\n%s", stdout)
 	}
 }
+
+func TestGHStatusFallsBackToTextOnOldCLI(t *testing.T) {
+	opts := &rootOptions{Timeout: time.Second}
+	runner := cliFakeRunner{
+		results: map[string]execx.CmdResult{
+			"gh auth status --json hosts": {
+				ExitCode: 1,
+				Err:      assertError("exit status 1"),
+				Stderr:   "unknown flag: --json\n\nUsage:  gh auth status [flags]\n",
+			},
+			"gh auth status": {
+				Stderr: `github.com
+  ✓ Logged in to github.com account oldwinter (keyring)
+  - Active account: true
+  - Git operations protocol: ssh
+`,
+			},
+		},
+	}
+
+	stdout, stderr, err := executeTestCommand(t, newGHCommand(opts, runner), "status")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if strings.Contains(stdout, "unknown flag") || strings.Contains(stderr, "unknown flag") || strings.Contains(stderr, "Usage:") {
+		t.Fatalf("usage leaked:\nstdout=%s\nstderr=%s", stdout, stderr)
+	}
+	if !strings.Contains(stdout, "github.com") || !strings.Contains(stdout, "oldwinter") {
+		t.Fatalf("expected host/account in stdout, got:\n%s", stdout)
+	}
+
+	stdout, stderr, err = executeTestCommand(t, newGHCommand(opts, runner), "current")
+	if err != nil {
+		t.Fatalf("current: %v", err)
+	}
+	if !strings.Contains(stdout, "github.com/oldwinter") {
+		t.Fatalf("unexpected current stdout:\n%s\nstderr=%q", stdout, stderr)
+	}
+
+	stdout, stderr, err = executeTestCommand(t, newGHCommand(opts, runner), "list")
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	if !strings.Contains(stdout, "github.com") || !strings.Contains(stdout, "oldwinter") {
+		t.Fatalf("unexpected list stdout:\n%s\nstderr=%q", stdout, stderr)
+	}
+}

--- a/internal/diagnose/diagnose.go
+++ b/internal/diagnose/diagnose.go
@@ -177,20 +177,13 @@ func diagnosticsForTool(tool model.ToolSummary) []model.DiagnosticItem {
 
 	if len(tool.Errors) > 0 {
 		out = append(out, model.DiagnosticItem{
-			ID:            tool.ID + ".collection_errors",
-			Severity:      model.DiagnosticError,
-			Problem:       fmt.Sprintf("%s status collection reported errors.", displayName(tool)),
-			Evidence:      appendPrefixed("error: ", tool.Errors),
-			RelatedTool:   tool.ID,
-			SafeToAutofix: false,
-			SuggestedActions: []model.SuggestedAction{{
-				ID:          "rerun_with_timeout",
-				Title:       "Rerun with a longer timeout",
-				Description: "Inspect whether the underlying CLI is slow, blocked on login, or returning a non-zero exit.",
-				Kind:        "inspect",
-				Command:     []string{"all-cli", "status", "--tools", tool.ID, "--timeout", "15s"},
-				Mutates:     false,
-			}},
+			ID:               tool.ID + ".collection_errors",
+			Severity:         model.DiagnosticError,
+			Problem:          fmt.Sprintf("%s status collection reported errors.", displayName(tool)),
+			Evidence:         appendPrefixed("error: ", tool.Errors),
+			RelatedTool:      tool.ID,
+			SafeToAutofix:    false,
+			SuggestedActions: collectionErrorActions(tool),
 		})
 	}
 
@@ -272,6 +265,43 @@ func diagnosticsForTool(tool model.ToolSummary) []model.DiagnosticItem {
 	}
 
 	return out
+}
+
+func collectionErrorActions(tool model.ToolSummary) []model.SuggestedAction {
+	if tool.ID == "gh" && errorsLookLikeUnsupportedGHJSON(tool.Errors) {
+		return []model.SuggestedAction{{
+			ID:          "upgrade_or_check_gh_auth",
+			Title:       "Upgrade gh or check auth status",
+			Description: "This GitHub CLI does not support `gh auth status --json` (added in 2.81.0). Upgrade gh, or inspect `gh auth status`.",
+			Kind:        "inspect",
+			Command:     []string{"gh", "auth", "status"},
+			Mutates:     false,
+		}}
+	}
+	return []model.SuggestedAction{{
+		ID:          "rerun_with_timeout",
+		Title:       "Rerun with a longer timeout",
+		Description: "Inspect whether the underlying CLI is slow, blocked on login, or returning a non-zero exit.",
+		Kind:        "inspect",
+		Command:     []string{"all-cli", "status", "--tools", tool.ID, "--timeout", "15s"},
+		Mutates:     false,
+	}}
+}
+
+func errorsLookLikeUnsupportedGHJSON(errs []string) bool {
+	for _, err := range errs {
+		lower := strings.ToLower(err)
+		if strings.Contains(lower, "unknown flag") && strings.Contains(lower, "json") {
+			return true
+		}
+		if strings.Contains(lower, "auth status --json is not supported") {
+			return true
+		}
+		if strings.Contains(lower, "2.81") && strings.Contains(lower, "gh auth status") {
+			return true
+		}
+	}
+	return false
 }
 
 func summarizeDiagnostics(items []model.DiagnosticItem) model.DiagnosticSummary {

--- a/internal/diagnose/diagnose_test.go
+++ b/internal/diagnose/diagnose_test.go
@@ -114,6 +114,37 @@ func TestGenerateCreatesErrorDiagnosticForCollectionErrors(t *testing.T) {
 	}
 }
 
+func TestGenerateSuggestsUpgradeForOldGHJSONFlag(t *testing.T) {
+	status := model.NewStatusReport(1)
+	status.Tools[0] = model.ToolSummary{
+		ID:              "gh",
+		DisplayName:     "gh",
+		Installed:       true,
+		ConfiguredState: model.ConfiguredUnknown,
+		Errors:          []string{"unknown flag: --json\n\nUsage:  gh auth status [flags]..."},
+	}
+
+	report := Generate(status, Options{})
+	if report.Summary.Error != 1 || len(report.Diagnostics) == 0 {
+		t.Fatalf("expected one collection error, got %#v", report)
+	}
+	item := report.Diagnostics[0]
+	if len(item.SuggestedActions) == 0 {
+		t.Fatalf("expected a suggested action, got %#v", item)
+	}
+	action := item.SuggestedActions[0]
+	if action.ID == "rerun_with_timeout" || strings.Contains(action.Title, "timeout") {
+		t.Fatalf("old gh JSON flag should not be diagnosed as timeout: %#v", action)
+	}
+	if action.ID != "upgrade_or_check_gh_auth" {
+		t.Fatalf("expected upgrade/check-auth action, got %#v", action)
+	}
+	joined := action.Title + " " + action.Description + " " + strings.Join(action.Command, " ")
+	if !strings.Contains(joined, "gh auth status") && !strings.Contains(strings.ToLower(joined), "upgrade") {
+		t.Fatalf("expected upgrade or gh auth status guidance, got %#v", action)
+	}
+}
+
 func TestBuildFixPlanIsDryRunOnlyAndNonMutating(t *testing.T) {
 	status := model.NewStatusReport(1)
 	status.Tools[0] = model.ToolSummary{

--- a/internal/tools/gh/adapter.go
+++ b/internal/tools/gh/adapter.go
@@ -3,11 +3,17 @@ package gh
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"sort"
 	"strings"
 
 	"github.com/oldwinter/all-cli/internal/execx"
+)
+
+const (
+	unsupportedJSONMessage = "gh auth status --json is not supported by this GitHub CLI (requires >= 2.81.0); run: gh auth status"
+	unauthenticatedMessage = "unauthenticated: not logged into any GitHub hosts"
 )
 
 type Adapter struct {
@@ -130,18 +136,269 @@ type ghAccount struct {
 func (a Adapter) Status(ctx context.Context) (Status, []string, []string, error) {
 	res := a.runner.Run(ctx, "gh", "auth", "status", "--json", "hosts")
 	if res.Err != nil {
-		errMsg := strings.TrimSpace(res.Stderr)
-		if errMsg == "" {
-			errMsg = res.Err.Error()
+		if isContextError(res.Err) || !shouldFallbackFromJSON(res) {
+			return statusCommandFailure(res)
 		}
-		return Status{}, nil, []string{errMsg}, fmt.Errorf("gh auth status failed (exit=%d)", res.ExitCode)
+		return a.statusFromText(ctx)
 	}
 
 	var raw ghAuthStatus
 	if err := json.Unmarshal([]byte(res.Stdout), &raw); err != nil {
+		if shouldFallbackFromJSON(res) || looksLikeUsage(res.Stdout) {
+			return a.statusFromText(ctx)
+		}
 		return Status{}, nil, []string{err.Error()}, fmt.Errorf("failed to parse gh auth status JSON")
 	}
 	return normalize(raw), nil, nil, nil
+}
+
+func (a Adapter) statusFromText(ctx context.Context) (Status, []string, []string, error) {
+	res := a.runner.Run(ctx, "gh", "auth", "status")
+	if isContextError(res.Err) {
+		return statusCommandFailure(res)
+	}
+
+	text := execx.StdoutOrStderr(res)
+	st := parseAuthStatusText(text)
+	if hasSuccessfulAccount(st) {
+		return st, nil, nil, nil
+	}
+	if isUnauthenticatedText(text) {
+		return st, []string{unauthenticatedMessage}, nil, nil
+	}
+	if len(st.Hosts) > 0 {
+		return st, nil, nil, nil
+	}
+	if shouldFallbackFromJSON(res) || looksLikeUsage(text) {
+		return Status{}, nil, []string{unsupportedJSONMessage}, fmt.Errorf("gh auth status failed (exit=%d)", res.ExitCode)
+	}
+	if res.Err != nil {
+		return Status{}, nil, []string{sanitizeGHAuthError(execx.ErrMessage(res))}, fmt.Errorf("gh auth status failed (exit=%d)", res.ExitCode)
+	}
+	return st, []string{unauthenticatedMessage}, nil, nil
+}
+
+func statusCommandFailure(res execx.CmdResult) (Status, []string, []string, error) {
+	return Status{}, nil, []string{sanitizeGHAuthError(execx.ErrMessage(res))}, fmt.Errorf("gh auth status failed (exit=%d)", res.ExitCode)
+}
+
+func shouldFallbackFromJSON(res execx.CmdResult) bool {
+	return looksLikeUnsupportedJSONText(res.Stdout + "\n" + res.Stderr)
+}
+
+func looksLikeUnsupportedJSONText(s string) bool {
+	lower := strings.ToLower(s)
+	if strings.Contains(lower, "unknown flag: --json") || strings.Contains(lower, "unknown option: --json") {
+		return true
+	}
+	return strings.Contains(lower, "flag provided but not defined") && strings.Contains(lower, "json")
+}
+
+func looksLikeUsage(s string) bool {
+	return strings.Contains(s, "Usage:") && strings.Contains(s, "gh auth status")
+}
+
+func isContextError(err error) bool {
+	return err != nil && (errors.Is(err, context.DeadlineExceeded) || errors.Is(err, context.Canceled))
+}
+
+func sanitizeGHAuthError(msg string) string {
+	msg = strings.TrimSpace(msg)
+	if looksLikeUnsupportedJSONText(msg) || looksLikeUsage(msg) {
+		return unsupportedJSONMessage
+	}
+	if idx := strings.Index(msg, "Usage:"); idx >= 0 {
+		head := strings.TrimSpace(msg[:idx])
+		if head != "" {
+			return head
+		}
+	}
+	return msg
+}
+
+func isUnauthenticatedText(s string) bool {
+	lower := strings.ToLower(s)
+	return strings.Contains(lower, "not logged into any github hosts") ||
+		strings.Contains(lower, "you are not logged") ||
+		strings.Contains(lower, "to log in, run: gh auth login")
+}
+
+func hasSuccessfulAccount(st Status) bool {
+	for _, h := range st.Hosts {
+		for _, acc := range h.Accounts {
+			if acc.State == "success" {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func parseAuthStatusText(text string) Status {
+	raw := ghAuthStatus{Hosts: map[string][]ghAccount{}}
+	var currentHost string
+	var current *ghAccount
+
+	flush := func() {
+		if current == nil || strings.TrimSpace(currentHost) == "" {
+			return
+		}
+		raw.Hosts[currentHost] = append(raw.Hosts[currentHost], *current)
+		current = nil
+	}
+
+	for _, rawLine := range strings.Split(text, "\n") {
+		line := strings.TrimRight(rawLine, "\r")
+		trimmed := strings.TrimSpace(line)
+		if trimmed == "" {
+			continue
+		}
+		if isHostHeader(line, trimmed) {
+			flush()
+			currentHost = trimmed
+			continue
+		}
+		if acc, host, ok := parseAccountLine(trimmed); ok {
+			flush()
+			if host != "" {
+				currentHost = host
+			}
+			current = &acc
+			continue
+		}
+		if current == nil {
+			continue
+		}
+		applyAuthStatusDetail(current, trimmed)
+	}
+	flush()
+	return normalize(raw)
+}
+
+func isHostHeader(line, trimmed string) bool {
+	if line == "" || strings.HasPrefix(line, " ") || strings.HasPrefix(line, "\t") {
+		return false
+	}
+	if isUnauthenticatedText(trimmed) || looksLikeUsage(trimmed) {
+		return false
+	}
+	switch {
+	case strings.HasPrefix(trimmed, "✓"), strings.HasPrefix(trimmed, "X"), strings.HasPrefix(trimmed, "x"):
+		return false
+	case strings.HasPrefix(trimmed, "-"), strings.HasPrefix(trimmed, "*"):
+		return false
+	}
+	return strings.Contains(trimmed, ".") || !strings.Contains(trimmed, " ")
+}
+
+func parseAccountLine(trimmed string) (ghAccount, string, bool) {
+	state := accountStateFromLine(trimmed)
+	if state == "" {
+		return ghAccount{}, "", false
+	}
+	host, login := parseHostAndLogin(trimmed)
+	if host == "" && login == "" {
+		return ghAccount{}, "", false
+	}
+	return ghAccount{
+		State:       state,
+		Active:      true,
+		Host:        host,
+		Login:       login,
+		TokenSource: parseParenTokenSource(trimmed),
+	}, host, true
+}
+
+func accountStateFromLine(trimmed string) string {
+	switch {
+	case strings.Contains(trimmed, "Logged in to ") && (strings.Contains(trimmed, " account ") || strings.Contains(trimmed, " as ")):
+		return "success"
+	case strings.Contains(trimmed, "Failed to log in"), strings.Contains(trimmed, "Timeout trying to log in"):
+		return "error"
+	default:
+		return ""
+	}
+}
+
+func parseHostAndLogin(line string) (string, string) {
+	for _, prefix := range []string{"Logged in to ", "Failed to log in to ", "Timeout trying to log in to "} {
+		idx := strings.Index(line, prefix)
+		if idx < 0 {
+			continue
+		}
+		rest := line[idx+len(prefix):]
+		if i := strings.Index(rest, " using token"); i >= 0 && !strings.Contains(rest[:i], " account ") && !strings.Contains(rest[:i], " as ") {
+			return strings.TrimSpace(rest[:i]), ""
+		}
+		for _, sep := range []string{" account ", " as "} {
+			sepIdx := strings.Index(rest, sep)
+			if sepIdx < 0 {
+				continue
+			}
+			return strings.TrimSpace(rest[:sepIdx]), firstToken(rest[sepIdx+len(sep):])
+		}
+	}
+	return "", ""
+}
+
+func firstToken(s string) string {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return ""
+	}
+	if i := strings.IndexAny(s, " ("); i >= 0 {
+		return strings.TrimSpace(s[:i])
+	}
+	return s
+}
+
+func parseParenTokenSource(line string) string {
+	start := strings.LastIndex(line, "(")
+	end := strings.LastIndex(line, ")")
+	if start < 0 || end <= start {
+		return ""
+	}
+	src := strings.TrimSpace(line[start+1 : end])
+	if src == "" || strings.Contains(src, "/") {
+		return ""
+	}
+	return src
+}
+
+func applyAuthStatusDetail(acc *ghAccount, detail string) {
+	switch {
+	case strings.Contains(detail, "Active account:"):
+		acc.Active = strings.Contains(detail, "true")
+	case strings.Contains(detail, "Git operations protocol:"):
+		acc.GitProtocol = strings.TrimSpace(extractAfter(detail, "Git operations protocol:"))
+	case strings.Contains(detail, "configured to use ") && strings.Contains(detail, "protocol"):
+		acc.GitProtocol = protocolFromLegacyLine(detail)
+	case strings.Contains(detail, "Token scopes:"):
+		acc.Scopes = normalizeScopes(extractAfter(detail, "Token scopes:"))
+	}
+}
+
+func protocolFromLegacyLine(detail string) string {
+	rest := strings.TrimSpace(extractAfter(detail, "configured to use "))
+	fields := strings.Fields(rest)
+	if len(fields) == 0 {
+		return ""
+	}
+	return fields[0]
+}
+
+func normalizeScopes(raw string) string {
+	raw = strings.TrimSpace(raw)
+	raw = strings.ReplaceAll(raw, "'", "")
+	return raw
+}
+
+func extractAfter(s, needle string) string {
+	idx := strings.Index(s, needle)
+	if idx < 0 {
+		return ""
+	}
+	return strings.TrimSpace(s[idx+len(needle):])
 }
 
 func normalize(raw ghAuthStatus) Status {

--- a/internal/tools/gh/adapter_test.go
+++ b/internal/tools/gh/adapter_test.go
@@ -1,6 +1,28 @@
 package gh
 
-import "testing"
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/oldwinter/all-cli/internal/execx"
+)
+
+type fakeRunner struct {
+	results map[string]execx.CmdResult
+}
+
+func (f fakeRunner) Run(_ context.Context, name string, args ...string) execx.CmdResult {
+	key := name
+	if len(args) > 0 {
+		key += " " + strings.Join(args, " ")
+	}
+	if res, ok := f.results[key]; ok {
+		return res
+	}
+	return execx.CmdResult{ExitCode: 1, Err: errors.New("unexpected command"), Stderr: "unexpected command"}
+}
 
 func TestNormalizeHostsAndAccountsOrder(t *testing.T) {
 	raw := ghAuthStatus{
@@ -36,4 +58,298 @@ func TestNormalizeHostsAndAccountsOrder(t *testing.T) {
 	if accts[1].Active || accts[1].Login != "bob" {
 		t.Fatalf("expected bob second, got %#v", accts[1])
 	}
+}
+
+func TestStatusParsesModernJSON(t *testing.T) {
+	t.Parallel()
+
+	a := New(fakeRunner{
+		results: map[string]execx.CmdResult{
+			"gh auth status --json hosts": {
+				Stdout: `{"hosts":{"github.com":[{"login":"oldwinter","active":true,"state":"success","gitProtocol":"ssh","tokenSource":"oauth"}]}}`,
+			},
+		},
+	})
+
+	st, warnings, errs, err := a.Status(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(warnings) != 0 || len(errs) != 0 {
+		t.Fatalf("unexpected diagnostics: %#v %#v", warnings, errs)
+	}
+	if len(st.Hosts) != 1 || st.Hosts[0].Hostname != "github.com" || st.Hosts[0].Accounts[0].Login != "oldwinter" {
+		t.Fatalf("unexpected status: %#v", st)
+	}
+}
+
+const modernLoggedInText = `github.com
+  ✓ Logged in to github.com account oldwinter (keyring)
+  - Active account: true
+  - Git operations protocol: ssh
+  - Token: gho_************************************
+  - Token scopes: 'gist', 'read:org', 'repo'
+`
+
+const oldLoggedInText = `github.com
+  ✓ Logged in to github.com as oldwinter (/home/user/.config/gh/hosts.yml)
+  ✓ Git operations for github.com configured to use https protocol.
+  ✓ Token: *******************
+`
+
+const unknownJSONUsage = `unknown flag: --json
+
+Usage:  gh auth status [flags]
+
+Flags:
+  -h, --hostname string   Check a specific hostname's auth status
+      --show-token        Display the auth token
+`
+
+func TestStatusFallsBackToTextWhenJSONFlagUnknown(t *testing.T) {
+	t.Parallel()
+
+	a := New(fakeRunner{
+		results: map[string]execx.CmdResult{
+			"gh auth status --json hosts": {
+				ExitCode: 1,
+				Err:      errors.New("exit status 1"),
+				Stderr:   unknownJSONUsage,
+			},
+			"gh auth status": {
+				Stderr: modernLoggedInText,
+			},
+		},
+	})
+
+	st, warnings, errs, err := a.Status(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(warnings) != 0 || len(errs) != 0 {
+		t.Fatalf("unexpected diagnostics: %#v %#v", warnings, errs)
+	}
+	if containsUnknownJSON(warnings, errs) {
+		t.Fatalf("usage/unknown flag leaked: %#v %#v", warnings, errs)
+	}
+	if len(st.Hosts) != 1 {
+		t.Fatalf("expected 1 host, got %#v", st)
+	}
+	acc := st.Hosts[0].Accounts[0]
+	if st.Hosts[0].Hostname != "github.com" || acc.Login != "oldwinter" || !acc.Active || acc.State != "success" {
+		t.Fatalf("unexpected account: %#v", acc)
+	}
+	if acc.GitProtocol != "ssh" || acc.TokenSource != "keyring" || !strings.Contains(acc.Scopes, "repo") {
+		t.Fatalf("unexpected details: %#v", acc)
+	}
+
+	ok, _, _, err := a.Configured(context.Background())
+	if err != nil || !ok {
+		t.Fatalf("expected configured=yes, ok=%v err=%v", ok, err)
+	}
+	cur, _, _, err := a.Current(context.Background())
+	if err != nil {
+		t.Fatalf("current: %v", err)
+	}
+	if cur["hostname"] != "github.com" || cur["user"] != "oldwinter" {
+		t.Fatalf("unexpected current: %#v", cur)
+	}
+}
+
+func TestStatusFallsBackWhenJSONStdoutIsUsage(t *testing.T) {
+	t.Parallel()
+
+	a := New(fakeRunner{
+		results: map[string]execx.CmdResult{
+			"gh auth status --json hosts": {
+				Stdout: unknownJSONUsage,
+			},
+			"gh auth status": {
+				Stdout: oldLoggedInText,
+			},
+		},
+	})
+
+	st, warnings, errs, err := a.Status(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(warnings) != 0 || len(errs) != 0 {
+		t.Fatalf("unexpected diagnostics: %#v %#v", warnings, errs)
+	}
+	if len(st.Hosts) != 1 || st.Hosts[0].Accounts[0].Login != "oldwinter" {
+		t.Fatalf("unexpected status: %#v", st)
+	}
+	if st.Hosts[0].Accounts[0].GitProtocol != "https" {
+		t.Fatalf("expected legacy https protocol, got %#v", st.Hosts[0].Accounts[0])
+	}
+}
+
+func TestStatusUnauthenticatedOldGH(t *testing.T) {
+	t.Parallel()
+
+	a := New(fakeRunner{
+		results: map[string]execx.CmdResult{
+			"gh auth status --json hosts": {
+				ExitCode: 1,
+				Err:      errors.New("exit status 1"),
+				Stderr:   unknownJSONUsage,
+			},
+			"gh auth status": {
+				ExitCode: 1,
+				Err:      errors.New("exit status 1"),
+				Stderr:   "You are not logged into any GitHub hosts. To log in, run: gh auth login\n",
+			},
+		},
+	})
+
+	ok, warnings, errs, err := a.Configured(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if ok {
+		t.Fatalf("expected configured=no")
+	}
+	if len(errs) != 0 {
+		t.Fatalf("did not expect errors, got %#v", errs)
+	}
+	joined := strings.Join(warnings, "\n")
+	if !strings.Contains(joined, "unauthenticated") {
+		t.Fatalf("expected unauthenticated warning, got %#v", warnings)
+	}
+	if containsUnknownJSON(warnings, errs) {
+		t.Fatalf("unknown flag leaked: %#v %#v", warnings, errs)
+	}
+}
+
+func TestStatusOtherJSONErrorsDoNotFallback(t *testing.T) {
+	t.Parallel()
+
+	a := New(fakeRunner{
+		results: map[string]execx.CmdResult{
+			"gh auth status --json hosts": {
+				ExitCode: 1,
+				Err:      errors.New("exit status 1"),
+				Stderr:   "auth broken",
+			},
+		},
+	})
+
+	_, _, errs, err := a.Status(context.Background())
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(err.Error(), "gh auth status failed (exit=1)") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(errs) != 1 || errs[0] != "auth broken" {
+		t.Fatalf("unexpected errs: %#v", errs)
+	}
+}
+
+func TestStatusPropagatesTimeoutWithoutFallback(t *testing.T) {
+	t.Parallel()
+
+	a := New(fakeRunner{
+		results: map[string]execx.CmdResult{
+			"gh auth status --json hosts": {
+				ExitCode: 1,
+				Err:      context.DeadlineExceeded,
+				Stderr:   "unknown flag: --json",
+			},
+		},
+	})
+
+	_, _, errs, err := a.Status(context.Background())
+	if err == nil {
+		t.Fatal("expected timeout error")
+	}
+	if !strings.Contains(strings.Join(errs, "\n"), "deadline exceeded") && !strings.Contains(err.Error(), "gh auth status failed") {
+		t.Fatalf("expected timeout-style failure, got err=%v errs=%#v", err, errs)
+	}
+}
+
+func TestStatusDoesNotDumpUsageOnFallbackFailure(t *testing.T) {
+	t.Parallel()
+
+	a := New(fakeRunner{
+		results: map[string]execx.CmdResult{
+			"gh auth status --json hosts": {
+				ExitCode: 1,
+				Err:      errors.New("exit status 1"),
+				Stderr:   unknownJSONUsage,
+			},
+			"gh auth status": {
+				ExitCode: 1,
+				Err:      errors.New("exit status 1"),
+				Stderr:   unknownJSONUsage,
+			},
+		},
+	})
+
+	_, warnings, errs, err := a.Status(context.Background())
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	blob := strings.Join(append(append([]string{}, warnings...), errs...), "\n")
+	if strings.Contains(blob, "Usage:") || strings.Contains(blob, "unknown flag: --json") {
+		t.Fatalf("usage leaked: %q", blob)
+	}
+	if !strings.Contains(blob, "2.81") && !strings.Contains(blob, "gh auth status") {
+		t.Fatalf("expected upgrade/check-auth message, got %q", blob)
+	}
+}
+
+func TestParseAuthStatusTextMultipleAccounts(t *testing.T) {
+	t.Parallel()
+
+	text := `github.com
+  ✓ Logged in to github.com account alice (keyring)
+  - Active account: true
+  - Git operations protocol: https
+
+  ✓ Logged in to github.com account bob (GH_TOKEN)
+  - Active account: false
+  - Git operations protocol: ssh
+
+ghe.example.com
+  ✓ Logged in to ghe.example.com account bot (keyring)
+  - Active account: true
+`
+	st := parseAuthStatusText(text)
+	if len(st.Hosts) != 2 {
+		t.Fatalf("expected 2 hosts, got %#v", st)
+	}
+	if st.Hosts[0].Hostname != "ghe.example.com" {
+		t.Fatalf("expected sorted hosts, got %#v", st.Hosts)
+	}
+	ghHost := st.Hosts[1]
+	if len(ghHost.Accounts) != 2 || ghHost.Accounts[0].Login != "alice" || !ghHost.Accounts[0].Active {
+		t.Fatalf("expected active alice first: %#v", ghHost.Accounts)
+	}
+	if ghHost.Accounts[1].Login != "bob" || ghHost.Accounts[1].Active {
+		t.Fatalf("expected inactive bob: %#v", ghHost.Accounts[1])
+	}
+}
+
+func TestSanitizeGHAuthErrorStripsUsage(t *testing.T) {
+	t.Parallel()
+	got := sanitizeGHAuthError(unknownJSONUsage)
+	if strings.Contains(got, "Usage:") || strings.Contains(got, "unknown flag: --json") {
+		t.Fatalf("usage not sanitized: %q", got)
+	}
+	if !strings.Contains(got, "2.81") {
+		t.Fatalf("expected upgrade hint, got %q", got)
+	}
+}
+
+func containsUnknownJSON(groups ...[]string) bool {
+	for _, group := range groups {
+		for _, item := range group {
+			if strings.Contains(item, "unknown flag: --json") || strings.Contains(item, "Usage:") {
+				return true
+			}
+		}
+	}
+	return false
 }


### PR DESCRIPTION
## Summary
- `gh auth status --json` exists only on GitHub CLI >= 2.81.0. The adapter now mirrors wrangler: if `--json` fails with an unknown flag (or stdout is usage, so JSON parse fails), fall back to parsing `gh auth status` text.
- Logged-in old gh reports `configured=yes` and fills `current.hostname` + `current.user`. Usage is never dumped into human/JSON errors. Unauthenticated old gh reports `configured=no` with an unauthenticated warning, not `unknown flag: --json`.
- If this case still surfaces as a collection error, `status --json` / `diagnose --json` `suggested_actions` now say to upgrade gh or run `gh auth status`, not `--timeout 15s`. Modern gh JSON path and existing `internal/cli/gh_cli_test.go` stay green.

Closes #33.

## Test plan
- [x] `go test ./internal/tools/gh ./internal/diagnose ./internal/cli -count=1`
- [x] `go test ./...` and `go vet ./...`
- [ ] Hosted CI on this PR
- [ ] Manual: Debian-style gh < 2.81, logged in — `all-cli status --tools gh` configured=yes, current has hostname+user, no `unknown flag: --json`
- [ ] Manual: `all-cli gh status` / `gh current` / `gh list` list host/account
- [ ] Manual: `all-cli doctor --tools gh --json` does not diagnose this as timeout
- [ ] Manual: unauthenticated old gh — configured=no, warning/error is unauthenticated

## Rollback
Revert commit `582560150601d2711bfe26ee0f84a5e74608becb`.