### PR TITLE
docs(cli): clarify doctor and diagnose help

### DIFF
--- a/internal/cli/agent_commands.go
+++ b/internal/cli/agent_commands.go
@@ -28,7 +28,10 @@ func newDiagnoseCommand(opts *rootOptions, runner execx.Runner) *cobra.Command {
 		Use:   "diagnose",
 		Short: "Generate agent-readable diagnostics from CLI status",
 		Long: `Generates structured diagnostics from the same tool evaluation used by status.
-Diagnostics include severity, evidence, suggested actions, autofix safety, and related tool IDs.`,
+Diagnostics include severity, evidence, suggested actions, autofix safety, and related tool IDs.
+Use this command when an agent or script needs a machine-readable report.`,
+		Example: `  all-cli diagnose --json
+  all-cli diagnose --tools kubectl,docker --profile ci --json`,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			report, err := buildDiagnosticReport(cmd, opts, runner, toolsFilter, profile)
 			if err != nil {
@@ -54,6 +57,10 @@ func newDoctorCommand(opts *rootOptions, runner execx.Runner) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "doctor",
 		Short: "Run read-only health checks for local CLI tools",
+		Long: `Runs the same diagnostic checks as diagnose with human-friendly output by default.
+Use this command when a person wants a quick local health check; add --json for automation.`,
+		Example: `  all-cli doctor
+  all-cli doctor --tools kubectl,docker --json`,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			report, err := buildDiagnosticReport(cmd, opts, runner, toolsFilter, profile)
 			if err != nil {

--- a/internal/cli/agent_commands_test.go
+++ b/internal/cli/agent_commands_test.go
@@ -55,6 +55,20 @@ func stubAgentStatusEvaluation(t *testing.T) {
 	stubShowStatusSpinner(t, false)
 }
 
+func TestDiagnosticCommandHelpExplainsAudience(t *testing.T) {
+	t.Parallel()
+
+	diagnose := newDiagnoseCommand(&rootOptions{}, cliFakeRunner{})
+	if !strings.Contains(diagnose.Long, "agent or script") || !strings.Contains(diagnose.Example, "--json") {
+		t.Fatalf("diagnose help should explain machine-readable usage, got long=%q example=%q", diagnose.Long, diagnose.Example)
+	}
+
+	doctor := newDoctorCommand(&rootOptions{}, cliFakeRunner{})
+	if !strings.Contains(doctor.Long, "human-friendly") || !strings.Contains(doctor.Example, "all-cli doctor") {
+		t.Fatalf("doctor help should explain human usage, got long=%q example=%q", doctor.Long, doctor.Example)
+	}
+}
+
 func TestDiagnoseCommandJSONUsesToolsFilter(t *testing.T) {
 	stubAgentStatusEvaluation(t)
 


### PR DESCRIPTION
This builds clearer help for `all-cli doctor` and `all-cli diagnose`, so people can immediately choose the human health check while agents and scripts can find the machine-readable diagnostic report. The distinct descriptions and copyable examples make the two entrypoints easier to discover and worth merging because the improvement is visible at the first `--help` interaction with no runtime or output-contract risk.

## Validation

- `go test ./internal/cli/...`
- `just check` (85.5% total coverage, vet, lint, race tests, and three-pass stability)
- `just build`
- Real binary checks for `doctor --help` and `diagnose --help`

## Impact

- Changes only Cobra help metadata and its focused test.
- Existing command behavior and JSON output are unchanged.

## Rollback

Revert commit `0fb3a50`.

Closes #54
