### PR TITLE
feat(cli): recommend a daily surprise tool

### DIFF
--- a/droid-wiki/fun-facts.md
+++ b/droid-wiki/fun-facts.md
@@ -2,7 +2,7 @@
 
 ## Hidden command
 
-`all-cli surprise` is a hidden Cobra command defined in `internal/cli/surprise.go` and registered from `internal/cli/root.go`. It prints a rainbow `★ all-cli ★` banner when ANSI output is available, then ends with `好奇的人运气不会太差`.
+`all-cli surprise` is a hidden Cobra command defined in `internal/cli/surprise.go` and registered from `internal/cli/root.go`. It prints a rainbow `★ all-cli ★` banner when ANSI output is available, recommends one built-in tool per local calendar day with its purpose and `describe` command, then ends with `好奇的人运气不会太差`.
 
 ## TODO count
 

--- a/internal/cli/surprise.go
+++ b/internal/cli/surprise.go
@@ -3,10 +3,19 @@ package cli
 import (
 	"fmt"
 	"os"
+	"sort"
 	"strings"
+	"time"
 
+	"github.com/oldwinter/all-cli/internal/tools"
 	"github.com/spf13/cobra"
 )
+
+type surpriseRecommendation struct {
+	ToolID   string
+	Category string
+	Purpose  string
+}
 
 func newSurpriseCommand() *cobra.Command {
 	return &cobra.Command{
@@ -15,6 +24,7 @@ func newSurpriseCommand() *cobra.Command {
 		Short:  "A small thank-you for curious users",
 		Run: func(cmd *cobra.Command, _ []string) {
 			out := cmd.OutOrStdout()
+			recommendation := dailySurpriseRecommendation(time.Now())
 			fmt.Fprintln(out, rainbowLine("    ★ all-cli ★"))
 			fmt.Fprintln(out)
 			fmt.Fprintln(out, strings.TrimSpace(`
@@ -25,8 +35,27 @@ func newSurpriseCommand() *cobra.Command {
   and your next deploy be boring in the best way.
 `))
 			fmt.Fprintln(out)
+			fmt.Fprintf(out, "  Tool of the day: %s (%s)\n", recommendation.ToolID, recommendation.Category)
+			fmt.Fprintf(out, "  %s\n", recommendation.Purpose)
+			fmt.Fprintf(out, "  Explore it: all-cli describe %s\n", recommendation.ToolID)
+			fmt.Fprintln(out)
 			fmt.Fprintln(out, dimIfTTY("  — the maintainers · 好奇的人运气不会太差"))
 		},
+	}
+}
+
+func dailySurpriseRecommendation(day time.Time) surpriseRecommendation {
+	registry := tools.DefaultRegistry()
+	sort.Slice(registry, func(i, j int) bool {
+		return registry[i].ID < registry[j].ID
+	})
+
+	dayNumber := day.Year()*366 + day.YearDay()
+	definition := registry[dayNumber%len(registry)]
+	return surpriseRecommendation{
+		ToolID:   definition.ID,
+		Category: definition.Category,
+		Purpose:  tools.MetadataForTool(definition.ID).Purpose,
 	}
 }
 

--- a/internal/cli/surprise_test.go
+++ b/internal/cli/surprise_test.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"strings"
 	"testing"
+	"time"
 )
 
 func TestSurpriseCommandIsHiddenFromHelp(t *testing.T) {
@@ -36,5 +37,40 @@ func TestSurpriseCommandPrintsMessage(t *testing.T) {
 	}
 	if !strings.Contains(stdout, "manual") {
 		t.Fatalf("expected easter egg copy, got:\n%s", stdout)
+	}
+	if !strings.Contains(stdout, "Tool of the day:") {
+		t.Fatalf("expected daily tool recommendation, got:\n%s", stdout)
+	}
+	if !strings.Contains(stdout, "Explore it: all-cli describe ") {
+		t.Fatalf("expected runnable discovery command, got:\n%s", stdout)
+	}
+}
+
+func TestDailySurpriseRecommendationIsStableForCalendarDay(t *testing.T) {
+	t.Parallel()
+
+	morning := time.Date(2026, time.August, 31, 8, 0, 0, 0, time.FixedZone("UTC+8", 8*60*60))
+	evening := time.Date(2026, time.August, 31, 23, 59, 59, 0, time.FixedZone("UTC-7", -7*60*60))
+
+	first := dailySurpriseRecommendation(morning)
+	second := dailySurpriseRecommendation(evening)
+	if first != second {
+		t.Fatalf("same calendar date returned different recommendations: %#v != %#v", first, second)
+	}
+	if first.ToolID == "" || first.Category == "" || first.Purpose == "" {
+		t.Fatalf("recommendation is incomplete: %#v", first)
+	}
+}
+
+func TestDailySurpriseRecommendationRotatesTheNextDay(t *testing.T) {
+	t.Parallel()
+
+	today := time.Date(2026, time.August, 31, 12, 0, 0, 0, time.Local)
+	tomorrow := today.AddDate(0, 0, 1)
+
+	first := dailySurpriseRecommendation(today)
+	second := dailySurpriseRecommendation(tomorrow)
+	if first.ToolID == second.ToolID {
+		t.Fatalf("consecutive days returned the same tool %q", first.ToolID)
 	}
 }


### PR DESCRIPTION
构建了什么：隐藏的 `all-cli surprise` 彩蛋现在会按本地日历日，从完整内置工具目录中稳定轮换推荐一个 CLI，并显示类别、用途以及可直接运行的 `all-cli describe <tool>` 探索命令。为什么觉得它会很酷/值得合并：它把原本只看一次的静态彩蛋变成每天都有一点新鲜感的工具发现入口，同时完全本地、零外部命令、零状态修改，改动很小也容易移除。

## Validation

- `go test ./internal/cli -run 'Surprise' -count=1`
- `just check` at `8ba3516a2d026a23f6a4d06618c9b2b12f5e1c41` (tidy, formatting, repository policy, vet, full tests, 83.3% coverage, golangci-lint with 0 issues, race tests, and three-pass stability)
- Built with `just build`; two same-day `NO_COLOR=1 ./all-cli surprise` runs both recommended `eksctl (k8s)` with identical purpose text
- `NO_COLOR=1 ./all-cli describe eksctl` returned the same category and purpose as the recommendation
- `just pre-commit` could not start because `pre-commit` is not installed on this host (exit 127); its repository checks were covered by the passing `just check`

## Impact

- Changes only the hidden `surprise` command, its colocated tests, and the matching wiki note
- Reads only the built-in registry and metadata; it does not invoke discovered tools, access the network, or mutate configuration
- Recommendations are stable within a local calendar day and rotate on the next day

## Rollback

Revert commit `8ba3516a2d026a23f6a4d06618c9b2b12f5e1c41`. No data or configuration migration is required.
