### PR TITLE
feat(cli): 支持 options JSON 输出

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,14 @@ all-cli version
 all-cli version --json
 ```
 
+Use `all-cli options --json` to inspect the effective global flags in a
+script-friendly shape:
+
+```bash
+all-cli options
+all-cli options --json
+```
+
 ### Global overview
 
 `all-cli status` defaults to grouping by `category` and sorting tools by `tool` (A-Z).

--- a/droid-wiki/reference/configuration.md
+++ b/droid-wiki/reference/configuration.md
@@ -35,3 +35,6 @@ Configured in `internal/cli/status.go`:
 ## Developer automation
 
 `justfile` defines `just ci`, `just check`, `just build`, `just run`, `just smoke`, `just release-check`, and release helper recipes. For details, see [tooling](../how-to-contribute/tooling.md).
+
+The `options` command reports the effective root flags as `json=true|false` and
+`timeout=<duration>` by default, or as a JSON object when invoked with `--json`.

--- a/internal/cli/options.go
+++ b/internal/cli/options.go
@@ -3,18 +3,34 @@ package cli
 import (
 	"fmt"
 
+	"github.com/oldwinter/all-cli/internal/output"
 	"github.com/spf13/cobra"
 )
+
+type optionsReport struct {
+	JSON    bool   `json:"json"`
+	Timeout string `json:"timeout"`
+}
 
 func newOptionsCommand(opts *rootOptions) *cobra.Command {
 	return &cobra.Command{
 		Use:   "options",
 		Short: "Show global CLI options inherited by subcommands",
 		Long: `Prints the effective values of persistent flags (--json, --timeout) that apply
-to all-cli and its subcommands. Similar to kubectl options.`,
-		Run: func(cmd *cobra.Command, _ []string) {
-			fmt.Fprintf(cmd.OutOrStdout(), "json=%v\n", opts.JSON)
-			fmt.Fprintf(cmd.OutOrStdout(), "timeout=%s\n", opts.Timeout)
+to all-cli and its subcommands. Similar to kubectl options. Use --json for a
+machine-readable object.`,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			if opts.JSON {
+				return output.PrintJSON(cmd.OutOrStdout(), optionsReport{
+					JSON:    opts.JSON,
+					Timeout: opts.Timeout.String(),
+				})
+			}
+			if _, err := fmt.Fprintf(cmd.OutOrStdout(), "json=%v\n", opts.JSON); err != nil {
+				return err
+			}
+			_, err := fmt.Fprintf(cmd.OutOrStdout(), "timeout=%s\n", opts.Timeout)
+			return err
 		},
 	}
 }

--- a/internal/cli/options_test.go
+++ b/internal/cli/options_test.go
@@ -1,12 +1,34 @@
 package cli
 
 import (
+	"encoding/json"
 	"strings"
 	"testing"
 	"time"
 )
 
-func TestOptionsCommandOutputsPersistentFlags(t *testing.T) {
+func TestOptionsCommandOutputsPersistentFlagsAsText(t *testing.T) {
+	t.Parallel()
+
+	opts := &rootOptions{Timeout: 7 * time.Second}
+	cmd := newOptionsCommand(opts)
+	var out strings.Builder
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	cmd.SetArgs([]string{})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("options: %v", err)
+	}
+	got := out.String()
+	if !strings.Contains(got, "json=false") {
+		t.Fatalf("expected json=false in output, got:\n%s", got)
+	}
+	if !strings.Contains(got, "timeout=7s") {
+		t.Fatalf("expected timeout=7s in output, got:\n%s", got)
+	}
+}
+
+func TestOptionsCommandOutputsPersistentFlagsAsJSON(t *testing.T) {
 	t.Parallel()
 
 	opts := &rootOptions{JSON: true, Timeout: 7 * time.Second}
@@ -18,11 +40,33 @@ func TestOptionsCommandOutputsPersistentFlags(t *testing.T) {
 	if err := cmd.Execute(); err != nil {
 		t.Fatalf("options: %v", err)
 	}
-	got := out.String()
-	if !strings.Contains(got, "json=true") {
-		t.Fatalf("expected json=true in output, got:\n%s", got)
+
+	var got optionsReport
+	if err := json.Unmarshal([]byte(out.String()), &got); err != nil {
+		t.Fatalf("decode options JSON: %v\n%s", err, out.String())
 	}
-	if !strings.Contains(got, "timeout=7s") {
-		t.Fatalf("expected timeout=7s in output, got:\n%s", got)
+	if !got.JSON || got.Timeout != "7s" {
+		t.Fatalf("unexpected options report: %#v", got)
+	}
+}
+
+func TestRootOptionsCommandUsesPersistentJSONFlag(t *testing.T) {
+	t.Parallel()
+
+	cmd := NewRootCommand()
+	cmd.SetArgs([]string{"--json", "--timeout", "9s", "options"})
+	var out strings.Builder
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("root options: %v", err)
+	}
+
+	var got optionsReport
+	if err := json.Unmarshal([]byte(out.String()), &got); err != nil {
+		t.Fatalf("decode root options JSON: %v\n%s", err, out.String())
+	}
+	if !got.JSON || got.Timeout != "9s" {
+		t.Fatalf("unexpected root options report: %#v", got)
 	}
 }


### PR DESCRIPTION
## What changed

`all-cli options --json` now emits a stable JSON object for automation while preserving the existing human-readable output. This closes the root `--json` contract gap for the command that reports effective global flags.

## Validation

- `env -u GOROOT -u GOTOOLDIR go test ./internal/cli -run 'Test(RootOptions|OptionsCommand)' -count=1 -v`
- `just check`
- `env -u GOROOT -u GOTOOLDIR go run ./cmd/all-cli --json --timeout 7s options`

The full gate passed with 83.2% total coverage, zero golangci-lint issues, race tests, and three stability passes.

## User impact

- Text mode remains `json=false|true` and `timeout=<duration>` lines.
- JSON mode returns `json` as a boolean and `timeout` as a duration string.
- No external commands, configuration, or secrets are accessed.

## Rollback

Revert commit `b1bb300` or close the PR before merge.

## Issue relationship

No open issue matched this narrow output-contract enhancement; no new issue was created because the change is small and self-contained.