### PR TITLE
feat(cli): add pipe-ready catalog IDs

### DIFF
--- a/README.md
+++ b/README.md
@@ -344,6 +344,16 @@ all-cli catalog kubernetes --categories k8s,cloud
 all-cli catalog cloud --json
 ```
 
+Use `--ids` to print one matching tool ID per line for a picker or a shell loop:
+
+```bash
+all-cli catalog kubernetes --ids
+all-cli catalog --ids | fzf
+```
+
+IDs keep the catalog's category-then-ID order. A search with no matches prints
+nothing in this mode. If you also pass `--json`, the full JSON report takes precedence.
+
 Use `all-cli describe <tool>` to inspect the built-in purpose, configuration
 criteria, context capabilities, and agent actions without running the tool:
 

--- a/internal/cli/catalog.go
+++ b/internal/cli/catalog.go
@@ -27,16 +27,19 @@ type catalogReport struct {
 
 func newCatalogCommand(opts *rootOptions) *cobra.Command {
 	var categoriesFilter string
+	var ids bool
 
 	cmd := &cobra.Command{
 		Use:   "catalog [search]",
 		Short: "Browse and search tracked CLI tools",
 		Long: `Lists the built-in tool catalog without running external commands. An optional
 search term matches tool IDs, names, categories, binary names, and purposes.
-Use --categories to limit results to one or more exact registry categories.`,
+Use --categories to limit results to one or more exact registry categories.
+Use --ids to print one matching tool ID per line. --json takes precedence over --ids.`,
 		Example: `  all-cli catalog
   all-cli catalog kubernetes
   all-cli catalog --categories ai,cloud
+  all-cli catalog kubernetes --ids
   all-cli catalog cloud --json`,
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -51,6 +54,14 @@ Use --categories to limit results to one or more exact registry categories.`,
 			report := buildCatalogReport(query, registry)
 			if opts.JSON {
 				return output.PrintJSON(cmd.OutOrStdout(), report)
+			}
+			if ids {
+				for _, tool := range report.Tools {
+					if _, err := fmt.Fprintln(cmd.OutOrStdout(), tool.ID); err != nil {
+						return err
+					}
+				}
+				return nil
 			}
 			if report.Count == 0 {
 				fmt.Fprintf(cmd.OutOrStdout(), "No tracked tools match %q.\n", query)
@@ -69,6 +80,7 @@ Use --categories to limit results to one or more exact registry categories.`,
 		},
 	}
 	cmd.Flags().StringVar(&categoriesFilter, "categories", "", "Comma-separated categories to browse (e.g. ai,cloud)")
+	cmd.Flags().BoolVar(&ids, "ids", false, "Print only tool IDs, one per line (ignored with --json)")
 	return cmd
 }
 

--- a/internal/cli/catalog_test.go
+++ b/internal/cli/catalog_test.go
@@ -2,11 +2,100 @@ package cli
 
 import (
 	"encoding/json"
+	"errors"
+	"io"
 	"strings"
 	"testing"
 
 	"github.com/oldwinter/all-cli/internal/tools"
 )
