### PR TITLE
feat(cli): add copyable examples to tool descriptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -370,6 +370,18 @@ all-cli describe kubectl
 all-cli describe kubectl --json
 ```
 
+The text output ends with read-only commands you can copy to inspect that tool:
+
+```text
+Examples:
+  all-cli status --tools kubectl
+  all-cli doctor --tools kubectl
+  all-cli current --tools kubectl
+```
+
+The `current` example appears only for tools that expose context state. Printing
+these examples does not run them. JSON output keeps the metadata-only format.
+
 If a tool ID is misspelled, `describe` and every `--tools` filter suggest a
 nearby tracked ID when there is a clear match:
 

--- a/internal/cli/describe.go
+++ b/internal/cli/describe.go
@@ -85,7 +85,15 @@ local configuration.`,
 					fmt.Fprintf(w, "  - %s\n", note)
 				}
 			}
-			return nil
+			examples := []string{
+				"all-cli status --tools " + def.ID,
+				"all-cli doctor --tools " + def.ID,
+			}
+			if def.Capabilities.HasContexts {
+				examples = append(examples, "all-cli current --tools "+def.ID)
+			}
+			_, err := fmt.Fprintf(w, "Examples:\n  %s\n", strings.Join(examples, "\n  "))
+			return err
 		},
 	}
 	cmd.SetFlagErrorFunc(func(_ *cobra.Command, err error) error {

--- a/internal/cli/describe_test.go
+++ b/internal/cli/describe_test.go
@@ -2,12 +2,79 @@ package cli
 
 import (
 	"encoding/json"
+	"errors"
 	"strconv"
 	"strings"
 	"testing"
 
 	"github.com/oldwinter/all-cli/internal/model"
 )
+
+func TestDescribeCommandPrintsReadOnlyExamples(t *testing.T) {
+	for _, tc := range []struct {
+		tool        string
+		wantCurrent bool
+	}{
+		{tool: "kubectl", wantCurrent: true},
+		{tool: "aws", wantCurrent: true},
+		{tool: "fd", wantCurrent: false},
+	} {
+		t.Run(tc.tool, func(t *testing.T) {
+			stdout, stderr, err := executeTestCommand(t, newDescribeCommand(&rootOptions{}), tc.tool)
+			if err != nil || stderr != "" {
+				t.Fatalf("describe: err=%v stderr=%q", err, stderr)
+			}
+			_, examples, found := strings.Cut(stdout, "Examples:\n")
+			want := "  all-cli status --tools " + tc.tool + "\n  all-cli doctor --tools " + tc.tool + "\n"
+			if tc.wantCurrent {
+				want += "  all-cli current --tools " + tc.tool + "\n"
+			}
+			if !found || examples != want {
+				t.Fatalf("examples = %q, want %q", examples, want)
+			}
+		})
+	}
+}
+
+func TestDescribeJSONKeepsMetadataOnly(t *testing.T) {
+	stdout, _, err := executeTestCommand(t, newDescribeCommand(&rootOptions{JSON: true}), "kubectl")
+	if err != nil {
+		t.Fatal(err)
+	}
+	var fields map[string]json.RawMessage
+	if err := json.Unmarshal([]byte(stdout), &fields); err != nil {
+		t.Fatal(err)
+	}
+	wantKeys := []string{"id", "display_name", "category", "binary", "capabilities", "metadata"}
+	if len(fields) != len(wantKeys) {
+		t.Fatalf("unexpected JSON fields: %v", fields)
+	}
+	for _, key := range wantKeys {
+		if _, ok := fields[key]; !ok {
+			t.Errorf("missing JSON field %q", key)
+		}
+	}
+}
+
+type exampleErrorWriter struct {
+	err error
+}
+
+func (w exampleErrorWriter) Write(p []byte) (int, error) {
+	if strings.Contains(string(p), "Examples:") {
+		return 0, w.err
+	}
+	return len(p), nil
+}
+
+func TestDescribeCommandReturnsExampleWriteError(t *testing.T) {
+	want := errors.New("output closed")
+	cmd := newDescribeCommand(&rootOptions{})
+	cmd.SetOut(exampleErrorWriter{err: want})
+	if err := cmd.RunE(cmd, []string{"fd"}); !errors.Is(err, want) {
+		t.Fatalf("error = %v, want %v", err, want)
+	}
+}
 
 func TestDescribeCommandPrintsHumanReadableMetadata(t *testing.T) {
 	// Given


### PR DESCRIPTION
`all-cli describe <tool>` now ends its text output with copyable, read-only commands for that tool. After learning what a tool does, you can inspect its status or diagnostics without having to assemble a filter yourself. Tools with context state also get a `current` example, including tools such as AWS that cannot switch contexts through all-cli.

## Scope

The change adds an Examples section to describe text, focused tests, and a README example. It uses the existing tool ID and capability fields. Printing the section remains offline, and describe JSON is unchanged.

```text
Examples:
  all-cli status --tools kubectl
  all-cli doctor --tools kubectl
  all-cli current --tools kubectl
```

## Verification

- Focused describe tests passed for kubectl, AWS, fd, JSON fields, and output errors.
- `just check` passed on the baseline and the final change, including coverage, lint, vet, race tests, and three-pass stability.
- Built-binary QA checked all 46 tools against the baseline. Existing text and JSON matched exactly, and examples followed each tool's context capability.
- Ran the printed kubectl and fd commands with an empty PATH and observed valid missing-tool reports without external tool execution.
- `just pre-commit` could not run because the existing mise pre-commit shim has no configured version. No machine configuration was changed.

## Impact and rollback

Human-readable describe output gains an appended section. JSON consumers retain the same format. No dependencies, shared adapters, configuration, or CI files change. Revert this commit to remove the section and its documentation.
