### PR TITLE
feat(cli): add shareable status report

### DIFF
--- a/internal/cli/report.go
+++ b/internal/cli/report.go
@@ -1,0 +1,39 @@
+package cli
+
+import (
+	diag "github.com/oldwinter/all-cli/internal/diagnose"
+	"github.com/oldwinter/all-cli/internal/execx"
+	"github.com/oldwinter/all-cli/internal/output"
+	"github.com/spf13/cobra"
+)
+
+func newReportCommand(opts *rootOptions, runner execx.Runner) *cobra.Command {
+	var toolsFilter string
+
+	cmd := &cobra.Command{
+		Use:   "report",
+		Short: "Create a shareable Markdown status report",
+		Long: `Evaluates tracked tools and prints a Markdown report ready to paste into an
+issue or pull request. Use --tools to limit external checks or --json to emit the
+existing machine-readable status report instead.`,
+		Example: `  all-cli report
+  all-cli report --tools kubectl,docker
+  all-cli report --tools gh --json`,
+		Args: cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			report, err := buildStatusReport(cmd.Context(), runner, opts.Timeout, toolsFilter)
+			if err != nil {
+				return err
+			}
+			if opts.JSON {
+				report.Diagnostics = diag.Generate(report, diag.Options{Profile: diag.ProfileAgent}).Diagnostics
+				return output.PrintJSON(cmd.OutOrStdout(), report)
+			}
+			output.PrintStatusMarkdown(cmd.OutOrStdout(), report)
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVar(&toolsFilter, "tools", "", "Comma-separated tool IDs to include")
+	return cmd
+}

--- a/internal/cli/report_test.go
+++ b/internal/cli/report_test.go
@@ -1,0 +1,89 @@
+package cli
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/oldwinter/all-cli/internal/execx"
+	"github.com/oldwinter/all-cli/internal/model"
+	"github.com/oldwinter/all-cli/internal/tools"
+)
+
+func TestReportCommandPrintsMarkdownForSelectedTools(t *testing.T) {
+	stubStatusRegistry(t, []tools.ToolDefinition{
+		{ID: "gh", DisplayName: "gh", Category: "code", Binary: "gh"},
+		{ID: "kubectl", DisplayName: "kubectl", Category: "k8s", Binary: "kubectl"},
+	})
+	oldEvaluate := evaluateToolSummary
+	evaluateToolSummary = func(_ context.Context, def tools.ToolDefinition, _ execx.Runner) model.ToolSummary {
+		return model.ToolSummary{
+			ID:              def.ID,
+			Category:        def.Category,
+			Installed:       true,
+			ConfiguredState: model.ConfiguredYes,
+			Current:         map[string]string{"user": "oldwinter"},
+		}
+	}
+	t.Cleanup(func() { evaluateToolSummary = oldEvaluate })
+
+	opts := &rootOptions{Timeout: time.Second}
+	stdout, stderr, err := executeTestCommand(t, newReportCommand(opts, cliFakeRunner{}), "--tools", "gh")
+	if err != nil {
+		t.Fatalf("report: %v", err)
+	}
+	if stderr != "" {
+		t.Fatalf("stderr = %q, want empty", stderr)
+	}
+	if !strings.Contains(stdout, "# all-cli status report") || !strings.Contains(stdout, "| gh | code | yes | yes | user=oldwinter |") {
+		t.Fatalf("unexpected report:\n%s", stdout)
+	}
+	if strings.Contains(stdout, "kubectl") {
+		t.Fatalf("report ignored --tools filter:\n%s", stdout)
+	}
+}
+
+func TestReportCommandJSONKeepsStatusContract(t *testing.T) {
+	stubStatusRegistry(t, []tools.ToolDefinition{{
+		ID: "aws", DisplayName: "AWS CLI", Category: "cloud", Binary: "aws",
+	}})
+	oldEvaluate := evaluateToolSummary
+	evaluateToolSummary = func(_ context.Context, def tools.ToolDefinition, _ execx.Runner) model.ToolSummary {
+		return model.ToolSummary{
+			ID:              def.ID,
+			Category:        def.Category,
+			ConfiguredState: model.ConfiguredUnknown,
+			Errors:          []string{"binary not found"},
+		}
+	}
+	t.Cleanup(func() { evaluateToolSummary = oldEvaluate })
+
+	opts := &rootOptions{JSON: true, Timeout: time.Second}
+	stdout, _, err := executeTestCommand(t, newReportCommand(opts, cliFakeRunner{}), "--tools", "aws")
+	if err != nil {
+		t.Fatalf("report --json: %v", err)
+	}
+	var got model.StatusReport
+	if err := json.Unmarshal([]byte(stdout), &got); err != nil {
+		t.Fatalf("decode report json: %v", err)
+	}
+	if got.SchemaVersion != model.SchemaVersionV01 || len(got.Tools) != 1 || got.Tools[0].ID != "aws" {
+		t.Fatalf("unexpected report payload: %#v", got)
+	}
+	if len(got.Diagnostics) != 1 || got.Diagnostics[0].RelatedTool != "aws" {
+		t.Fatalf("expected aws diagnostic, got %#v", got.Diagnostics)
+	}
+}
+
+func TestRootCommandIncludesReport(t *testing.T) {
+	root := NewRootCommand()
+	report, _, err := root.Find([]string{"report"})
+	if err != nil {
+		t.Fatalf("find report command: %v", err)
+	}
+	if report.Name() != "report" || report.GroupID != "primary" {
+		t.Fatalf("unexpected report registration: name=%q group=%q", report.Name(), report.GroupID)
+	}
+}

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -85,6 +85,7 @@ Environment:
 	}
 
 	cmd.AddCommand(newStatusCommand(opts, runner))