+
+func TestCatalogCommandIDs(t *testing.T) {
+	t.Setenv("PATH", t.TempDir())
+	for _, tc := range []struct {
+		name  string
+		query string
+		want  string
+	}{
+		{name: "metadata search", query: "GITLAB", want: "glab\n"},
+		{name: "trimmed search", query: "  GitLab  ", want: "glab\n"},
+		{name: "no matches", query: "not-a-real-tool", want: ""},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			stdout, stderr, err := executeTestCommand(t, NewRootCommand(), "catalog", tc.query, "--ids")
+			if err != nil || stderr != "" || stdout != tc.want {
+				t.Fatalf("catalog --ids: stdout=%q stderr=%q err=%v, want stdout=%q", stdout, stderr, err, tc.want)
+			}
+		})
+	}
+}
+
+func TestCatalogCommandIDsPreserveReportOrder(t *testing.T) {
+	stdout, stderr, err := executeTestCommand(t, NewRootCommand(), "catalog", "--json")
+	if err != nil || stderr != "" {
+		t.Fatalf("catalog --json: stderr=%q err=%v", stderr, err)
+	}
+	var report catalogReport
+	if err := json.Unmarshal([]byte(stdout), &report); err != nil {
+		t.Fatalf("decode catalog: %v", err)
+	}
+	if len(report.Tools) == 0 {
+		t.Fatal("catalog must contain tools")
+	}
+	var want strings.Builder
+	for _, tool := range report.Tools {
+		want.WriteString(tool.ID + "\n")
+	}
+	stdout, stderr, err = executeTestCommand(t, NewRootCommand(), "catalog", "--ids")
+	if err != nil || stderr != "" || stdout != want.String() {
+		t.Fatalf("catalog --ids: stdout=%q stderr=%q err=%v, want stdout=%q", stdout, stderr, err, want.String())
+	}
+}
+
+func TestCatalogCommandIDsJSONPrecedence(t *testing.T) {
+	want, _, err := executeTestCommand(t, NewRootCommand(), "catalog", "GITLAB", "--json")
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, args := range [][]string{
+		{"catalog", "GITLAB", "--ids", "--json"},
+		{"catalog", "GITLAB", "--json", "--ids"},
+		{"--json", "catalog", "GITLAB", "--ids"},
+	} {
+		t.Run(strings.Join(args, " "), func(t *testing.T) {
+			stdout, stderr, err := executeTestCommand(t, NewRootCommand(), args...)
+			if err != nil || stderr != "" || stdout != want {
+				t.Fatalf("JSON precedence: stdout=%q stderr=%q err=%v, want stdout=%q", stdout, stderr, err, want)
+			}
+		})
+	}
+}
+
+func TestCatalogCommandIDsFalsePreservesTable(t *testing.T) {
+	want, _, err := executeTestCommand(t, NewRootCommand(), "catalog", "GITLAB")
+	if err != nil {
+		t.Fatal(err)
+	}
+	stdout, stderr, err := executeTestCommand(t, NewRootCommand(), "catalog", "GITLAB", "--ids=false")
+	if err != nil || stderr != "" || stdout != want {
+		t.Fatalf("catalog --ids=false: stdout=%q stderr=%q err=%v, want stdout=%q", stdout, stderr, err, want)
+	}
+}
+
+func TestCatalogCommandIDsReturnsWriteError(t *testing.T) {
+	reader, writer := io.Pipe()
+	if err := reader.Close(); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = writer.Close() })
+	cmd := newCatalogCommand(&rootOptions{})
+	cmd.SetOut(writer)
+	cmd.SetErr(io.Discard)
+	cmd.SetArgs([]string{"GITLAB", "--ids"})
+	if err := cmd.Execute(); !errors.Is(err, io.ErrClosedPipe) {
+		t.Fatalf("catalog --ids error = %v, want %v", err, io.ErrClosedPipe)
+	}
+}
 
 func TestCatalogCommandListsTrackedTools(t *testing.T) {
 	// Given


### PR DESCRIPTION
This adds `all-cli catalog --ids`, which prints one matching tool ID per line. The offline catalog can now feed a fuzzy picker or a shell loop without a JSON parser or table-column extraction, making it more useful in everyday terminal workflows.

## Usage

```console
$ all-cli catalog GITLAB --ids
glab
```

```sh
all-cli catalog --ids | fzf
```

IDs retain the catalog's category-then-ID order. Searches with no matches produce empty output. When combined with `--json`, the full JSON report takes precedence.

## Verification

- `just check` passed with 83.3% total coverage, zero lint issues, race tests, and three-pass stability tests. The clean default baseline also passed.
- `just build` passed. Restricted-PATH binary QA checked all 46 catalog entries, metadata searches, empty results, ID order, JSON precedence, and unchanged default table output.
- Command tests cover output write failures and inherited root flags. `git diff --check` passed.
- `just pre-commit` could not run because `pre-commit` is not installed. The format, repository policy, vet, and test checks ran through `just check`; no tools were installed.

## Impact and rollback

The change is limited to catalog output, command tests, and README usage. It adds no external commands or dependencies. Existing table and JSON output remain unchanged. Revert this commit to remove the flag.

PR #31 separately adds catalog category filtering and touches some of the same lines. These features are independent; the second PR to merge may need a small conflict resolution in command help, local flag declarations, or tests.
