### PR TITLE
chore(deps): upgrade Go and automation toolchains

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,5 +1,5 @@
 {
-  "name": "all-cli Go 1.26",
+  "name": "all-cli Go 1.27",
   "build": {
     "dockerfile": "Dockerfile",
     "context": ".."

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,10 +19,10 @@ jobs:
     timeout-minutes: 20
     steps:
       - name: Checkout
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Setup Go
-        uses: actions/setup-go@v6.3.0
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
           go-version-file: go.mod
           cache: true
@@ -93,14 +93,14 @@ jobs:
         run: bash scripts/check-coverage.sh
 
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v9.2.0
+        uses: golangci/golangci-lint-action@ba0d7d2ec06a0ea1cb5fa41b2e4a3ab91d21278a # v9.3.0
         with:
-          version: v2.11.3
+          version: v2.13.2
           args: --output.sarif.path=quality-metrics/golangci-lint.sarif
 
       - name: Upload lint SARIF
         if: always() && hashFiles('quality-metrics/golangci-lint.sarif') != ''
-        uses: github/codeql-action/upload-sarif@v4
+        uses: github/codeql-action/upload-sarif@cdf488f595d80d6e07e03d4674febd5ab45fa938 # v4
         with:
           sarif_file: quality-metrics/golangci-lint.sarif
           category: golangci-lint
@@ -120,7 +120,7 @@ jobs:
 
       - name: Upload quality metrics
         if: always()
-        uses: actions/upload-artifact@v4.6.2
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: quality-metrics
           path: quality-metrics/

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -19,16 +19,16 @@ jobs:
     timeout-minutes: 20
     steps:
       - name: Checkout
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Setup Go
-        uses: actions/setup-go@v6.3.0
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
           go-version-file: go.mod
           cache: true
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v4
+        uses: github/codeql-action/init@cdf488f595d80d6e07e03d4674febd5ab45fa938 # v4
         with:
           languages: go
           queries: security-and-quality
@@ -37,7 +37,7 @@ jobs:
         run: go build ./cmd/all-cli
 
       - name: Analyze
-        uses: github/codeql-action/analyze@v4
+        uses: github/codeql-action/analyze@cdf488f595d80d6e07e03d4674febd5ab45fa938 # v4
         with:
           category: /language:go
           upload: always
@@ -50,10 +50,10 @@ jobs:
       contents: read
     steps:
       - name: Checkout
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Review dependency changes
-        uses: actions/dependency-review-action@v4.8.0
+        uses: actions/dependency-review-action@a1d282b36b6f3519aa1f3fc636f609c47dddb294 # v5.0.0
         with:
           fail-on-severity: high
           deny-licenses: GPL-2.0, GPL-3.0, AGPL-1.0, AGPL-3.0

--- a/.github/workflows/labels.yml
+++ b/.github/workflows/labels.yml
@@ -18,10 +18,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Synchronize versioned labels
-        uses: actions/github-script@v7
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
             const fs = require("fs");

--- a/.github/workflows/qa.yml
+++ b/.github/workflows/qa.yml
@@ -20,7 +20,7 @@ jobs:
     timeout-minutes: 25
     steps:
       - name: Checkout
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
           token: ${{ secrets.GITHUB_TOKEN }}
@@ -41,7 +41,7 @@ jobs:
           fi
 
       - name: Setup Go
-        uses: actions/setup-go@v6.3.0
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
           go-version-file: go.mod
           cache: true
@@ -52,9 +52,9 @@ jobs:
           sudo apt-get install -y -qq imagemagick
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
-          node-version: 22
+          node-version: 24.20.0
 
       - name: Install test tools
         run: npm install -g tuistory
@@ -135,7 +135,7 @@ jobs:
 
       - name: Upload QA artifacts
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: qa-results
           path: qa-results/
@@ -144,7 +144,7 @@ jobs:
 
       - name: Post QA report as PR comment
         if: always() && github.event_name == 'pull_request'
-        uses: actions/github-script@v7
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
             const fs = require('fs');

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,12 +23,12 @@ jobs:
       url: ${{ steps.release-info.outputs.url }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
 
       - name: Setup Go
-        uses: actions/setup-go@v6.3.0
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
           go-version-file: go.mod
           cache: true
@@ -57,9 +57,9 @@ jobs:
 
       - name: GoReleaser
         id: goreleaser
-        uses: goreleaser/goreleaser-action@v7.0.0
+        uses: goreleaser/goreleaser-action@f06c13b6b1a9625abc9e6e439d9c05a8f2190e94 # v7.2.3
         with:
-          version: v2.14.3
+          version: v2.18.0
           args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/telemetry-alerts.yml
+++ b/.github/workflows/telemetry-alerts.yml
@@ -52,7 +52,7 @@ jobs:
 
       - name: Create or update actionable issues
         if: steps.config.outputs.enabled == 'true'
-        uses: actions/github-script@v7
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
             const fs = require("fs");

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -34,11 +34,19 @@ checksum:
 release:
   prerelease: auto
 
-brews:
+homebrew_casks:
   - name: all-cli
+    binaries:
+      - all-cli
     description: "Inspect and manage common CLI tool contexts"
     homepage: "https://github.com/oldwinter/all-cli"
-    directory: Formula
+    directory: Casks
+    hooks:
+      post:
+        install: |
+          if OS.mac?
+            system_command "/usr/bin/xattr", args: ["-dr", "com.apple.quarantine", "#{staged_path}/all-cli"]
+          end
     repository:
       owner: oldwinter
       name: homebrew-tap
@@ -47,7 +55,3 @@ brews:
     commit_author:
       name: github-actions[bot]
       email: 41898282+github-actions[bot]@users.noreply.github.com
-    install: |
-      bin.install "all-cli"
-    test: |
-      system "#{bin}/all-cli", "version"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -41,7 +41,7 @@
 - `just run docker update`: run planned `docker pull` commands only; it does not stop, recreate, prune, remove containers, or switch contexts.
 
 ## Coding Style & Naming Conventions
-- Target Go `1.26.1` (see `go.mod`).
+- Target Go `1.27.0` (see `go.mod`).
 - Always format with `gofmt` (`just fmt` or `just fmt-check` in pre-PR checks).
 - Follow Go naming defaults: package names lowercase, exported identifiers in `CamelCase`, test names `TestXxx`.
 - Keep command constructors in `internal/cli` as `new<Name>Command`.
@@ -76,6 +76,6 @@ This is a pure Go CLI with zero runtime service dependencies. The update script 
 
 - **Service**: `all-cli` — a standalone CLI binary; no servers, databases, or Docker required.
 - **Build & run**: see `justfile` recipes or the "Build, Test, and Development Commands" section above. `just ci` is the fastest way to verify correctness; `just smoke` builds and runs a quick sanity check.
-- **Go toolchain**: The project requires Go 1.26.1 (declared in `go.mod`). The Go toolchain auto-downloads the correct version on first use, so no manual version management is needed.
+- **Go toolchain**: The project requires Go 1.27.0 (declared in `go.mod`). The Go toolchain auto-downloads the correct version on first use, so no manual version management is needed.
 - **justfile quirk**: All Go commands in the justfile use `env -u GOROOT -u GOTOOLDIR go` to avoid stale shell variable mismatches. Run `just go-env` to debug toolchain issues.
 - **No external services**: The CLI shells out to other tools (kubectl, docker, gh, etc.) to inspect their status at runtime, but none of these are required for building or testing `all-cli` itself.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,9 +4,9 @@ Thanks for your interest in contributing! This document covers the development w
 
 ## Prerequisites
 
-- **Go 1.26.1+** (auto-downloads if your Go toolchain supports it; see `go.mod`)
+- **Go 1.27.0+** (auto-downloads if your Go toolchain supports it; see `go.mod`)
 - **just** (optional but recommended — install via `brew install just` or [just.systems](https://just.systems/))
-- **golangci-lint v2.11.3+** for complexity, duplication, and static analysis
+- **golangci-lint v2.13.2+** for complexity, duplication, and static analysis
 - **pre-commit 3.7+** for commit-time validation
 
 ## Quick Start

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ It defaults to human-friendly output and supports `--json` for stable machine-re
 ### Homebrew
 
 ```bash
-brew install oldwinter/tap/all-cli
+brew install --cask oldwinter/tap/all-cli
 all-cli version
 ```
 

--- a/docs/runbooks/release.md
+++ b/docs/runbooks/release.md
@@ -19,7 +19,7 @@ credentials.
 
 1. Preserve the failed workflow link and step logs in a `type:bug`,
    `area:ci` issue.
-2. Determine whether tagging, GitHub release publication, or Homebrew formula
+2. Determine whether tagging, GitHub release publication, or Homebrew cask
    update occurred.
 3. If nothing published, fix forward through a reviewed pull request.
 4. If a partial release published, mark the GitHub release as a prerelease,
@@ -43,3 +43,8 @@ credentials.
 Close the incident only after release assets, Homebrew installation, `all-cli
 version`, and one representative `all-cli status --group-by none` smoke test
 are verified.
+
+When promoting the first release with `homebrew_casks`, migrate the Tap's old
+`Formula/all-cli.rb` entry with `tap_migrations.json` and remove the obsolete
+Formula in the same reviewed Tap change. Do not delete the Formula before the
+new Cask has been published and installation has been verified.

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/oldwinter/all-cli
 
-go 1.26.1
+go 1.27.0
 
 require (
 	github.com/santhosh-tekuri/jsonschema/v6 v6.0.3
@@ -8,7 +8,8 @@ require (
 )
 
 require (
+	github.com/dlclark/regexp2 v1.12.0 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
-	github.com/spf13/pflag v1.0.9 // indirect
-	golang.org/x/text v0.14.0 // indirect
+	github.com/spf13/pflag v1.0.10 // indirect
+	golang.org/x/text v0.41.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -1,6 +1,6 @@
 github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
-github.com/dlclark/regexp2 v1.11.0 h1:G/nrcoOa7ZXlpoa/91N3X7mM3r8eIlMBBJZvsz/mxKI=
-github.com/dlclark/regexp2 v1.11.0/go.mod h1:DHkYz0B9wPfa6wondMfaivmHpzrQ3v9q8cnmRbL6yW8=
+github.com/dlclark/regexp2 v1.12.0 h1:0j4c5qQmnC6XOWNjP3PIXURXN2gWx76rd3KvgdPkCz8=
+github.com/dlclark/regexp2 v1.12.0/go.mod h1:DHkYz0B9wPfa6wondMfaivmHpzrQ3v9q8cnmRbL6yW8=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
@@ -8,9 +8,10 @@ github.com/santhosh-tekuri/jsonschema/v6 v6.0.3 h1:1EYB5IzjZawrrnELUi78f9fPu57Hu
 github.com/santhosh-tekuri/jsonschema/v6 v6.0.3/go.mod h1:JXeL+ps8p7/KNMjDQk3TCwPpBy0wYklyWTfbkIzdIFU=
 github.com/spf13/cobra v1.10.2 h1:DMTTonx5m65Ic0GOoRY2c16WCbHxOOw6xxezuLaBpcU=
 github.com/spf13/cobra v1.10.2/go.mod h1:7C1pvHqHw5A4vrJfjNwvOdzYu0Gml16OCs2GRiTUUS4=
-github.com/spf13/pflag v1.0.9 h1:9exaQaMOCwffKiiiYk6/BndUBv+iRViNW+4lEMi0PvY=
 github.com/spf13/pflag v1.0.9/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
+github.com/spf13/pflag v1.0.10 h1:4EBh2KAYBwaONj6b2Ye1GiHfwjqyROoF4RwYO+vPwFk=
+github.com/spf13/pflag v1.0.10/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
 go.yaml.in/yaml/v3 v3.0.4/go.mod h1:DhzuOOF2ATzADvBadXxruRBLzYTpT36CKvDb3+aBEFg=
-golang.org/x/text v0.14.0 h1:ScX5w1eTa3QqT8oi6+ziP7dTV1S2+ALU0bI+0zXKWiQ=
-golang.org/x/text v0.14.0/go.mod h1:18ZOQIKpY8NJVqYksKHtTdi31H5itFRjB5/qKTNYzSU=
+golang.org/x/text v0.41.0 h1:vz/seA0lnX87Othu2f/0L24RcgrXD9/YFTSuGjj3rH8=
+golang.org/x/text v0.41.0/go.mod h1:jvf1O8ajNzZqhSrQBPbutR/EB83Cc0CFrezNQIwbb5M=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=


### PR DESCRIPTION
## 构建了什么

- 将 Go 工具链从 1.26.1 升级到 1.27.0，并更新由当前依赖图实际选中的间接模块。
- 将 golangci-lint 升级到 2.13.2、GoReleaser 升级到 2.18.0、QA Node.js 升级到 24.20.0 LTS。
- 将 checkout、setup-go、upload-artifact、dependency-review、github-script、setup-node、golangci-lint-action、goreleaser-action 和 CodeQL 固定到最新发布对应的完整 commit SHA。
- 将 GoReleaser 已弃用的 `brews` 发布配置迁移到 `homebrew_casks`，并同步安装命令与发布回滚手册。

## 为什么觉得它会很酷/值得合并

这让开发、CI、安全扫描和发布链路落在同一代受支持工具上，同时移除 GoReleaser 2.18 会拒绝的旧 Homebrew Formula 配置。工作流 Action 改为不可变 SHA 后，版本可读性和供应链可复现性也同时保留。

### 官方迁移来源

- [go.dev](https://go.dev/dl/)
- [go.dev](https://go.dev/ref/mod)
- [nodejs.org](https://nodejs.org/dist/index.json)
- [github.com](https://github.com/golangci/golangci-lint/releases/tag/v2.13.2)
- [github.com](https://github.com/goreleaser/goreleaser/releases/tag/v2.18.0)
- [goreleaser.com](https://goreleaser.com/resources/deprecations/)
- [goreleaser.com](https://goreleaser.com/customization/publish/homebrew_casks/)
- [nodejs.org](https://nodejs.org/en/about/previous-releases)

## 验证

- `just check`：通过（Go 1.27.0、golangci-lint 2.13.2、总覆盖率 83.2%、race、三轮稳定性测试）。
- `pre-commit run --all-files`：全部通过（pre-commit 4.6.2）。
- `actionlint`：全部工作流通过。
- `govulncheck ./...`：未发现漏洞（govulncheck 1.7.0，数据库 2026-08-28）。
- `just release-check` 与 `just release-snapshot`：GoReleaser 2.18.0 生成四个平台归档和 `Casks/all-cli.rb`；Ruby 语法、归档校验和及 darwin/arm64 二进制版本均通过。
- Node 24.20.0 + npm 11.19.0：全局安装并运行 `tuistory` 0.11.0 通过。
- devcontainer：从当前可用的 `mcr.microsoft.com/devcontainers/go:1.26-bookworm` 构建成功，容器内 `GOTOOLCHAIN=auto` 下载 Go 1.27.0，Linux/arm64 全测试通过。
- 发布二进制功能 smoke：`status --tools gh,docker --group-by none --json` 通过。

## 影响

- Homebrew 发布产物从 `Formula/all-cli.rb` 改为 `Casks/all-cli.rb`；安装文档改为 `brew install --cask oldwinter/tap/all-cli`。
- 首次使用新配置发布时，需要在 `oldwinter/homebrew-tap` 通过独立审查变更添加 `tap_migrations.json` 并在 Cask 可安装后移除旧 Formula。
- 已有 Dependabot PR #28 的 8 个 GitHub Actions 更新被本 PR 完整覆盖；本 PR 不自动关闭或修改 #28。

## 回滚

如 Go 1.27、Node 24、Action 主版本或 Cask 发布出现回归，revert 本提交即可恢复 Go 1.26.1、Node 22、旧 Action 版本和 Formula 配置。不要改写已发布 tag；若 Cask 已发布，先恢复可安装产物，再通过 Tap 的独立审查变更回退迁移。

## 阻塞项

- 残余风险：本 PR 不自动合并；兼容上限、外部 CI/运行环境限制及未覆盖场景以本节和“影响”中的记录为准。

- 仓库策略要求普通依赖发布满 7 天后才能合并。golangci-lint 2.13.2 发布于 2026-08-27T23:23:58Z，因此最早合并时间为 2026-09-03T23:23:58Z；Node 24.20.0 发布于 2026-08-26，也尚处成熟期。请保持 PR open 至门禁满足。
- 当前 MCR 尚无 Go 1.27 devcontainer tag，因此镜像继续使用 1.26 bootstrap；已验证 `GOTOOLCHAIN=auto` 在容器内实际运行 Go 1.27.0。
