### PR TITLE
fix(wrangler): missing binary is not logged_in: no

### DIFF
--- a/internal/cli/wrangler_test.go
+++ b/internal/cli/wrangler_test.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"context"
 	"encoding/json"
+	"os/exec"
 	"strings"
 	"testing"
 	"time"
@@ -185,4 +186,58 @@ func TestRootCommandIncludesWrangler(t *testing.T) {
 		}
 	}
 	t.Fatal("expected root command to register wrangler")
+}
+
+func TestWranglerCurrentJSONMissingBinaryReportsError(t *testing.T) {
+	opts := &rootOptions{JSON: true, Timeout: time.Second}
+	runner := cliFakeRunner{
+		results: map[string]execx.CmdResult{
+			"wrangler whoami --json": {
+				ExitCode: 1,
+				Err:      exec.ErrNotFound,
+			},
+		},
+	}
+
+	stdout, _, err := executeTestCommand(t, newWranglerCommand(opts, runner), "current")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var got struct {
+		Current map[string]string `json:"current"`
+		Errors  []string          `json:"errors"`
+	}
+	if err := json.Unmarshal([]byte(stdout), &got); err != nil {
+		t.Fatalf("failed to decode JSON: %v", err)
+	}
+	if len(got.Errors) == 0 {
+		t.Fatalf("expected missing-binary error, got %#v", got)
+	}
+	if got.Current["logged_in"] == "no" {
+		t.Fatalf("missing binary must not report logged_in=no: %#v", got)
+	}
+}
+
+func TestWranglerCurrentPlainMissingBinaryDoesNotPrintLoggedOut(t *testing.T) {
+	opts := &rootOptions{Timeout: time.Second}
+	runner := cliFakeRunner{
+		results: map[string]execx.CmdResult{
+			"wrangler whoami --json": {
+				ExitCode: 1,
+				Err:      exec.ErrNotFound,
+			},
+		},
+	}
+
+	stdout, stderr, err := executeTestCommand(t, newWranglerCommand(opts, runner), "current")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if strings.Contains(stdout, "logged_in: no") {
+		t.Fatalf("missing binary must not print logged_in: no, got %q", stdout)
+	}
+	if !strings.Contains(stderr, "error:") {
+		t.Fatalf("expected error on stderr, got %q", stderr)
+	}
 }

--- a/internal/tools/wrangler/adapter.go
+++ b/internal/tools/wrangler/adapter.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"os/exec"
 	"regexp"
 	"sort"
 	"strings"
