### PR TITLE
fix(docker): include runner cause when current context fails

### DIFF
--- a/internal/tools/docker/adapter.go
+++ b/internal/tools/docker/adapter.go
@@ -57,7 +57,11 @@ func (a Adapter) Configured(ctx context.Context) (bool, []string, []string, erro
 func (a Adapter) Current(ctx context.Context) (map[string]string, []string, []string, error) {
 	res := a.runner.Run(ctx, "docker", "context", "show")
 	if res.Err != nil {
-		return nil, nil, []string{strings.TrimSpace(res.Stderr)}, fmt.Errorf("docker context show failed (exit=%d)", res.ExitCode)
+		cause := execx.ErrMessage(res)
+		if cause == "" {
+			return nil, nil, nil, fmt.Errorf("docker context show failed (exit=%d)", res.ExitCode)
+		}
+		return nil, nil, []string{cause}, fmt.Errorf("docker context show failed (exit=%d): %s", res.ExitCode, cause)
 	}
 	cur := map[string]string{}
 	if v := strings.TrimSpace(res.Stdout); v != "" {
@@ -81,7 +85,11 @@ func (a Adapter) ListContexts(ctx context.Context) ([]Context, []string, []strin
 func (a Adapter) UseContext(ctx context.Context, contextName string) error {
 	res := a.runner.Run(ctx, "docker", "context", "use", contextName)
 	if res.Err != nil {
-		return fmt.Errorf("docker context use %q failed (exit=%d): %s", contextName, res.ExitCode, strings.TrimSpace(res.Stderr))
+		cause := execx.ErrMessage(res)
+		if cause == "" {
+			return fmt.Errorf("docker context use %q failed (exit=%d)", contextName, res.ExitCode)
+		}
+		return fmt.Errorf("docker context use %q failed (exit=%d): %s", contextName, res.ExitCode, cause)
 	}
 	return nil
 }

--- a/internal/tools/docker/adapter_test.go
+++ b/internal/tools/docker/adapter_test.go
@@ -205,3 +205,90 @@ func (f dockerFakeRunner) Run(_ context.Context, name string, args ...string) ex
 	}
 	return execx.CmdResult{ExitCode: 1, Err: errors.New("unexpected command"), Stderr: "unexpected command"}
 }
+
+func TestCurrentMissingDockerBinaryIncludesCause(t *testing.T) {
+	runner := dockerFakeRunner{
+		results: map[string]execx.CmdResult{
+			"docker context show": {
+				ExitCode: 1,
+				Stderr:   "",
+				Err:      errors.New(`exec: "docker": executable file not found in $PATH`),
+			},
+		},
+	}
+	cur, warnings, errs, err := New(runner).Current(context.Background())
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if cur != nil {
+		t.Fatalf("expected nil current, got %#v", cur)
+	}
+	if len(warnings) != 0 {
+		t.Fatalf("unexpected warnings: %#v", warnings)
+	}
+	cause := `exec: "docker": executable file not found in $PATH`
+	if !strings.Contains(err.Error(), cause) {
+		t.Fatalf("expected error text to contain runner cause, got %q", err.Error())
+	}
+	for i, e := range errs {
+		if e == "" {
+			t.Fatalf("errors[%d] is empty: %#v", i, errs)
+		}
+	}
+	if len(errs) == 0 {
+		t.Fatal("expected at least one error message")
+	}
+	if !strings.Contains(strings.Join(errs, "\n"), "not found") {
+		t.Fatalf("expected errors to mention not found, got %#v", errs)
+	}
+}
+
+func TestCurrentBadContextUsesStderr(t *testing.T) {
+	runner := dockerFakeRunner{
+		results: map[string]execx.CmdResult{
+			"docker context show": {
+				ExitCode: 1,
+				Stderr:   `current context "broken" does not exist`,
+				Err:      errors.New("exit status 1"),
+			},
+		},
+	}
+	_, _, errs, err := New(runner).Current(context.Background())
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	joined := err.Error() + "\n" + strings.Join(errs, "\n")
+	if !strings.Contains(joined, `current context "broken" does not exist`) {
+		t.Fatalf("expected stderr cause, got err=%q errs=%#v", err.Error(), errs)
+	}
+	if strings.Contains(joined, "executable file not found") {
+		t.Fatalf("installed-but-bad-context should not look like missing binary: %q", joined)
+	}
+	for i, e := range errs {
+		if e == "" {
+			t.Fatalf("errors[%d] is empty: %#v", i, errs)
+		}
+	}
+}
+
+func TestUseContextMissingDockerBinaryIncludesCause(t *testing.T) {
+	runner := dockerFakeRunner{
+		results: map[string]execx.CmdResult{
+			"docker context use prod": {
+				ExitCode: 1,
+				Stderr:   "",
+				Err:      errors.New(`exec: "docker": executable file not found in $PATH`),
+			},
+		},
+	}
+	err := New(runner).UseContext(context.Background(), "prod")
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(err.Error(), `exec: "docker": executable file not found in $PATH`) {
+		t.Fatalf("expected use error to contain runner cause, got %q", err.Error())
+	}
+	if strings.HasSuffix(err.Error(), ": ") {
+		t.Fatalf("use error has empty cause suffix: %q", err.Error())
+	}
+}


### PR DESCRIPTION
## Summary

- `all-cli docker current` with docker missing from PATH printed a blank `error: ` line because `Adapter.Current` stuffed trimmed stderr (empty) into the errors slice and returned a generic `docker context show failed` error.
- Use `execx.ErrMessage` so the runner cause (`executable file not found`) is in both the errors slice and the returned error. `UseContext` gets the same empty-cause fix.
- `docker status` still treats a missing binary as `installed=no` via LookPath and does not call `Current`.

Fixes #42

## Acceptance

- Missing docker: human output has no empty `error: ` line; text contains not found / not installed.
- `--json` errors contains no `""`.
- `docker status` still `installed=no`; missing binary is not promoted into a misleading context failure on status.
- Installed-but-bad-context errors remain distinguishable from not-installed.

## Test plan

- [x] `go test ./internal/tools/docker ./internal/execx`
- [x] `go test ./internal/cli -run Docker`
- [ ] `PATH` without docker: `all-cli docker status` → INSTALLED=no; `all-cli docker current` has no blank `error: ` line and mentions not found
- [ ] `all-cli docker current --json` errors has no empty string
- [ ] With docker installed but a broken current context, the error is still a context failure rather than not-installed