+	cmd.AddCommand(newReportCommand(opts, runner))
 	cmd.AddCommand(newCurrentCommand(opts, runner))
 	cmd.AddCommand(newCatalogCommand(opts))
 	cmd.AddCommand(newDescribeCommand(opts))
@@ -120,7 +121,7 @@ Environment:
 func setSubcommandGroups(root *cobra.Command) {
 	for _, c := range root.Commands() {
 		switch c.Name() {
-		case "status", "current", "catalog", "describe", "diagnose", "doctor", "fix", "snapshot", "diff":
+		case "status", "report", "current", "catalog", "describe", "diagnose", "doctor", "fix", "snapshot", "diff":
 			c.GroupID = "primary"
 		case "aws", "aliyun", "wrangler":
 			c.GroupID = "cloud"

--- a/internal/output/status_markdown.go
+++ b/internal/output/status_markdown.go
@@ -1,0 +1,76 @@
+package output
+
+import (
+	"fmt"
+	"io"
+	"strings"
+	"time"
+
+	"github.com/oldwinter/all-cli/internal/model"
+)
+
+// PrintStatusMarkdown writes a paste-ready status report for issues and pull requests.
+func PrintStatusMarkdown(w io.Writer, report model.StatusReport) {
+	fmt.Fprintln(w, "# all-cli status report")
+	if !report.GeneratedAt.IsZero() {
+		fmt.Fprintf(w, "\nGenerated: `%s`\n", report.GeneratedAt.UTC().Format(time.RFC3339))
+	}
+
+	fmt.Fprintln(w, "\n| Tool | Category | Installed | Configured | Current |")
+	fmt.Fprintln(w, "| --- | --- | --- | --- | --- |")
+	for _, tool := range report.Tools {
+		fmt.Fprintf(w, "| %s | %s | %s | %s | %s |\n",
+			markdownTableCell(tool.ID),
+			markdownTableCell(tool.Category),
+			boolToYesNo(tool.Installed),
+			markdownTableCell(string(tool.ConfiguredState)),
+			markdownTableCell(formatCurrentSummary(tool)),
+		)
+	}
+
+	printMarkdownMessages(w, "Warnings", report.Tools, func(tool model.ToolSummary) []string {
+		return tool.Warnings
+	})
+	printMarkdownMessages(w, "Errors", report.Tools, func(tool model.ToolSummary) []string {
+		return tool.Errors
+	})
+}
+
+func printMarkdownMessages(
+	w io.Writer,
+	heading string,
+	tools []model.ToolSummary,
+	pick func(model.ToolSummary) []string,
+) {
+	lines := make([]string, 0)
+	for _, tool := range tools {
+		for _, message := range pick(tool) {
+			message = strings.TrimSpace(message)
+			if message == "" {
+				continue
+			}
+			lines = append(lines, fmt.Sprintf("- `%s`: %s", tool.ID, markdownLine(message)))
+		}
+	}
+	if len(lines) == 0 {
+		return
+	}
+
+	fmt.Fprintf(w, "\n## %s\n\n", heading)
+	for _, line := range lines {
+		fmt.Fprintln(w, line)
+	}
+}
+
+func markdownTableCell(value string) string {
+	value = strings.TrimSpace(value)
+	value = strings.ReplaceAll(value, `\`, `\\`)
+	value = strings.ReplaceAll(value, "|", `\|`)
+	return markdownLine(value)
+}
+
+func markdownLine(value string) string {
+	value = strings.ReplaceAll(value, "\r\n", "<br>")
+	value = strings.ReplaceAll(value, "\n", "<br>")
+	return strings.ReplaceAll(value, "\r", "<br>")
+}

--- a/internal/output/status_markdown_test.go
+++ b/internal/output/status_markdown_test.go
@@ -1,0 +1,77 @@
+package output
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/oldwinter/all-cli/internal/model"
+)
+
+func TestPrintStatusMarkdownProducesPasteReadyReport(t *testing.T) {
+	report := model.StatusReport{
+		GeneratedAt: time.Date(2026, time.September, 3, 2, 15, 0, 0, time.FixedZone("CST", 8*60*60)),
+		Tools: []model.ToolSummary{
+			{
+				ID:              "kubectl",
+				Category:        "k8s",
+				Installed:       true,
+				ConfiguredState: model.ConfiguredYes,
+				Current: map[string]string{
+					"context":   "prod|west",
+					"namespace": "team\nblue",
+				},
+				Warnings: []string{"namespace may be stale"},
+			},
+			{
+				ID:              "docker",
+				Category:        "containers",
+				ConfiguredState: model.ConfiguredUnknown,
+				Errors:          []string{"binary not found\ncheck PATH"},
+			},
+		},
+	}
+
+	var output bytes.Buffer
+	PrintStatusMarkdown(&output, report)
+	got := output.String()
+
+	for _, want := range []string{
+		"# all-cli status report",
+		"Generated: `2026-09-02T18:15:00Z`",
+		"| Tool | Category | Installed | Configured | Current |",
+		`| kubectl | k8s | yes | yes | context=prod\|west namespace=team<br>blue |`,
+		"| docker | containers | no | unknown |  |",
+		"## Warnings",
+		"- `kubectl`: namespace may be stale",
+		"## Errors",
+		"- `docker`: binary not found<br>check PATH",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("markdown missing %q:\n%s", want, got)
+		}
+	}
+}
+
+func TestPrintStatusMarkdownOmitsEmptyMessageSections(t *testing.T) {
+	report := model.StatusReport{
+		Tools: []model.ToolSummary{{
+			ID:              "gh",
+			Category:        "code",
+			Installed:       true,
+			ConfiguredState: model.ConfiguredYes,
+			Warnings:        []string{"  "},
+		}},
+	}
+
+	var output bytes.Buffer
+	PrintStatusMarkdown(&output, report)
+	got := output.String()
+	if strings.Contains(got, "## Warnings") || strings.Contains(got, "## Errors") {
+		t.Fatalf("unexpected empty message section:\n%s", got)
+	}
+	if strings.Contains(got, "Generated:") {
+		t.Fatalf("unexpected zero timestamp:\n%s", got)
+	}
+}


### PR DESCRIPTION
`all-cli report` now evaluates the existing tool registry and emits a paste-ready Markdown status report, with optional `--tools` filtering and the established `--json` contract.

This is worth merging because it turns the current status inventory into a one-command artifact for GitHub issues, pull requests, and support conversations without adding dependencies or mutating tool configuration.

## What changed

- Added the read-only `all-cli report` primary command.
- Rendered a stable Markdown table with UTC generation time, current contexts, and separate warning/error sections.
- Escaped table pipes and multiline values so real tool output cannot break the Markdown layout.
- Kept `report --json` aligned with `status --json`, including agent diagnostics.

## Sample

```markdown
# all-cli status report

| Tool | Category | Installed | Configured | Current |
| --- | --- | --- | --- | --- |
| fd | navigation | yes | n/a |  |
| rg | navigation | yes | n/a |  |
```

## Validation

- `just check` at `43c5422c7065413af00404ad7cd4a867bf4915ca` (format, policy, vet, full tests, 83.8% coverage, golangci-lint with 0 issues, race tests, and three-pass stability)
- `just build`
- `ALL_CLI_NO_PROGRESS=1 ./all-cli report --tools fd,rg`
- `ALL_CLI_NO_PROGRESS=1 ./all-cli report --tools fd,rg --json | jq -e ...`

## Impact

The new command is additive and read-only. It reuses existing status evaluation, timeout handling, tool filtering, diagnostics, and JSON models. No schema, dependency, configuration, CI, infrastructure, permission, secret, remote, or credential changes are included.

## Rollback

Revert commit `43c5422c7065413af00404ad7cd4a867bf4915ca`; the command and renderer are isolated to five files.

## Related issues

No open issue matches this feature; the current open issues are already represented by separate PRs.

## Blockers

`pre-commit` is not installed locally, so `just pre-commit` could not run. Its format, repository policy, vet, and test coverage were exercised by the passing `just check` gate.