### PR TITLE
feat(cli): 支持导出内置 JSON Schema

### DIFF
--- a/README.md
+++ b/README.md
@@ -269,6 +269,14 @@ added, removed, or changed. The complete text or JSON report is still printed:
 all-cli diff before.json after.json --json --exit-code
 ```
 
+Print the matching JSON Schema directly from the installed binary when another
+tool needs to validate these reports offline:
+
+```bash
+all-cli schema status > status.schema.json
+all-cli schema diagnostic > diagnostic.schema.json
+```
+
 Use `-` for either diff input to compare a saved snapshot with a live pipeline
 without creating another file. Standard input snapshots are limited to 1 MiB:
 

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -96,6 +96,7 @@ Environment:
 	cmd.AddCommand(newFixCommand(opts, runner))
 	cmd.AddCommand(newSnapshotCommand(opts, runner))
 	cmd.AddCommand(newDiffCommand(opts))
+	cmd.AddCommand(newSchemaCommand())
 	cmd.AddCommand(newVersionCommand(opts))
 	cmd.AddCommand(newOptionsCommand(opts))
 	cmd.AddCommand(newSurpriseCommand())
@@ -123,7 +124,7 @@ Environment:
 func setSubcommandGroups(root *cobra.Command) {
 	for _, c := range root.Commands() {
 		switch c.Name() {
-		case "status", "report", "current", "catalog", "describe", "diagnose", "doctor", "fix", "snapshot", "diff":
+		case "status", "report", "current", "catalog", "describe", "diagnose", "doctor", "fix", "snapshot", "diff", "schema":
 			c.GroupID = "primary"
 		case "aws", "aliyun", "wrangler":
 			c.GroupID = "cloud"

--- a/internal/cli/schema.go
+++ b/internal/cli/schema.go
@@ -1,0 +1,27 @@
+package cli
+
+import (
+	"github.com/oldwinter/all-cli/schemas"
+	"github.com/spf13/cobra"
+)
+
+func newSchemaCommand() *cobra.Command {
+	return &cobra.Command{
+		Use:   "schema <status|diagnostic>",
+		Short: "Print a bundled JSON Schema",
+		Long: `Prints the official JSON Schema for status snapshots or diagnostic reports.
+The schema is bundled with the binary, so callers can validate output offline.`,
+		Example: `  all-cli schema status > status.schema.json
+  all-cli schema diagnostic > diagnostic.schema.json`,
+		Args:      cobra.MatchAll(cobra.ExactArgs(1), cobra.OnlyValidArgs),
+		ValidArgs: schemas.Names(),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			content, err := schemas.Read(args[0])
+			if err != nil {
+				return err
+			}
+			_, err = cmd.OutOrStdout().Write(content)
+			return err
+		},
+	}
+}

--- a/internal/cli/schema_test.go
+++ b/internal/cli/schema_test.go
@@ -1,0 +1,61 @@
+package cli
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/oldwinter/all-cli/schemas"
+)
+
+func TestSchemaCommandPrintsBundledSchemas(t *testing.T) {
+	t.Parallel()
+
+	for _, name := range schemas.Names() {
+		name := name
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			stdout, stderr, err := executeTestCommand(t, newSchemaCommand(), name)
+			if err != nil {
+				t.Fatalf("schema %s: %v", name, err)
+			}
+			if stderr != "" {
+				t.Fatalf("stderr = %q, want empty", stderr)
+			}
+			want, err := schemas.Read(name)
+			if err != nil {
+				t.Fatalf("read expected schema: %v", err)
+			}
+			if stdout != string(want) {
+				t.Fatalf("schema output differs from bundled %s schema", name)
+			}
+			var decoded map[string]any
+			if err := json.Unmarshal([]byte(stdout), &decoded); err != nil {
+				t.Fatalf("decode schema output: %v", err)
+			}
+		})
+	}
+}
+
+func TestSchemaCommandRejectsUnknownName(t *testing.T) {
+	t.Parallel()
+
+	_, _, err := executeTestCommand(t, newSchemaCommand(), "other")
+	if err == nil || !strings.Contains(err.Error(), "invalid argument \"other\"") {
+		t.Fatalf("schema other error = %v, want invalid argument", err)
+	}
+}
+
+func TestRootCommandIncludesSchema(t *testing.T) {
+	t.Parallel()
+
+	root := NewRootCommand()
+	schema, _, err := root.Find([]string{"schema"})
+	if err != nil {
+		t.Fatalf("find schema command: %v", err)
+	}
+	if schema.Name() != "schema" || schema.GroupID != "primary" {
+		t.Fatalf("unexpected schema command registration: name=%q group=%q", schema.Name(), schema.GroupID)
+	}
+}

--- a/schemas/embed.go
+++ b/schemas/embed.go
@@ -1,0 +1,35 @@
+// Package schemas exposes the JSON Schemas bundled with all-cli.
+package schemas
+
+import (
+	"embed"
+	"fmt"
+	"strings"
+)
+
+const (
+	Status     = "status"
+	Diagnostic = "diagnostic"
+)
+
+var schemaFiles = map[string]string{
+	Status:     "status-report-v0.1.json",
+	Diagnostic: "diagnostic-report-v0.1.json",
+}
+
+//go:embed *.json
+var files embed.FS
+
+// Names returns the stable names accepted by Read.
+func Names() []string {
+	return []string{Status, Diagnostic}
+}
+
+// Read returns one bundled JSON Schema by its stable name.
+func Read(name string) ([]byte, error) {
+	fileName, ok := schemaFiles[name]
+	if !ok {
+		return nil, fmt.Errorf("unknown schema %q; expected one of: %s", name, strings.Join(Names(), ", "))
+	}
+	return files.ReadFile(fileName)
+}

--- a/schemas/embed_test.go
+++ b/schemas/embed_test.go
@@ -1,0 +1,48 @@
+package schemas
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+func TestReadReturnsBundledSchemas(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		wantID string
+	}{
+		{name: Status, wantID: "status-report-v0.1.json"},
+		{name: Diagnostic, wantID: "diagnostic-report-v0.1.json"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			content, err := Read(tt.name)
+			if err != nil {
+				t.Fatalf("Read(%q): %v", tt.name, err)
+			}
+			var schema struct {
+				ID string `json:"$id"`
+			}
+			if err := json.Unmarshal(content, &schema); err != nil {
+				t.Fatalf("decode %q schema: %v", tt.name, err)
+			}
+			if !strings.HasSuffix(schema.ID, "/"+tt.wantID) {
+				t.Fatalf("schema ID = %q, want suffix %q", schema.ID, tt.wantID)
+			}
+		})
+	}
+}
+
+func TestReadRejectsUnknownSchema(t *testing.T) {
+	t.Parallel()
+
+	_, err := Read("other")
+	if err == nil || !strings.Contains(err.Error(), "expected one of: status, diagnostic") {
+		t.Fatalf("Read(other) error = %v, want supported names", err)
+	}
+}


### PR DESCRIPTION
新增 `all-cli schema status|diagnostic`，将随版本发布的两份官方 JSON Schema 直接嵌入二进制。它值得合并，因为脚本、Agent 和其他项目现在可以从已安装的 `all-cli` 离线取得与该版本严格匹配的契约，不再依赖仓库路径或手工复制 schema。

## 使用体验

```console
$ all-cli schema status | jq -r '.title'
all-cli status report

