### PR TITLE
feat(cli): auto-detect completion shell

### DIFF
--- a/internal/cli/completion.go
+++ b/internal/cli/completion.go
@@ -3,6 +3,8 @@ package cli
 import (
 	"fmt"
 	"io"
+	"os"
+	"path/filepath"
 	"sort"
 	"strings"
 	"unicode"
@@ -120,11 +122,31 @@ func writeZshCompletion(cmd *cobra.Command) error {
 	return writePatchedCompletion(cmd, cmd.Root().GenZshCompletion, splitWords, quotedWords, unquotedRequest, quotedRequest)
 }
 
+func detectCompletionShell(shellPath string) (string, error) {
+	shellPath = strings.TrimSpace(shellPath)
+	if shellPath == "" {
+		return "", fmt.Errorf("cannot detect shell because SHELL is empty; specify one, for example: all-cli completion zsh")
+	}
+
+	shell := strings.TrimSuffix(strings.ToLower(filepath.Base(shellPath)), ".exe")
+	switch shell {
+	case "bash", "zsh", "fish", "powershell":
+		return shell, nil
+	case "pwsh":
+		return "powershell", nil
+	default:
+		return "", fmt.Errorf("cannot detect a supported shell from SHELL=%q; specify one, for example: all-cli completion zsh", shellPath)
+	}
+}
+
 func newCompletionCommand() *cobra.Command {
 	return &cobra.Command{
 		Use:   "completion [bash|zsh|fish|powershell]",
 		Short: "Generate shell completion script",
 		Long: `Generate a shell completion script for the specified shell.
+
+When the shell argument is omitted, all-cli detects bash, zsh, fish, or
+PowerShell from the SHELL environment variable.
 
 To load completions:
 
@@ -140,10 +162,21 @@ To load completions:
   powershell:
     all-cli completion powershell | Out-String | Invoke-Expression`,
 		ValidArgs:             []string{"bash", "zsh", "fish", "powershell"},
-		Args:                  cobra.MatchAll(cobra.ExactArgs(1), cobra.OnlyValidArgs),
+		Args:                  cobra.MatchAll(cobra.MaximumNArgs(1), cobra.OnlyValidArgs),
 		DisableFlagsInUseLine: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			switch args[0] {
+			shell := ""
+			if len(args) == 1 {
+				shell = args[0]
+			} else {
+				var err error
+				shell, err = detectCompletionShell(os.Getenv("SHELL"))
+				if err != nil {
+					return err
+				}
+			}
+
+			switch shell {
 			case "bash":
 				return writeBashCompletion(cmd)
 			case "zsh":
@@ -153,7 +186,7 @@ To load completions:
 			case "powershell":
 				return cmd.Root().GenPowerShellCompletionWithDesc(cmd.OutOrStdout())
 			default:
-				return fmt.Errorf("unsupported shell: %s", args[0])
+				return fmt.Errorf("unsupported shell: %s", shell)
 			}
 		},
 	}

--- a/internal/cli/completion_test.go
+++ b/internal/cli/completion_test.go
@@ -29,6 +29,59 @@ func TestCompletionCommandGeneratesScripts(t *testing.T) {
 	}
 }
 
+func TestCompletionCommandDetectsCurrentShell(t *testing.T) {
+	t.Setenv("SHELL", "/bin/zsh")
+
+	stdout, stderr, err := executeTestCommand(t, NewRootCommand(), "completion")
+	if err != nil {
+		t.Fatalf("generate detected zsh completion: %v", err)
+	}
+	if stderr != "" {
+		t.Fatalf("expected empty stderr, got %q", stderr)
+	}
+	if !strings.Contains(stdout, "#compdef all-cli") {
+		t.Fatalf("expected zsh completion output, got:\n%s", stdout)
+	}
+}
+
+func TestDetectCompletionShell(t *testing.T) {
+	tests := []struct {
+		name      string
+		shellPath string
+		want      string
+		wantErr   string
+	}{
+		{name: "bash", shellPath: "/bin/bash", want: "bash"},
+		{name: "zsh", shellPath: "/opt/homebrew/bin/zsh", want: "zsh"},
+		{name: "fish", shellPath: "/usr/local/bin/fish", want: "fish"},
+		{name: "powershell", shellPath: "/usr/local/bin/powershell", want: "powershell"},
+		{name: "pwsh alias", shellPath: "/opt/microsoft/powershell/7/pwsh", want: "powershell"},
+		{name: "empty", wantErr: "SHELL is empty"},
+		{name: "unsupported", shellPath: "/bin/nu", wantErr: `SHELL="/bin/nu"`},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := detectCompletionShell(tt.shellPath)
+			if tt.wantErr != "" {
+				if err == nil || !strings.Contains(err.Error(), tt.wantErr) {
+					t.Fatalf("detectCompletionShell(%q) error = %v, want %q", tt.shellPath, err, tt.wantErr)
+				}
+				if !strings.Contains(err.Error(), "completion zsh") {
+					t.Fatalf("error should suggest an explicit shell: %v", err)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("detectCompletionShell(%q): %v", tt.shellPath, err)
+			}
+			if got != tt.want {
+				t.Fatalf("detectCompletionShell(%q) = %q, want %q", tt.shellPath, got, tt.want)
+			}
+		})
+	}
+}
+
 func TestCompletionCommandRejectsUnsupportedShell(t *testing.T) {
 	cmd := newCompletionCommand()
 	err := cmd.RunE(cmd, []string{"unknown"})


### PR DESCRIPTION
This builds automatic shell detection for `all-cli completion`: when the shell argument is omitted, the command now reads `SHELL` and emits the matching Bash, Zsh, Fish, or PowerShell completion script, while every explicit form remains unchanged. It is worth merging because the obvious command now does the useful thing immediately, removing a small piece of setup friction without installing anything, invoking another CLI, or changing machine configuration.

## Validation

- `env -u GOROOT -u GOTOOLDIR go test ./internal/cli -run 'Test(Completion|DetectCompletionShell)' -count=1`
- `env -u GOROOT -u GOTOOLDIR go test ./internal/cli -count=1`
- `just build`
- `just check` at commit `664c12091d061bb4cf1048387080496b1e2fddb5`
  - total coverage: 83.3% (minimum 80.0%)
  - golangci-lint: 0 issues
  - race suite: passed
  - three-pass stability suite: passed
- Manual Zsh QA: detected output begins with `#compdef all-cli`, is byte-for-byte identical to `all-cli completion zsh`, and passes `zsh -n`.
- Empty `SHELL` QA: exits non-zero with an explicit-shell recovery command.
- `just pre-commit` could not start because `pre-commit` is not installed on this host (exit 127). Its repository checks overlap with the successful `just check`; no machine state was changed.

## Impact

- Changes only `internal/cli/completion.go` and its colocated tests.
- Adds no dependency and does not change generated scripts, JSON output, external-tool execution, configuration, or existing explicit completion commands.
- Unsupported or empty `SHELL` values fail clearly and suggest an explicit command.

## Rollback

Revert commit `664c12091d061bb4cf1048387080496b1e2fddb5`. The prior explicit `all-cli completion <shell>` workflow remains the fallback.
