### PR TITLE
feat(cli): add no-progress output control

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,7 +138,13 @@ all-cli status --group-by none
 all-cli status --sort tool-desc
 all-cli status --sort category-desc
 all-cli status --timeout 10s
+all-cli status --no-progress
+all-cli status --quiet
 ```
+
+Use the global `--no-progress` flag to suppress progress indicators in human-readable
+commands. `status --quiet` also suppresses the status spinner while showing only tools
+with issues; JSON output never emits progress indicators.
 
 Use `--categories` to check one or more registry categories at once. When combined with
 `--tools`, both filters apply, so the result contains only tools matching both selections.

--- a/internal/cli/current.go
+++ b/internal/cli/current.go
@@ -35,7 +35,7 @@ Use --tools to evaluate only selected tools and skip unrelated external commands
 			}
 
 			var spinner *progressSpinner
-			if !opts.JSON && showStatusSpinner() {
+			if !opts.JSON && !opts.NoProgress && showStatusSpinner() {
 				spinner = newProgressSpinner(cmd.ErrOrStderr(), len(contextRegistry))
 				spinner.Start()
 			}

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -16,8 +16,9 @@ var (
 )
 
 type rootOptions struct {
-	JSON    bool
-	Timeout time.Duration
+	JSON       bool
+	NoProgress bool
+	Timeout    time.Duration
 }
 
 func NewRootCommand() *cobra.Command {
@@ -75,6 +76,7 @@ Environment:
 	)
 
 	cmd.PersistentFlags().BoolVar(&opts.JSON, "json", false, "Output JSON")
+	cmd.PersistentFlags().BoolVar(&opts.NoProgress, "no-progress", false, "Disable progress indicators")
 	cmd.PersistentFlags().DurationVar(&opts.Timeout, "timeout", opts.Timeout, "External command timeout (e.g. 3s)")
 
 	cmd.PersistentPreRunE = func(_ *cobra.Command, _ []string) error {

--- a/internal/cli/root_test.go
+++ b/internal/cli/root_test.go
@@ -97,6 +97,7 @@ func TestRootHelpGroupsCommands(t *testing.T) {
 	for _, needle := range []string{
 		"NO_COLOR",
 		"ALL_CLI_NO_PROGRESS",
+		"--no-progress",
 		"TERM",
 		"CI",
 	} {

--- a/internal/cli/status.go
+++ b/internal/cli/status.go
@@ -72,7 +72,7 @@ When not using --json, a progress indicator may be shown on stderr while tools a
 			}
 
 			var spinner *progressSpinner
-			if !opts.JSON && showStatusSpinner() {
+			if !opts.JSON && !opts.NoProgress && !quiet && showStatusSpinner() {
 				spinner = newProgressSpinner(cmd.ErrOrStderr(), len(reg))
 				spinner.Start()
 			}

--- a/internal/cli/status_command_test.go
+++ b/internal/cli/status_command_test.go
@@ -81,6 +81,49 @@ func TestStatusCommandPlainToolsFilterAndSpinner(t *testing.T) {
 	}
 }
 
+func TestStatusCommandQuietSkipsSpinner(t *testing.T) {
+	stubStatusRegistry(t, []tools.ToolDefinition{
+		{ID: "aws", DisplayName: "AWS CLI", Category: "cloud", Binary: "aws"},
+	})
+	oldEvaluate := evaluateToolSummary
+	evaluateToolSummary = func(_ context.Context, def tools.ToolDefinition, _ execx.Runner) model.ToolSummary {
+		return model.ToolSummary{ID: def.ID, Category: def.Category, Installed: false, ConfiguredState: model.ConfiguredUnknown}
+	}
+	t.Cleanup(func() { evaluateToolSummary = oldEvaluate })
+	stubShowStatusSpinner(t, true)
+
+	stdout, stderr, err := executeTestCommand(t, newStatusCommand(&rootOptions{Timeout: time.Second}, cliFakeRunner{}), "--quiet")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(stdout, "aws") {
+		t.Fatalf("expected quiet status output, got %q", stdout)
+	}
+	if stderr != "" {
+		t.Fatalf("expected quiet status to skip spinner, got %q", stderr)
+	}
+}
+
+func TestStatusCommandNoProgressSkipsSpinner(t *testing.T) {
+	stubStatusRegistry(t, []tools.ToolDefinition{
+		{ID: "aws", DisplayName: "AWS CLI", Category: "cloud", Binary: "aws"},
+	})
+	oldEvaluate := evaluateToolSummary
+	evaluateToolSummary = func(_ context.Context, def tools.ToolDefinition, _ execx.Runner) model.ToolSummary {
+		return model.ToolSummary{ID: def.ID, Category: def.Category, Installed: true, ConfiguredState: model.ConfiguredYes, Configured: true}
+	}
+	t.Cleanup(func() { evaluateToolSummary = oldEvaluate })
+	stubShowStatusSpinner(t, true)
+
+	_, stderr, err := executeTestCommand(t, newStatusCommand(&rootOptions{NoProgress: true, Timeout: time.Second}, cliFakeRunner{}))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if stderr != "" {
+		t.Fatalf("expected --no-progress to skip spinner, got %q", stderr)
+	}
+}
+
 func TestStatusCommandJSONIncludesAdditiveDiagnostics(t *testing.T) {
 	stubStatusRegistry(t, []tools.ToolDefinition{
 		{ID: "aws", DisplayName: "AWS CLI", Category: "cloud", Binary: "aws"},


### PR DESCRIPTION
## What changed

Add a global --no-progress flag for scripts and log collectors. status --quiet now suppresses its spinner automatically, while JSON output remains unchanged.

## Validation

- just check
- just build
- go run ./cmd/all-cli --no-progress status --tools fd --group-by none with zero stderr bytes

## Impact and rollback

This changes only progress rendering. Revert the single commit if needed.