$ all-cli schema diagnostic | jq -r '.title'
all-cli diagnostic report
```

未知 schema 名称会返回非零退出码和明确错误；shell completion 只提供 `status` 与 `diagnostic`。

## 验证

- `go test ./schemas ./internal/cli`
- `just check`（总覆盖率 83.3%，golangci-lint 0 issues，包含 race 与三轮稳定性测试）
- `just build`
- `./all-cli schema status | cmp - schemas/status-report-v0.1.json`
- `./all-cli schema diagnostic | cmp - schemas/diagnostic-report-v0.1.json`
- `./all-cli schema other`（预期非零并报告 invalid argument）

## 影响范围

这是纯增量、只读能力；不运行外部命令，不新增依赖，不改变现有 schema 或已有命令输出。schema 与二进制一同发布，可在离线环境使用。

## Issue 关系

检索了开放 issue，没有发现与内置 schema 导出强相关的条目，因此不创建或关联 issue。

## 回滚

移除 `schema` 命令注册、`schemas` 嵌入层及对应测试/README 段落即可完整回滚，不涉及数据迁移。

## 风险与阻塞

主要维护风险是未来新增或重命名 schema 时需要同步稳定名称映射；当前测试覆盖两份现有 schema 的解析、ID 和字节级命令输出。无已知阻塞。