@@ -45,7 +46,7 @@ func (a Adapter) Configured(ctx context.Context) (bool, []string, []string, erro
 func (a Adapter) Current(ctx context.Context) (map[string]string, []string, []string, error) {
 	w, warnings, errs, err := a.Whoami(ctx)
 	if err != nil {
-		return nil, warnings, errs, err
+		return map[string]string{}, warnings, errs, err
 	}
 	out := map[string]string{
 		"logged_in": yesNo(w.LoggedIn),
@@ -65,7 +66,7 @@ func (a Adapter) Current(ctx context.Context) (map[string]string, []string, []st
 func (a Adapter) Whoami(ctx context.Context) (Whoami, []string, []string, error) {
 	res := a.runner.Run(ctx, "wrangler", "whoami", "--json")
 	if res.Err != nil {
-		if errors.Is(res.Err, context.DeadlineExceeded) || errors.Is(res.Err, context.Canceled) {
+		if isFatalWhoamiErr(res.Err) {
 			return Whoami{}, nil, nil, res.Err
 		}
 		return a.whoamiFromText(ctx)
@@ -81,10 +82,10 @@ func (a Adapter) Whoami(ctx context.Context) (Whoami, []string, []string, error)
 func (a Adapter) whoamiFromText(ctx context.Context) (Whoami, []string, []string, error) {
 	res := a.runner.Run(ctx, "wrangler", "whoami")
 	if res.Err != nil {
-		if errors.Is(res.Err, context.DeadlineExceeded) || errors.Is(res.Err, context.Canceled) {
+		if isFatalWhoamiErr(res.Err) {
 			return Whoami{}, nil, nil, res.Err
 		}
-		// treat as not logged in
+		// wrangler ran, but whoami failed: treat as not logged in
 		return Whoami{LoggedIn: false}, nil, nil, nil
 	}
 
@@ -142,4 +143,10 @@ func yesNo(b bool) string {
 		return "yes"
 	}
 	return "no"
+}
+
+func isFatalWhoamiErr(err error) bool {
+	return errors.Is(err, context.DeadlineExceeded) ||
+		errors.Is(err, context.Canceled) ||
+		errors.Is(err, exec.ErrNotFound)
 }

--- a/internal/tools/wrangler/adapter_test.go
+++ b/internal/tools/wrangler/adapter_test.go
@@ -3,6 +3,7 @@ package wrangler
 import (
 	"context"
 	"errors"
+	"os/exec"
 	"strings"
 	"testing"
 
@@ -143,6 +144,81 @@ func TestWhoamiPropagatesTimeout(t *testing.T) {
 	_, warnings, errs, err := a.Whoami(context.Background())
 	if !errors.Is(err, context.DeadlineExceeded) {
 		t.Fatalf("expected deadline exceeded, got %v", err)
+	}
+	if len(warnings) != 0 || len(errs) != 0 {
+		t.Fatalf("unexpected diagnostics: %#v %#v", warnings, errs)
+	}
+}
+
+func TestWhoamiMissingBinaryIsError(t *testing.T) {
+	t.Parallel()
+
+	a := New(fakeRunner{
+		results: map[string]execx.CmdResult{
+			"wrangler whoami --json": {
+				ExitCode: 1,
+				Err:      exec.ErrNotFound,
+			},
+		},
+	})
+
+	got, warnings, errs, err := a.Whoami(context.Background())
+	if !errors.Is(err, exec.ErrNotFound) {
+		t.Fatalf("expected exec.ErrNotFound, got %v", err)
+	}
+	if got.LoggedIn {
+		t.Fatalf("missing binary must not look logged in: %#v", got)
+	}
+	if len(warnings) != 0 || len(errs) != 0 {
+		t.Fatalf("unexpected diagnostics: %#v %#v", warnings, errs)
+	}
+}
+
+func TestCurrentMissingBinaryDoesNotReportLoggedOut(t *testing.T) {
+	t.Parallel()
+
+	a := New(fakeRunner{
+		results: map[string]execx.CmdResult{
+			"wrangler whoami --json": {
+				ExitCode: 1,
+				Err:      exec.ErrNotFound,
+			},
+		},
+	})
+
+	cur, _, _, err := a.Current(context.Background())
+	if !errors.Is(err, exec.ErrNotFound) {
+		t.Fatalf("expected exec.ErrNotFound, got %v", err)
+	}
+	if _, ok := cur["logged_in"]; ok {
+		t.Fatalf("missing binary must not set logged_in: %#v", cur)
+	}
+}
+
+func TestCurrentNotLoggedInWhenWhoamiFails(t *testing.T) {
+	t.Parallel()
+
+	a := New(fakeRunner{
+		results: map[string]execx.CmdResult{
+			"wrangler whoami --json": {
+				ExitCode: 1,
+				Err:      errors.New("exit status 1"),
+				Stderr:   "Not logged in",
+			},
+			"wrangler whoami": {
+				ExitCode: 1,
+				Err:      errors.New("exit status 1"),
+				Stderr:   "You are not logged in",
+			},
+		},
+	})
+
+	cur, warnings, errs, err := a.Current(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cur["logged_in"] != "no" {
+		t.Fatalf("expected logged_in=no, got %#v", cur)
 	}
 	if len(warnings) != 0 || len(errs) != 0 {
 		t.Fatalf("unexpected diagnostics: %#v %#v", warnings, errs)


### PR DESCRIPTION
## Summary
- `wrangler current` no longer treats a missing binary as logged out.
- `exec.ErrNotFound` now surfaces as an error (`exec: "wrangler": executable file not found in $PATH`), matching `aws current`.
- Installed-but-not-logged-in still reports `logged_in: no`.

Closes #46

## Test plan
- [x] `go test ./internal/tools/wrangler ./internal/cli`
- [x] On a machine without wrangler (`command -v wrangler` fails):
  - `all-cli wrangler current` prints the PATH error, not `logged_in: no`
  - `all-cli wrangler current --json` has non-empty `errors` and no `logged_in: no`
  - `all-cli wrangler status` still shows `INSTALLED=no`
- [x] Unit tests: missing binary vs installed-not-logged-in